### PR TITLE
Remove reflection from Connect test

### DIFF
--- a/tests/ModelContextProtocol.Tests/Transport/SseClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/SseClientTransportTests.cs
@@ -5,7 +5,6 @@ using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Tests.Utils;
 using System.Net;
 using System.Reflection;
-using System.Reflection.Metadata;
 
 namespace ModelContextProtocol.Tests.Transport;
 

--- a/tests/ModelContextProtocol.Tests/Transport/SseClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/SseClientTransportTests.cs
@@ -5,6 +5,7 @@ using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Tests.Utils;
 using System.Net;
 using System.Reflection;
+using System.Reflection.Metadata;
 
 namespace ModelContextProtocol.Tests.Transport;
 
@@ -107,12 +108,53 @@ public class SseClientTransportTests
     [Fact]
     public async Task ConnectAsync_Throws_If_Already_Connected()
     {
-        await using var transport = new SseClientTransport(_transportOptions, _serverConfig, NullLoggerFactory.Instance);
-        transport.GetType().BaseType!.GetField("_isConnected", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.SetValue(transport, true);
+        using var mockHttpHandler = new MockHttpHandler();
+        using var httpClient = new HttpClient(mockHttpHandler);
+        await using var transport = new SseClientTransport(_transportOptions, _serverConfig, httpClient, NullLoggerFactory.Instance);
+        using var mreConnected = new ManualResetEventSlim(false);
+        using var mreDone = new ManualResetEventSlim(false);
+        var callIndex = 0;
 
+        mockHttpHandler.RequestHandler = (request) =>
+        {
+            switch (callIndex++)
+            {
+                case 0:
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new StringContent("event: endpoint\r\ndata: http://localhost\r\n\r\n")
+                    });
+                case 1:
+                    mreConnected.Set();
+                    mreDone.Wait();
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new StringContent("")
+                    });
+                default:
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new StringContent("")
+                    });
+            }
+        };
+
+        var task = Task.Run(async () =>
+        {
+            await transport.ConnectAsync(TestContext.Current.CancellationToken);
+        }, TestContext.Current.CancellationToken);
+
+        mreConnected.Wait(TestContext.Current.CancellationToken);
+        Assert.True(transport.IsConnected);
         var action = async () => await transport.ConnectAsync();
         var exception = await Assert.ThrowsAsync<McpTransportException>(action);
         Assert.Equal("Transport is already connected", exception.Message);
+        mreDone.Set();
+        await transport.CloseAsync();
+        await task;
     }
 
     [Fact]


### PR DESCRIPTION
## Motivation and Context

This removes the reflection from the double connection test and replaces it with a `MockHttpHandler` to let the connection actually succeed and then test the redundant `ConnectAsync` call.

partial fix for #48

## How Has This Been Tested?

Ran unit tests locally

## Breaking Changes

No. Test only change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

