### PR TITLE
Add initial support for Resource Templates

### DIFF
--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -144,7 +144,7 @@ public static class McpClientExtensions
     /// </summary>
     /// <param name="client">The client.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>An asynchronous sequence of resource information.</returns>
+    /// <returns>An asynchronous sequence of resource template information.</returns>
     public static async IAsyncEnumerable<ResourceTemplate> ListResourceTemplatesAsync(
         this IMcpClient client, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {

--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -140,7 +140,7 @@ public static class McpClientExtensions
     }
 
     /// <summary>
-    /// Retrieves a sequence of available resources from the server.
+    /// Retrieves a sequence of available resource templates from the server.
     /// </summary>
     /// <param name="client">The client.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>

--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -145,6 +145,44 @@ public static class McpClientExtensions
     /// <param name="client">The client.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>An asynchronous sequence of resource information.</returns>
+    public static async IAsyncEnumerable<ResourceTemplate> ListResourceTemplatesAsync(
+        this IMcpClient client, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        string? cursor = null;
+        do
+        {
+            var resources = await ListResourceTemplatesAsync(client, cursor, cancellationToken).ConfigureAwait(false);
+            foreach (var resource in resources.ResourceTemplates)
+            {
+                yield return resource;
+            }
+
+            cursor = resources.NextCursor;
+        }
+        while (cursor is not null);
+    }
+
+    /// <summary>
+    /// Retrieves a list of available resources from the server.
+    /// </summary>
+    /// <param name="client">The client.</param>
+    /// <param name="cursor">A  cursor to paginate the results.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    public static Task<ListResourceTemplatesResult> ListResourceTemplatesAsync(this IMcpClient client, string? cursor, CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(client);
+
+        return client.SendRequestAsync<ListResourceTemplatesResult>(
+            CreateRequest("resources/templates/list", CreateCursorDictionary(cursor)),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Retrieves a sequence of available resources from the server.
+    /// </summary>
+    /// <param name="client">The client.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>An asynchronous sequence of resource information.</returns>
     public static async IAsyncEnumerable<Resource> ListResourcesAsync(
         this IMcpClient client, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {

--- a/src/ModelContextProtocol/Configuration/McpServerBuilderExtensions.Handler.cs
+++ b/src/ModelContextProtocol/Configuration/McpServerBuilderExtensions.Handler.cs
@@ -12,6 +12,19 @@ namespace ModelContextProtocol;
 public static partial class McpServerBuilderExtensions
 {
     /// <summary>
+    /// Sets the handler for list resource templates requests.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="handler">The handler.</param>
+    public static IMcpServerBuilder WithListResourceTemplatesHandler(this IMcpServerBuilder builder, Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>> handler)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerHandlers>(s => s.ListResourceTemplatesHandler = handler);
+        return builder;
+    }
+
+    /// <summary>
     /// Sets the handler for list tools requests.
     /// </summary>
     /// <param name="builder">The builder instance.</param>

--- a/src/ModelContextProtocol/Protocol/Types/Capabilities.cs
+++ b/src/ModelContextProtocol/Protocol/Types/Capabilities.cs
@@ -111,6 +111,12 @@ public record ResourcesCapability
     public bool? ListChanged { get; init; }
 
     /// <summary>
+    /// Gets or sets the handler for list resource templates requests.
+    /// </summary>
+    [JsonIgnore]
+    public Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>>? ListResourceTemplatesHandler { get; init; }
+
+    /// <summary>
     /// Gets or sets the handler for list resources requests.
     /// </summary>
     [JsonIgnore]

--- a/src/ModelContextProtocol/Protocol/Types/ListResourceTemplatesRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ListResourceTemplatesRequestParams.cs
@@ -1,0 +1,15 @@
+﻿namespace ModelContextProtocol.Protocol.Types;
+
+/// <summary>
+/// Sent from the client to request a list of resource templates the server has.
+/// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
+/// </summary>
+public class ListResourceTemplatesRequestParams
+{
+    /// <summary>
+    /// An opaque token representing the current pagination position.
+    /// If provided, the server should return results starting after this cursor.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("cursor")]
+    public string? Cursor { get; init; }
+}

--- a/src/ModelContextProtocol/Protocol/Types/ListResourceTemplatesResult.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ListResourceTemplatesResult.cs
@@ -1,0 +1,16 @@
+﻿using ModelContextProtocol.Protocol.Messages;
+
+namespace ModelContextProtocol.Protocol.Types;
+
+/// <summary>
+/// The server's response to a resources/templates/list request from the client.
+/// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
+/// </summary>
+public class ListResourceTemplatesResult : PaginatedResult
+{
+    /// <summary>
+    /// A list of resource templates that the server offers.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("resourceTemplates")]
+    public List<ResourceTemplate> ResourceTemplates { get; set; } = [];
+}

--- a/src/ModelContextProtocol/Protocol/Types/ResourceTemplate.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ResourceTemplate.cs
@@ -1,0 +1,42 @@
+﻿using ModelContextProtocol.Protocol.Types;
+
+using System.Text.Json.Serialization;
+
+namespace ModelContextProtocol.Protocol.Types;
+
+/// <summary>
+/// Represents a known resource template that the server is capable of reading.
+/// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
+/// </summary>
+public record ResourceTemplate
+{
+    /// <summary>
+    /// The URI template (according to RFC 6570) that can be used to construct resource URIs.
+    /// </summary>
+    [JsonPropertyName("uriTemplate")]
+    public required string UriTemplate { get; init; }
+
+    /// <summary>
+    /// A human-readable name for this resource template.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// A description of what this resource template represents.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// The MIME type of this resource template, if known.
+    /// </summary>
+    [JsonPropertyName("mimeType")]
+    public string? MimeType { get; init; }
+
+    /// <summary>
+    /// Optional annotations for the resource template.
+    /// </summary>
+    [JsonPropertyName("annotations")]
+    public Annotations? Annotations { get; init; }
+}

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -159,7 +159,7 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
         var listResourceTemplatesHandler = resourcesCapability.ListResourceTemplatesHandler
             ?? (static (_, _) => Task.FromResult(new ListResourceTemplatesResult()));
 
-		SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
+        SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
 
         if (resourcesCapability.Subscribe is not true)
         {

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -157,8 +157,9 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
 
         // Set the list resource templates handler, or use the default if not specified
         var listResourceTemplatesHandler = resourcesCapability.ListResourceTemplatesHandler
-            ?? McpServerHandlers.Defaults.ListResourceTemplatesHandler;
-        SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
+	        ?? ((_, _) => Task.FromResult(new ListResourceTemplatesResult()));
+
+		SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
 
         if (resourcesCapability.Subscribe is not true)
         {

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -147,11 +147,13 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
         }
 
         if (resourcesCapability.ListResourcesHandler is not { } listResourcesHandler ||
-            resourcesCapability.ReadResourceHandler is not { } readResourceHandler)
+            resourcesCapability.ReadResourceHandler is not { } readResourceHandler ||
+            resourcesCapability.ListResourceTemplatesHandler is not { } listResourceTemplatesHandler)
         {
             throw new McpServerException("Resources capability was enabled, but ListResources and/or ReadResource handlers were not specified.");
         }
 
+        SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
         SetRequestHandler<ListResourcesRequestParams, ListResourcesResult>("resources/list", (request, ct) => listResourcesHandler(new(this, request), ct));
         SetRequestHandler<ReadResourceRequestParams, ReadResourceResult>("resources/read", (request, ct) => readResourceHandler(new(this, request), ct));
 

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -147,13 +147,15 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
         }
 
         if (resourcesCapability.ListResourcesHandler is not { } listResourcesHandler ||
-            resourcesCapability.ReadResourceHandler is not { } readResourceHandler ||
-            resourcesCapability.ListResourceTemplatesHandler is not { } listResourceTemplatesHandler)
+            resourcesCapability.ReadResourceHandler is not { } readResourceHandler)
         {
             throw new McpServerException("Resources capability was enabled, but ListResources and/or ReadResource handlers were not specified.");
         }
 
-        SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
+        if (resourcesCapability.ListResourceTemplatesHandler is { } listResourceTemplatesHandler)
+        {
+            SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
+        }
         SetRequestHandler<ListResourcesRequestParams, ListResourcesResult>("resources/list", (request, ct) => listResourcesHandler(new(this, request), ct));
         SetRequestHandler<ReadResourceRequestParams, ReadResourceResult>("resources/read", (request, ct) => readResourceHandler(new(this, request), ct));
 

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -157,9 +157,9 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
 
         // Set the list resource templates handler, or use the default if not specified
         var listResourceTemplatesHandler = resourcesCapability.ListResourceTemplatesHandler
-            ?? ((_, _) => Task.FromResult(new ListResourceTemplatesResult()));
+            ?? (static (_, _) => Task.FromResult(new ListResourceTemplatesResult()));
 
-        SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
+		SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
 
         if (resourcesCapability.Subscribe is not true)
         {

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -157,9 +157,9 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
 
         // Set the list resource templates handler, or use the default if not specified
         var listResourceTemplatesHandler = resourcesCapability.ListResourceTemplatesHandler
-	        ?? ((_, _) => Task.FromResult(new ListResourceTemplatesResult()));
+            ?? ((_, _) => Task.FromResult(new ListResourceTemplatesResult()));
 
-		SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
+        SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
 
         if (resourcesCapability.Subscribe is not true)
         {

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -152,12 +152,13 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
             throw new McpServerException("Resources capability was enabled, but ListResources and/or ReadResource handlers were not specified.");
         }
 
-        if (resourcesCapability.ListResourceTemplatesHandler is { } listResourceTemplatesHandler)
-        {
-            SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
-        }
         SetRequestHandler<ListResourcesRequestParams, ListResourcesResult>("resources/list", (request, ct) => listResourcesHandler(new(this, request), ct));
         SetRequestHandler<ReadResourceRequestParams, ReadResourceResult>("resources/read", (request, ct) => readResourceHandler(new(this, request), ct));
+
+        // Set the list resource templates handler, or use the default if not specified
+        var listResourceTemplatesHandler = resourcesCapability.ListResourceTemplatesHandler
+            ?? McpServerHandlers.Defaults.ListResourceTemplatesHandler;
+        SetRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>("resources/templates/list", (request, ct) => listResourceTemplatesHandler(new(this, request), ct));
 
         if (resourcesCapability.Subscribe is not true)
         {

--- a/src/ModelContextProtocol/Server/McpServerHandlers.cs
+++ b/src/ModelContextProtocol/Server/McpServerHandlers.cs
@@ -141,4 +141,17 @@ public sealed class McpServerHandlers
 
         options.GetCompletionHandler = GetCompletionHandler ?? options.GetCompletionHandler;
     }
+
+    /// <summary>
+    /// Default handlers for capabilities.
+    /// </summary>
+    public static class Defaults
+    {
+		/// <summary>
+		/// Gets or sets the handler for list resource templates requests.
+		/// </summary>
+		public static Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>> ListResourceTemplatesHandler
+		    => (context, token) => Task.FromResult(new ListResourceTemplatesResult());
+
+	}
 }

--- a/src/ModelContextProtocol/Server/McpServerHandlers.cs
+++ b/src/ModelContextProtocol/Server/McpServerHandlers.cs
@@ -147,11 +147,11 @@ public sealed class McpServerHandlers
     /// </summary>
     public static class Defaults
     {
-		/// <summary>
-		/// Gets or sets the handler for list resource templates requests.
-		/// </summary>
-		public static Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>> ListResourceTemplatesHandler
-		    => (context, token) => Task.FromResult(new ListResourceTemplatesResult());
+        /// <summary>
+        /// Gets or sets the handler for list resource templates requests.
+        /// </summary>
+        public static Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>> ListResourceTemplatesHandler
+            => (context, token) => Task.FromResult(new ListResourceTemplatesResult());
 
-	}
+    }
 }

--- a/src/ModelContextProtocol/Server/McpServerHandlers.cs
+++ b/src/ModelContextProtocol/Server/McpServerHandlers.cs
@@ -151,7 +151,7 @@ public sealed class McpServerHandlers
         /// Gets or sets the handler for list resource templates requests.
         /// </summary>
         public static Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>> ListResourceTemplatesHandler
-            => (context, token) => Task.FromResult(new ListResourceTemplatesResult());
+            => static (context, token) => Task.FromResult(new ListResourceTemplatesResult());
 
     }
 }

--- a/src/ModelContextProtocol/Server/McpServerHandlers.cs
+++ b/src/ModelContextProtocol/Server/McpServerHandlers.cs
@@ -145,7 +145,7 @@ public sealed class McpServerHandlers
     /// <summary>
     /// Default handlers for capabilities.
     /// </summary>
-    public static class Defaults
+    internal static class Defaults
     {
         /// <summary>
         /// Gets or sets the handler for list resource templates requests.

--- a/src/ModelContextProtocol/Server/McpServerHandlers.cs
+++ b/src/ModelContextProtocol/Server/McpServerHandlers.cs
@@ -28,6 +28,11 @@ public sealed class McpServerHandlers
     public Func<RequestContext<GetPromptRequestParams>, CancellationToken, Task<GetPromptResult>>? GetPromptHandler { get; set; }
 
     /// <summary>
+    /// Gets or sets the handler for list resource templates requests.
+    /// </summary>
+    public Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>>? ListResourceTemplatesHandler { get; set; }
+
+    /// <summary>
     /// Gets or sets the handler for list resources requests.
     /// </summary>
     public Func<RequestContext<ListResourcesRequestParams>, CancellationToken, Task<ListResourcesResult>>? ListResourcesHandler { get; set; }
@@ -82,11 +87,13 @@ public sealed class McpServerHandlers
             resourcesCapability = resourcesCapability is null ?
                 new()
                 {
+                    ListResourceTemplatesHandler = ListResourceTemplatesHandler,
                     ListResourcesHandler = ListResourcesHandler,
                     ReadResourceHandler = ReadResourceHandler
                 } :
                 resourcesCapability with
                 {
+                    ListResourceTemplatesHandler = ListResourceTemplatesHandler ?? resourcesCapability.ListResourceTemplatesHandler,
                     ListResourcesHandler = ListResourcesHandler ?? resourcesCapability.ListResourcesHandler,
                     ReadResourceHandler = ReadResourceHandler ?? resourcesCapability.ReadResourceHandler
                 };

--- a/src/ModelContextProtocol/Server/McpServerHandlers.cs
+++ b/src/ModelContextProtocol/Server/McpServerHandlers.cs
@@ -141,17 +141,4 @@ public sealed class McpServerHandlers
 
         options.GetCompletionHandler = GetCompletionHandler ?? options.GetCompletionHandler;
     }
-
-    /// <summary>
-    /// Default handlers for capabilities.
-    /// </summary>
-    internal static class Defaults
-    {
-        /// <summary>
-        /// Gets or sets the handler for list resource templates requests.
-        /// </summary>
-        public static Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>> ListResourceTemplatesHandler
-            => static (context, token) => Task.FromResult(new ListResourceTemplatesResult());
-
-    }
 }

--- a/tests/ModelContextProtocol.TestServer/Program.cs
+++ b/tests/ModelContextProtocol.TestServer/Program.cs
@@ -315,7 +315,6 @@ internal static class Program
         {
             ListResourceTemplatesHandler = (request, cancellationToken) =>
             {
-
                 return Task.FromResult(new ListResourceTemplatesResult()
                 {
                     ResourceTemplates = [

--- a/tests/ModelContextProtocol.TestServer/Program.cs
+++ b/tests/ModelContextProtocol.TestServer/Program.cs
@@ -313,6 +313,21 @@ internal static class Program
 
         return new()
         {
+            ListResourceTemplatesHandler = (request, cancellationToken) =>
+            {
+
+                return Task.FromResult(new ListResourceTemplatesResult()
+                {
+                    ResourceTemplates = [
+                        new ResourceTemplate()
+                        {
+                            UriTemplate = "test://dynamic/resource/{id}",
+                            Name = "Dynamic Resource",
+                        }
+                    ]
+                });
+            },
+
             ListResourcesHandler = (request, cancellationToken) =>
             {
                 int startIndex = 0;
@@ -349,6 +364,27 @@ internal static class Program
                 {
                     throw new McpServerException("Missing required argument 'uri'");
                 }
+
+                if (request.Params.Uri.StartsWith("test://dynamic/resource/"))
+                {
+                    var id = request.Params.Uri.Split('/').LastOrDefault();
+                    if (string.IsNullOrEmpty(id))
+                    {
+                        throw new McpServerException("Invalid resource URI");
+                    }
+                    return Task.FromResult(new ReadResourceResult()
+                    {
+                        Contents = [
+                            new ResourceContents()
+                            {
+                                Uri = request.Params.Uri,
+                                MimeType = "text/plain",
+                                Text = $"Dynamic resource {id}: This is a plaintext resource"
+                            }
+                        ]
+                    });
+                }
+
                 ResourceContents contents = resourceContents.FirstOrDefault(r => r.Uri == request.Params.Uri)
                     ?? throw new McpServerException("Resource not found");
 
@@ -364,7 +400,8 @@ internal static class Program
                 {
                     throw new McpServerException("Missing required argument 'uri'");
                 }
-                if (!request.Params.Uri.StartsWith("test://static/resource/"))
+                if (!request.Params.Uri.StartsWith("test://static/resource/")
+                    && !request.Params.Uri.StartsWith("test://dynamic/resource/"))
                 {
                     throw new McpServerException("Invalid resource URI");
                 }
@@ -383,7 +420,8 @@ internal static class Program
                 {
                     throw new McpServerException("Missing required argument 'uri'");
                 }
-                if (!request.Params.Uri.StartsWith("test://static/resource/"))
+                if (!request.Params.Uri.StartsWith("test://static/resource/")
+                    && !request.Params.Uri.StartsWith("test://dynamic/resource/"))
                 {
                     throw new McpServerException("Invalid resource URI");
                 }

--- a/tests/ModelContextProtocol.TestSseServer/Program.cs
+++ b/tests/ModelContextProtocol.TestSseServer/Program.cs
@@ -263,11 +263,11 @@ internal class Program
                         {
                             Contents = [
                                 new ResourceContents()
-                            {
-                                Uri = request.Params.Uri,
-                                MimeType = "text/plain",
-                                Text = $"Dynamic resource {id}: This is a plaintext resource"
-                            }
+                                {
+                                    Uri = request.Params.Uri,
+                                    MimeType = "text/plain",
+                                    Text = $"Dynamic resource {id}: This is a plaintext resource"
+                                }
                             ]
                         });
                     }

--- a/tests/ModelContextProtocol.TestSseServer/Program.cs
+++ b/tests/ModelContextProtocol.TestSseServer/Program.cs
@@ -200,6 +200,21 @@ internal class Program
             },
             Resources = new()
             {
+                ListResourceTemplatesHandler = (request, cancellationToken) =>
+                {
+
+                    return Task.FromResult(new ListResourceTemplatesResult()
+                    {
+                        ResourceTemplates = [
+                            new ResourceTemplate()
+                        {
+                            UriTemplate = "test://dynamic/resource/{id}",
+                            Name = "Dynamic Resource",
+                        }
+                        ]
+                    });
+                },
+
                 ListResourcesHandler = (request, cancellationToken) =>
                 {
                     int startIndex = 0;
@@ -236,7 +251,27 @@ internal class Program
                     {
                         throw new McpServerException("Missing required argument 'uri'");
                     }
-                    
+
+                    if (request.Params.Uri.StartsWith("test://dynamic/resource/"))
+                    {
+                        var id = request.Params.Uri.Split('/').LastOrDefault();
+                        if (string.IsNullOrEmpty(id))
+                        {
+                            throw new McpServerException("Invalid resource URI");
+                        }
+                        return Task.FromResult(new ReadResourceResult()
+                        {
+                            Contents = [
+                                new ResourceContents()
+                            {
+                                Uri = request.Params.Uri,
+                                MimeType = "text/plain",
+                                Text = $"Dynamic resource {id}: This is a plaintext resource"
+                            }
+                            ]
+                        });
+                    }
+
                     ResourceContents? contents = resourceContents.FirstOrDefault(r => r.Uri == request.Params.Uri) ?? 
                         throw new McpServerException("Resource not found");
                     

--- a/tests/ModelContextProtocol.TestSseServer/Program.cs
+++ b/tests/ModelContextProtocol.TestSseServer/Program.cs
@@ -207,10 +207,10 @@ internal class Program
                     {
                         ResourceTemplates = [
                             new ResourceTemplate()
-                        {
-                            UriTemplate = "test://dynamic/resource/{id}",
-                            Name = "Dynamic Resource",
-                        }
+                            {
+                                UriTemplate = "test://dynamic/resource/{id}",
+                                Name = "Dynamic Resource",
+                            }
                         ]
                     });
                 },

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -187,7 +187,7 @@ public class ClientIntegrationTests : IClassFixture<ClientIntegrationTestFixture
 
         List<ResourceTemplate> allResourceTemplates = await client.ListResourceTemplatesAsync(TestContext.Current.CancellationToken).ToListAsync(TestContext.Current.CancellationToken);
 
-        // The server provides 2 test resource templates
+        // The server provides a single test resource template
         Assert.Single(allResourceTemplates);
     }
 

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -178,6 +178,29 @@ public class ClientIntegrationTests : IClassFixture<ClientIntegrationTestFixture
 
     [Theory]
     [MemberData(nameof(GetClients))]
+    public async Task ListResourceTemplates_Stdio(string clientId)
+    {
+        // arrange
+
+        // act
+        await using var client = await _fixture.CreateClientAsync(clientId);
+
+        List<ResourceTemplate> allResourceTemplates = [];
+        string? cursor = null;
+        do
+        {
+            var resources = await client.ListResourceTemplatesAsync(cursor, CancellationToken.None);
+            allResourceTemplates.AddRange(resources.ResourceTemplates);
+            cursor = resources.NextCursor;
+        }
+        while (cursor != null);
+
+        // The server provides 2 test resource templates
+        Assert.Single(allResourceTemplates);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetClients))]
     public async Task ListResources_Stdio(string clientId)
     {
         // arrange

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -185,15 +185,7 @@ public class ClientIntegrationTests : IClassFixture<ClientIntegrationTestFixture
         // act
         await using var client = await _fixture.CreateClientAsync(clientId);
 
-        List<ResourceTemplate> allResourceTemplates = [];
-        string? cursor = null;
-        do
-        {
-            var resources = await client.ListResourceTemplatesAsync(cursor, CancellationToken.None);
-            allResourceTemplates.AddRange(resources.ResourceTemplates);
-            cursor = resources.NextCursor;
-        }
-        while (cursor != null);
+        List<ResourceTemplate> allResourceTemplates = await client.ListResourceTemplatesAsync(TestContext.Current.CancellationToken).ToListAsync(TestContext.Current.CancellationToken);
 
         // The server provides 2 test resource templates
         Assert.Single(allResourceTemplates);

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsHandlerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsHandlerTests.cs
@@ -72,6 +72,19 @@ public class McpServerBuilderExtensionsHandlerTests
     }
 
     [Fact]
+    public void WithListResourceTemplatesHandler_Sets_Handler()
+    {
+        Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>> handler = (context, token) => Task.FromResult(new ListResourceTemplatesResult());
+
+        _builder.Object.WithListResourceTemplatesHandler(handler);
+
+        var serviceProvider = _services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+
+        Assert.Equal(handler, options.ListResourceTemplatesHandler);
+    }
+
+    [Fact]
     public void WithListResourcesHandler_Sets_Handler()
     {
         Func<RequestContext<ListResourcesRequestParams>, CancellationToken, Task<ListResourcesResult>> handler = (context, token) => Task.FromResult(new ListResourcesResult());

--- a/tests/ModelContextProtocol.Tests/Server/McpServerDelegatesTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerDelegatesTests.cs
@@ -14,6 +14,7 @@ public class McpServerHandlerTests
         Assert.Null(handlers.CallToolHandler);
         Assert.Null(handlers.ListPromptsHandler);
         Assert.Null(handlers.GetPromptHandler);
+        Assert.Null(handlers.ListResourceTemplatesHandler);
         Assert.Null(handlers.ListResourcesHandler);
         Assert.Null(handlers.ReadResourceHandler);
         Assert.Null(handlers.GetCompletionHandler);
@@ -24,6 +25,7 @@ public class McpServerHandlerTests
         handlers.CallToolHandler = (p, c) => Task.FromResult(new CallToolResponse());
         handlers.ListPromptsHandler = (p, c) => Task.FromResult(new ListPromptsResult());
         handlers.GetPromptHandler = (p, c) => Task.FromResult(new GetPromptResult());
+        handlers.ListResourceTemplatesHandler = (p, c) => Task.FromResult(new ListResourceTemplatesResult());
         handlers.ListResourcesHandler = (p, c) => Task.FromResult(new ListResourcesResult());
         handlers.ReadResourceHandler = (p, c) => Task.FromResult(new ReadResourceResult());
         handlers.GetCompletionHandler = (p, c) => Task.FromResult(new CompleteResult());
@@ -34,6 +36,7 @@ public class McpServerHandlerTests
         Assert.NotNull(handlers.CallToolHandler);
         Assert.NotNull(handlers.ListPromptsHandler);
         Assert.NotNull(handlers.GetPromptHandler);
+        Assert.NotNull(handlers.ListResourceTemplatesHandler);
         Assert.NotNull(handlers.ListResourcesHandler);
         Assert.NotNull(handlers.ReadResourceHandler);
         Assert.NotNull(handlers.GetCompletionHandler);

--- a/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
@@ -305,6 +305,37 @@ public class McpServerTests
     }
 
     [Fact]
+    public async Task Can_Handle_ResourceTemplates_List_Requests()
+    {
+        await Can_Handle_Requests(
+            new ServerCapabilities
+            {
+                Resources = new()
+                {
+                    ListResourceTemplatesHandler = (request, ct) =>
+                    {
+                        return Task.FromResult(new ListResourceTemplatesResult
+                        {
+                            ResourceTemplates = [new() { UriTemplate = "test", Name = "Test Resource" }]
+                        });
+                    },
+                    ReadResourceHandler = (request, ct) => throw new NotImplementedException(),
+                }
+            },
+            "resources/templates/list",
+            configureOptions: null,
+            assertResult: response =>
+            {
+                Assert.IsType<ListResourceTemplatesResult>(response);
+
+                var result = (ListResourceTemplatesResult)response;
+                Assert.NotNull(result.ResourceTemplates);
+                Assert.NotEmpty(result.ResourceTemplates);
+                Assert.Equal("test", result.ResourceTemplates[0].UriTemplate);
+            });
+    }
+
+    [Fact]
     public async Task Can_Handle_Resources_List_Requests()
     {
         await Can_Handle_Requests(

--- a/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
@@ -319,6 +319,13 @@ public class McpServerTests
                             ResourceTemplates = [new() { UriTemplate = "test", Name = "Test Resource" }]
                         });
                     },
+                    ListResourcesHandler = (request, ct) =>
+                    {
+                        return Task.FromResult(new ListResourcesResult
+                        {
+                            Resources = [new() { Uri = "test", Name = "Test Resource" }]
+                        });
+                    },
                     ReadResourceHandler = (request, ct) => throw new NotImplementedException(),
                 }
             },


### PR DESCRIPTION
This adds some new types and handlers to implement Resource Template functionality according to the spec.

## Motivation and Context
Adds more functionality from the spec :)

## How Has This Been Tested?
- Unit tests
- Manual testing with mcp-inspector and the Test Server project (List Templates, Read dynamic template resource, and subscribe/unsubscribe validated)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

Fixes #20 