### PR TITLE
Set the NuGet package copyright text

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <PackageVersion>0.1.0-preview</PackageVersion>
+    <Copyright>Copyright (c) Anthropic and Contributors</Copyright>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))</RepoRoot>
     <VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).$(TargetFramework).$(OS).trx</VSTestLogger>
     <VSTestResultsDirectory>$(RepoRoot)/artifacts/TestResults</VSTestResultsDirectory>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <PackageVersion>0.1.0-preview</PackageVersion>
-    <Copyright>Copyright (c) Anthropic and Contributors</Copyright>
+    <Authors>Microsoft</Authors>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))</RepoRoot>
     <VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).$(TargetFramework).$(OS).trx</VSTestLogger>
     <VSTestResultsDirectory>$(RepoRoot)/artifacts/TestResults</VSTestResultsDirectory>


### PR DESCRIPTION
The Copyright metadata was missing from the NuGet package.