### PR TITLE
Fix enum serialization

### DIFF
--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -485,7 +485,7 @@ public static class McpClientExtensions
         Throw.IfNull(client);
 
         return client.SendRequestAsync<EmptyResult>(
-            CreateRequest("logging/setLevel", new() { ["level"] = level.ToJsonValue() }),
+            CreateRequest("logging/setLevel", new() { ["level"] = level }),
             cancellationToken);
     }
 
@@ -512,22 +512,6 @@ public static class McpClientExtensions
         }
 
         return parameters;
-    }
-
-    private static string ToJsonValue(this LoggingLevel level)
-    {
-        return level switch
-        {
-            LoggingLevel.Debug => "debug",
-            LoggingLevel.Info => "info",
-            LoggingLevel.Notice => "notice",
-            LoggingLevel.Warning => "warning",
-            LoggingLevel.Error => "error",
-            LoggingLevel.Critical => "critical",
-            LoggingLevel.Alert => "alert",
-            LoggingLevel.Emergency => "emergency",
-            _ => throw new ArgumentOutOfRangeException(nameof(level))
-        };
     }
 
     /// <summary>Provides an AI function that calls a tool through <see cref="IMcpClient"/>.</summary>

--- a/src/ModelContextProtocol/Protocol/Types/ContextInclusion.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ContextInclusion.cs
@@ -1,23 +1,29 @@
-﻿namespace ModelContextProtocol.Protocol.Types;
+﻿using System.Text.Json.Serialization;
+
+namespace ModelContextProtocol.Protocol.Types;
 
 /// <summary>
 /// A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<ContextInclusion>))]
 public enum ContextInclusion
 {
     /// <summary>
     /// No context should be included.
     /// </summary>
+    [JsonStringEnumMemberName("none")]
     None,
 
     /// <summary>
     /// Include context from the server that sent the request.
     /// </summary>
+    [JsonStringEnumMemberName("thisServer")]
     ThisServer,
 
     /// <summary>
     /// Include context from all servers that the client is connected to.
     /// </summary>
+    [JsonStringEnumMemberName("allServers")]
     AllServers
 }

--- a/src/ModelContextProtocol/Protocol/Types/LoggingLevel.cs
+++ b/src/ModelContextProtocol/Protocol/Types/LoggingLevel.cs
@@ -10,34 +10,34 @@ namespace ModelContextProtocol.Protocol.Types;
 public enum LoggingLevel
 {
     /// <summary>Detailed debug information, typically only valuable to developers.</summary>
-    [JsonPropertyName("debug")]
+    [JsonStringEnumMemberName("debug")]
     Debug,
 
     /// <summary>Normal operational messages that require no action.</summary>
-    [JsonPropertyName("info")]
+    [JsonStringEnumMemberName("info")]
     Info,
 
     /// <summary>Normal but significant events that might deserve attention.</summary>
-    [JsonPropertyName("notice")]
+    [JsonStringEnumMemberName("notice")]
     Notice,
 
     /// <summary>Warning conditions that don't represent an error but indicate potential issues.</summary>
-    [JsonPropertyName("warning")]
+    [JsonStringEnumMemberName("warning")]
     Warning,
 
     /// <summary>Error conditions that should be addressed but don't require immediate action.</summary>
-    [JsonPropertyName("error")]
+    [JsonStringEnumMemberName("error")]
     Error,
 
     /// <summary>Critical conditions that require immediate attention.</summary>
-    [JsonPropertyName("critical")]
+    [JsonStringEnumMemberName("critical")]
     Critical,
 
     /// <summary>Action must be taken immediately to address the condition.</summary>
-    [JsonPropertyName("alert")]
+    [JsonStringEnumMemberName("alert")]
     Alert,
 
     /// <summary>System is unusable and requires immediate attention.</summary>
-    [JsonPropertyName("emergency")]
+    [JsonStringEnumMemberName("emergency")]
     Emergency
 }

--- a/src/ModelContextProtocol/Protocol/Types/LoggingLevel.cs
+++ b/src/ModelContextProtocol/Protocol/Types/LoggingLevel.cs
@@ -7,6 +7,7 @@ namespace ModelContextProtocol.Protocol.Types;
 /// These map to syslog message severities, as specified in RFC-5424:
 /// https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<LoggingLevel>))]
 public enum LoggingLevel
 {
     /// <summary>Detailed debug information, typically only valuable to developers.</summary>

--- a/src/ModelContextProtocol/Protocol/Types/Role.cs
+++ b/src/ModelContextProtocol/Protocol/Types/Role.cs
@@ -11,12 +11,12 @@ public enum Role
     /// <summary>
     /// Corresponds to the user in the conversation.
     /// </summary>
-    [JsonPropertyName("user")]
+    [JsonStringEnumMemberName("user")]
     User,
 
     /// <summary>
     /// Corresponds to the AI in the conversation.
     /// </summary>
-    [JsonPropertyName("assistant")]
+    [JsonStringEnumMemberName("assistant")]
     Assistant
 }

--- a/src/ModelContextProtocol/Protocol/Types/Role.cs
+++ b/src/ModelContextProtocol/Protocol/Types/Role.cs
@@ -6,6 +6,7 @@ namespace ModelContextProtocol.Protocol.Types;
 /// Represents the type of role in the conversation.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<Role>))]
 public enum Role
 {
     /// <summary>

--- a/tests/ModelContextProtocol.Tests/Protocol/ProtocolTypeTests.cs
+++ b/tests/ModelContextProtocol.Tests/Protocol/ProtocolTypeTests.cs
@@ -1,4 +1,5 @@
 ﻿using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Utils.Json;
 using System.Text.Json;
 
 namespace ModelContextProtocol.Tests.Protocol;
@@ -50,5 +51,31 @@ public static class ProtocolTypeTests
         };
 
         Assert.True(JsonElement.DeepEquals(document.RootElement, tool.InputSchema));
+    }
+
+    [Theory]
+    [InlineData(Role.User, "\"user\"")]
+    [InlineData(Role.Assistant, "\"assistant\"")]
+    public static void SerializeRole_Should_Be_Lower_Case(Role role, string expectedValue)
+    {
+        var actualValue = JsonSerializer.Serialize(role, McpJsonUtilities.DefaultOptions);
+
+        Assert.Equal(expectedValue, actualValue);
+    }
+
+    [Theory]
+    [InlineData(LoggingLevel.Debug, "\"debug\"")]
+    [InlineData(LoggingLevel.Info, "\"info\"")]
+    [InlineData(LoggingLevel.Notice, "\"notice\"")]
+    [InlineData(LoggingLevel.Warning, "\"warning\"")]
+    [InlineData(LoggingLevel.Error, "\"error\"")]
+    [InlineData(LoggingLevel.Critical, "\"critical\"")]
+    [InlineData(LoggingLevel.Alert, "\"alert\"")]
+    [InlineData(LoggingLevel.Emergency, "\"emergency\"")]
+    public static void SerializeLoggingLevel_Should_Be_Lower_Case(LoggingLevel level, string expectedValue)
+    {
+        var actualValue = JsonSerializer.Serialize(level, McpJsonUtilities.DefaultOptions);
+
+        Assert.Equal(expectedValue, actualValue);
     }
 }

--- a/tests/ModelContextProtocol.Tests/Protocol/ProtocolTypeTests.cs
+++ b/tests/ModelContextProtocol.Tests/Protocol/ProtocolTypeTests.cs
@@ -56,9 +56,9 @@ public static class ProtocolTypeTests
     [Theory]
     [InlineData(Role.User, "\"user\"")]
     [InlineData(Role.Assistant, "\"assistant\"")]
-    public static void SerializeRole_Should_Be_Lower_Case(Role role, string expectedValue)
+    public static void SerializeRole_ShouldBeCamelCased(Role role, string expectedValue)
     {
-        var actualValue = JsonSerializer.Serialize(role, McpJsonUtilities.DefaultOptions);
+        var actualValue = JsonSerializer.Serialize(role);
 
         Assert.Equal(expectedValue, actualValue);
     }
@@ -72,9 +72,20 @@ public static class ProtocolTypeTests
     [InlineData(LoggingLevel.Critical, "\"critical\"")]
     [InlineData(LoggingLevel.Alert, "\"alert\"")]
     [InlineData(LoggingLevel.Emergency, "\"emergency\"")]
-    public static void SerializeLoggingLevel_Should_Be_Lower_Case(LoggingLevel level, string expectedValue)
+    public static void SerializeLoggingLevel_ShouldBeCamelCased(LoggingLevel level, string expectedValue)
     {
-        var actualValue = JsonSerializer.Serialize(level, McpJsonUtilities.DefaultOptions);
+        var actualValue = JsonSerializer.Serialize(level);
+
+        Assert.Equal(expectedValue, actualValue);
+    }
+
+    [Theory]
+    [InlineData(ContextInclusion.None, "\"none\"")]
+    [InlineData(ContextInclusion.ThisServer, "\"thisServer\"")]
+    [InlineData(ContextInclusion.AllServers, "\"allServers\"")]
+    public static void ContextInclusion_ShouldBeCamelCased(ContextInclusion level, string expectedValue)
+    {
+        var actualValue = JsonSerializer.Serialize(level);
 
         Assert.Equal(expectedValue, actualValue);
     }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

- Fix: #55

Use `JsonStringEnumMemberName` for `Role` and `LoggingLevel` enum to ensure their serialization is lower-case.

Remove `McpClientExtensions.ToJsonValue(LoggingLevel)` since serializing issue is fixed.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tested in reproduction for #55.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

N/A