### PR TITLE
Remove Nerdbank.GitVersioning and set version to 0.1.0-preview

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <PackageVersion>0.1.0-preview</PackageVersion>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))</RepoRoot>
     <VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).$(TargetFramework).$(OS).trx</VSTestLogger>
     <VSTestResultsDirectory>$(RepoRoot)/artifacts/TestResults</VSTestResultsDirectory>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,6 @@
 
     <!-- Build Infra & Packaging -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
 
     <!-- Testing dependencies -->
     <PackageVersion Include="Anthropic.SDK" Version="4.7.1" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,9 +1,0 @@
-{
-    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.1.0-preview",
-    "publicReleaseRefSpec": [
-      "^refs/heads/main$",
-      "^refs/heads/v\\d+(?:\\.\\d+)?$",
-      "^refs/tags/v\\d+(?:\\.\\d+)?"
-    ]
-}


### PR DESCRIPTION
Simplifies the versioning approach and eliminates the SHA from the end of the version number.