### PR TITLE
Move the SseResponseStreamTransport out of sample

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="System.Net.ServerSentEvents" Version="$(SystemVersion)" />
+    <PackageVersion Include="System.Net.ServerSentEvents" Version="$(System10Version)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemVersion)" />
     <PackageVersion Include="System.Threading.Channels" Version="$(SystemVersion)" />
 

--- a/samples/AspNetCoreSseServer/AspNetCoreSseServer.csproj
+++ b/samples/AspNetCoreSseServer/AspNetCoreSseServer.csproj
@@ -10,8 +10,4 @@
     <ProjectReference Include="..\..\src\ModelContextProtocol\ModelContextProtocol.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Net.ServerSentEvents" VersionOverride="10.0.0-preview.1.25080.5" />
-  </ItemGroup>
-
 </Project>

--- a/samples/AspNetCoreSseServer/McpEndpointRouteBuilderExtensions.cs
+++ b/samples/AspNetCoreSseServer/McpEndpointRouteBuilderExtensions.cs
@@ -2,6 +2,7 @@
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Utils.Json;
 using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol.Transport;
 
 namespace AspNetCoreSseServer;
 
@@ -10,7 +11,7 @@ public static class McpEndpointRouteBuilderExtensions
     public static IEndpointConventionBuilder MapMcpSse(this IEndpointRouteBuilder endpoints)
     {
         IMcpServer? server = null;
-        SseServerStreamTransport? transport = null;
+        SseResponseStreamTransport? transport = null;
         var loggerFactory = endpoints.ServiceProvider.GetRequiredService<ILoggerFactory>();
         var mcpServerOptions = endpoints.ServiceProvider.GetRequiredService<IOptions<McpServerOptions>>();
 
@@ -18,7 +19,7 @@ public static class McpEndpointRouteBuilderExtensions
 
         routeGroup.MapGet("/sse", async (HttpResponse response, CancellationToken requestAborted) =>
         {
-            await using var localTransport = transport = new SseServerStreamTransport(response.Body);
+            await using var localTransport = transport = new SseResponseStreamTransport(response.Body);
             await using var localServer = server = McpServerFactory.Create(transport, mcpServerOptions.Value, loggerFactory, endpoints.ServiceProvider);
 
             await localServer.StartAsync(requestAborted);
@@ -37,7 +38,7 @@ public static class McpEndpointRouteBuilderExtensions
             }
         });
 
-        routeGroup.MapPost("/message", async (HttpContext context) =>
+        routeGroup.MapPost("/message", async context =>
         {
             if (transport is null)
             {

--- a/src/ModelContextProtocol/Protocol/Transport/HttpListenerServerProvider.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/HttpListenerServerProvider.cs
@@ -28,7 +28,7 @@ internal class HttpListenerServerProvider : IDisposable
     }
 
     public required Func<Stream, CancellationToken, Task> OnSseConnectionAsync { get; set; }
-    public required Func<string, CancellationToken, Task<bool>> OnMessageAsync { get; set; }
+    public required Func<Stream, CancellationToken, Task<bool>> OnMessageAsync { get; set; }
 
     /// <inheritdoc/>
     public Task StartAsync(CancellationToken cancellationToken = default)
@@ -169,15 +169,8 @@ internal class HttpListenerServerProvider : IDisposable
         var request = context.Request;
         var response = context.Response;
 
-        // Read the request body
-        string requestBody;
-        using (var reader = new StreamReader(request.InputStream, request.ContentEncoding))
-        {
-            requestBody = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-        }
-
         // Process the message asynchronously
-        if (await OnMessageAsync(requestBody, cancellationToken))
+        if (await OnMessageAsync(request.InputStream, cancellationToken))
         {
             // Return 202 Accepted
             response.StatusCode = 202;

--- a/src/ModelContextProtocol/Protocol/Transport/HttpListenerServerProvider.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/HttpListenerServerProvider.cs
@@ -1,5 +1,4 @@
 ﻿using ModelContextProtocol.Server;
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text;
 
@@ -8,7 +7,6 @@ namespace ModelContextProtocol.Protocol.Transport;
 /// <summary>
 /// HTTP server provider using HttpListener.
 /// </summary>
-[ExcludeFromCodeCoverage]
 internal class HttpListenerServerProvider : IDisposable
 {
     private static readonly byte[] s_accepted = "Accepted"u8.ToArray();
@@ -30,11 +28,6 @@ internal class HttpListenerServerProvider : IDisposable
     public HttpListenerServerProvider(int port)
     {
         _port = port;
-    }
-
-    public Task<string> GetSseEndpointUri()
-    {
-        return Task.FromResult($"http://localhost:{_port}{SseEndpoint}");
     }
 
     public Task InitializeMessageHandler(Func<string, CancellationToken, bool> messageHandler)

--- a/src/ModelContextProtocol/Protocol/Transport/HttpListenerSseServerTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/HttpListenerSseServerTransport.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Net;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Utils.Json;
@@ -9,7 +10,7 @@ using ModelContextProtocol.Utils;
 namespace ModelContextProtocol.Protocol.Transport;
 
 /// <summary>
-/// Implements the MCP transport protocol over standard input/output streams.
+/// Implements the MCP transport protocol using <see cref="HttpListener"/>.
 /// </summary>
 public sealed class HttpListenerSseServerTransport : TransportBase, IServerTransport
 {

--- a/src/ModelContextProtocol/Protocol/Transport/HttpListenerSseServerTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/HttpListenerSseServerTransport.cs
@@ -17,9 +17,8 @@ public sealed class HttpListenerSseServerTransport : TransportBase, IServerTrans
     private readonly string _serverName;
     private readonly HttpListenerServerProvider _httpServerProvider;
     private readonly ILogger<HttpListenerSseServerTransport> _logger;
-    private readonly JsonSerializerOptions _jsonOptions;
-    private CancellationTokenSource? _shutdownCts;
-    
+    private SseResponseStreamTransport? _sseResponseStreamTransport;
+
     private string EndpointName => $"Server (SSE) ({_serverName})";
 
     /// <summary>
@@ -44,28 +43,23 @@ public sealed class HttpListenerSseServerTransport : TransportBase, IServerTrans
     {
         _serverName = serverName;
         _logger = loggerFactory.CreateLogger<HttpListenerSseServerTransport>();
-        _jsonOptions = McpJsonUtilities.DefaultOptions;
-        _httpServerProvider = new HttpListenerServerProvider(port);
+        _httpServerProvider = new HttpListenerServerProvider(port)
+        {
+            OnSseConnectionAsync = OnSseConnectionAsync,
+            OnMessageAsync = OnMessageAsync,
+        };
     }
 
     /// <inheritdoc/>
     public Task StartListeningAsync(CancellationToken cancellationToken = default)
     {
-        _shutdownCts = new CancellationTokenSource();
-
-        _httpServerProvider.InitializeMessageHandler(HttpMessageHandler);
-        _httpServerProvider.StartAsync(cancellationToken);
-
-        SetConnected(true);
-
-        return Task.CompletedTask;
+        return _httpServerProvider.StartAsync(cancellationToken);
     }
-
 
     /// <inheritdoc/>
     public override async Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
     {
-        if (!IsConnected)
+        if (!IsConnected || _sseResponseStreamTransport is null)
         {
             _logger.TransportNotConnected(EndpointName);
             throw new McpTransportException("Transport is not connected");
@@ -79,10 +73,10 @@ public sealed class HttpListenerSseServerTransport : TransportBase, IServerTrans
 
         try
         {
-            var json = JsonSerializer.Serialize(message, _jsonOptions.GetTypeInfo<IJsonRpcMessage>());
+            var json = JsonSerializer.Serialize(message, McpJsonUtilities.DefaultOptions.GetTypeInfo<IJsonRpcMessage>());
             _logger.TransportSendingMessage(EndpointName, id, json);
 
-            await _httpServerProvider.SendEvent(json, "message").ConfigureAwait(false);
+            await _sseResponseStreamTransport.SendMessageAsync(message, cancellationToken).ConfigureAwait(false);
 
             _logger.TransportSentMessage(EndpointName, id);
         }
@@ -100,49 +94,47 @@ public sealed class HttpListenerSseServerTransport : TransportBase, IServerTrans
         GC.SuppressFinalize(this);
     }
 
-    private async Task CleanupAsync(CancellationToken cancellationToken)
+    private Task CleanupAsync(CancellationToken cancellationToken)
     {
         _logger.TransportCleaningUp(EndpointName);
 
-        if (_shutdownCts != null)
-        {
-            await _shutdownCts.CancelAsync().ConfigureAwait(false);
-            _shutdownCts.Dispose();
-            _shutdownCts = null;
-        }
-
         _httpServerProvider.Dispose();
-
         SetConnected(false);
+
         _logger.TransportCleanedUp(EndpointName);
+        return Task.CompletedTask;
+    }
+
+    private async Task OnSseConnectionAsync(Stream responseStream, CancellationToken cancellationToken)
+    {
+        await using var sseResponseStreamTransport = new SseResponseStreamTransport(responseStream);
+        _sseResponseStreamTransport = sseResponseStreamTransport;
+        SetConnected(true);
+        await sseResponseStreamTransport.RunAsync(cancellationToken);
     }
 
     /// <summary>
     /// Handles HTTP messages received by the HTTP server provider.
     /// </summary>
     /// <returns>true if the message was accepted (return 202), false otherwise (return 400)</returns>
-    private bool HttpMessageHandler(string request, CancellationToken cancellationToken)
+    private async Task<bool> OnMessageAsync(string request, CancellationToken cancellationToken)
     {
         _logger.TransportReceivedMessage(EndpointName, request);
 
         try
         {
-            var message = JsonSerializer.Deserialize(request, _jsonOptions.GetTypeInfo<IJsonRpcMessage>());
+            var message = JsonSerializer.Deserialize(request, McpJsonUtilities.DefaultOptions.GetTypeInfo<IJsonRpcMessage>());
             if (message != null)
             {
-                // Fire-and-forget the message to the message channel
-                Task.Run(async () =>
+                string messageId = "(no id)";
+                if (message is IJsonRpcMessageWithId messageWithId)
                 {
-                    string messageId = "(no id)";
-                    if (message is IJsonRpcMessageWithId messageWithId)
-                    {
-                        messageId = messageWithId.Id.ToString();
-                    }
+                    messageId = messageWithId.Id.ToString();
+                }
 
-                    _logger.TransportReceivedMessageParsed(EndpointName, messageId);
-                    await WriteMessageAsync(message, cancellationToken).ConfigureAwait(false);
-                    _logger.TransportMessageWritten(EndpointName, messageId);
-                }, cancellationToken);
+                _logger.TransportReceivedMessageParsed(EndpointName, messageId);
+                await WriteMessageAsync(message, cancellationToken).ConfigureAwait(false);
+                _logger.TransportMessageWritten(EndpointName, messageId);
 
                 return true;
             }

--- a/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
@@ -61,14 +61,14 @@ public sealed class SseResponseStreamTransport(Stream sseResponseStream) : ITran
     }
 
     /// <inheritdoc/>
-    public Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
+    public async Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
     {
         if (_sseWriteTask is null)
         {
             throw new InvalidOperationException($"Transport is not connected. Make sure to call {nameof(RunAsync)} first.");
         }
 
-        return _outgoingSseChannel.Writer.WriteAsync(new SseItem<IJsonRpcMessage?>(message), cancellationToken).AsTask();
+        await _outgoingSseChannel.Writer.WriteAsync(new SseItem<IJsonRpcMessage?>(message), cancellationToken).AsTask();
     }
 
     /// <summary>
@@ -78,14 +78,14 @@ public sealed class SseResponseStreamTransport(Stream sseResponseStream) : ITran
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task representing the potentially asynchronous operation to buffer or process the JSON-RPC message.</returns>
     /// <exception cref="InvalidOperationException">Thrown when there is an attempt to process a message before calling <see cref="RunAsync(CancellationToken)"/>.</exception>
-    public Task OnMessageReceivedAsync(IJsonRpcMessage message, CancellationToken cancellationToken)
+    public async Task OnMessageReceivedAsync(IJsonRpcMessage message, CancellationToken cancellationToken)
     {
         if (_sseWriteTask is null)
         {
             throw new InvalidOperationException($"Transport is not connected. Make sure to call {nameof(RunAsync)} first.");
         }
 
-        return _incomingChannel.Writer.WriteAsync(message, cancellationToken).AsTask();
+        await _incomingChannel.Writer.WriteAsync(message, cancellationToken).AsTask();
     }
 
     private static Channel<T> CreateSingleItemChannel<T>() =>

--- a/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
@@ -3,12 +3,15 @@ using System.Net.ServerSentEvents;
 using System.Text.Json;
 using System.Threading.Channels;
 using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Utils.Json;
 
-namespace AspNetCoreSseServer;
+namespace ModelContextProtocol.Protocol.Transport;
 
-public class SseServerStreamTransport(Stream sseResponseStream) : ITransport
+/// <summary>
+/// Implements the MCP SSE server transport protocol using the SSE response <see cref="Stream"/>.
+/// </summary>
+/// <param name="sseResponseStream">The stream to write the SSE response body to.</param>
+public sealed class SseResponseStreamTransport(Stream sseResponseStream) : ITransport
 {
     private readonly Channel<IJsonRpcMessage> _incomingChannel = CreateSingleItemChannel<IJsonRpcMessage>();
     private readonly Channel<SseItem<IJsonRpcMessage?>> _outgoingSseChannel = CreateSingleItemChannel<SseItem<IJsonRpcMessage?>>();
@@ -16,8 +19,15 @@ public class SseServerStreamTransport(Stream sseResponseStream) : ITransport
     private Task? _sseWriteTask;
     private Utf8JsonWriter? _jsonWriter;
 
+    /// <inherityydoc/>
     public bool IsConnected => _sseWriteTask?.IsCompleted == false;
 
+    /// <summary>
+    /// Starts the transport and writes the JSON-RPC messages sent via <see cref="SendMessageAsync(IJsonRpcMessage, CancellationToken)"/>
+    /// to the SSE response stream until cancelled or disposed.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel writing to the SSE response stream.</param>
+    /// <returns>A task representing the send loop that writes JSON-RPC messages to the SSE response stream.</returns>
     public Task RunAsync(CancellationToken cancellationToken)
     {
         void WriteJsonRpcMessageToBuffer(SseItem<IJsonRpcMessage?> item, IBufferWriter<byte> writer)
@@ -28,7 +38,7 @@ public class SseServerStreamTransport(Stream sseResponseStream) : ITransport
                 return;
             }
 
-            JsonSerializer.Serialize(GetUtf8JsonWriter(writer), item.Data, McpJsonUtilities.DefaultOptions);
+            JsonSerializer.Serialize(GetUtf8JsonWriter(writer), item.Data, McpJsonUtilities.DefaultOptions.GetTypeInfo<IJsonRpcMessage?>());
         }
 
         // The very first SSE event isn't really an IJsonRpcMessage, but there's no API to write a single item of a different type,
@@ -39,8 +49,10 @@ public class SseServerStreamTransport(Stream sseResponseStream) : ITransport
         return _sseWriteTask = SseFormatter.WriteAsync(sseItems, sseResponseStream, WriteJsonRpcMessageToBuffer, cancellationToken);
     }
 
+    /// <inheritdoc/>
     public ChannelReader<IJsonRpcMessage> MessageReader => _incomingChannel.Reader;
 
+    /// <inheritdoc/>
     public ValueTask DisposeAsync()
     {
         _incomingChannel.Writer.TryComplete();
@@ -48,14 +60,29 @@ public class SseServerStreamTransport(Stream sseResponseStream) : ITransport
         return new ValueTask(_sseWriteTask ?? Task.CompletedTask);
     }
 
-    public Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default) =>
-        _outgoingSseChannel.Writer.WriteAsync(new SseItem<IJsonRpcMessage?>(message), cancellationToken).AsTask();
+    /// <inheritdoc/>
+    public Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
+    {
+        if (_sseWriteTask is null)
+        {
+            throw new InvalidOperationException($"Transport is not connected. Make sure to call {nameof(RunAsync)} first.");
+        }
 
+        return _outgoingSseChannel.Writer.WriteAsync(new SseItem<IJsonRpcMessage?>(message), cancellationToken).AsTask();
+    }
+
+    /// <summary>
+    /// Handles incoming JSON-RPC messages received on the /message endpoint.
+    /// </summary>
+    /// <param name="message">The JSON-RPC message received.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task representing the potentially asynchronous operation to buffer or process the JSON-RPC message.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when there is an attempt to process a message before calling <see cref="RunAsync(CancellationToken)"/>.</exception>
     public Task OnMessageReceivedAsync(IJsonRpcMessage message, CancellationToken cancellationToken)
     {
-        if (!IsConnected)
+        if (_sseWriteTask is null)
         {
-            throw new McpTransportException("Transport is not connected");
+            throw new InvalidOperationException($"Transport is not connected. Make sure to call {nameof(RunAsync)} first.");
         }
 
         return _incomingChannel.Writer.WriteAsync(message, cancellationToken).AsTask();

--- a/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
@@ -19,7 +19,7 @@ public sealed class SseResponseStreamTransport(Stream sseResponseStream) : ITran
     private Task? _sseWriteTask;
     private Utf8JsonWriter? _jsonWriter;
 
-    /// <inherityydoc/>
+    /// <inheritdoc/>
     public bool IsConnected => _sseWriteTask?.IsCompleted == false;
 
     /// <summary>


### PR DESCRIPTION
TODO:

- Add tests
  - We now have some integration test coverage, because this is now used by the SseServerIntegrationTests.
- ~Add logging~ I decided against adding logging since logging could be added by the creator of the transport like the ASP.NET Core sample or the HttpListenerSseServerTransport as demonstrated by this PR.
- ~Use it in the HttpListenerSseServerTransport~ Done

I'm working on these things now, but if we like the API shape, I think we can merge it as-is to let people try it out and do the TODOs as follow ups.