### PR TITLE
Refactor Resource/ResourceTemplate to subclass Annotated

### DIFF
--- a/src/ModelContextProtocol/Protocol/Types/Annotated.cs
+++ b/src/ModelContextProtocol/Protocol/Types/Annotated.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ModelContextProtocol.Protocol.Types;
+
+/// <summary>
+/// Base for objects that include optional annotations for the client. The client can use annotations to inform how objects are used or displayed.
+/// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
+/// </summary>
+public abstract record Annotated
+{
+    /// <summary>
+    /// Optional annotations for the resource.
+    /// </summary>
+    [JsonPropertyName("annotations")]
+    public Annotations? Annotations { get; init; }
+}

--- a/src/ModelContextProtocol/Protocol/Types/Resource.cs
+++ b/src/ModelContextProtocol/Protocol/Types/Resource.cs
@@ -6,7 +6,7 @@ namespace ModelContextProtocol.Protocol.Types;
 /// Represents a known resource that the server is capable of reading.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public record Resource
+public record Resource : Annotated
 {
     /// <summary>
     /// The URI of this resource.
@@ -31,10 +31,4 @@ public record Resource
     /// </summary>
     [JsonPropertyName("mimeType")]
     public string? MimeType { get; init; }
-
-    /// <summary>
-    /// Optional annotations for the resource.
-    /// </summary>
-    [JsonPropertyName("annotations")]
-    public Annotations? Annotations { get; init; }
 }

--- a/src/ModelContextProtocol/Protocol/Types/ResourceTemplate.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ResourceTemplate.cs
@@ -8,7 +8,7 @@ namespace ModelContextProtocol.Protocol.Types;
 /// Represents a known resource template that the server is capable of reading.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public record ResourceTemplate
+public record ResourceTemplate : Annotated
 {
     /// <summary>
     /// The URI template (according to RFC 6570) that can be used to construct resource URIs.
@@ -33,10 +33,4 @@ public record ResourceTemplate
     /// </summary>
     [JsonPropertyName("mimeType")]
     public string? MimeType { get; init; }
-
-    /// <summary>
-    /// Optional annotations for the resource template.
-    /// </summary>
-    [JsonPropertyName("annotations")]
-    public Annotations? Annotations { get; init; }
 }


### PR DESCRIPTION
The `Resource` and `ResourceTemplate` types should derive from a base `Annotated` type having the `Annotations` property as per the [spec](https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.ts#L821)

This small change makes the C# types match the schema more closely.

Also renamed Resources.cs to Resource.cs to reflect the type name.

## Motivation and Context
As per #20 refactoring these two types

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
