### PR TITLE
Make client config optional to McpClientFactory.CreateAsync

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -20,16 +20,10 @@ For more information about MCP:
 ## Getting Started (Client)
 
 To get started writing a client, the `McpClientFactory.CreateAsync` method is used to instantiate and connect an `IMcpClient`
-to a server, with details about the client and server specified in `McpClientOptions` and `McpServerConfig` objects.
-Once you have an `IMcpClient`, you can interact with it, such as to enumerate all available tools and invoke tools.
+to a server. Once you have an `IMcpClient`, you can interact with it, such as to enumerate all available tools and invoke tools.
 
 ```csharp
-McpClientOptions options = new()
-{
-    ClientInfo = new() { Name = "TestClient", Version = "1.0.0" }
-};
-
-McpServerConfig config = new()
+var client = await McpClientFactory.CreateAsync(new()
 {
     Id = "everything",
     Name = "Everything",
@@ -39,9 +33,7 @@ McpServerConfig config = new()
         ["command"] = "npx",
         ["arguments"] = "-y @modelcontextprotocol/server-everything",
     }
-};
-
-var client = await McpClientFactory.CreateAsync(config, options);
+});
 
 // Print the list of tools available from the server.
 await foreach (var tool in client.ListToolsAsync())

--- a/samples/ChatWithTools/Program.cs
+++ b/samples/ChatWithTools/Program.cs
@@ -15,8 +15,7 @@ var mcpClient = await McpClientFactory.CreateAsync(
         {
             ["command"] = "npx", ["arguments"] = "-y @modelcontextprotocol/server-everything",
         }
-    },
-    new() { ClientInfo = new() { Name = "ChatClient", Version = "1.0.0" } });
+    });
 
 // Get all available tools
 Console.WriteLine("Tools available:");

--- a/src/ModelContextProtocol/Client/McpClientFactory.cs
+++ b/src/ModelContextProtocol/Client/McpClientFactory.cs
@@ -19,7 +19,7 @@ public static class McpClientFactory
     /// <summary>Creates default client options to use when no options are supplied.</summary>
     private static McpClientOptions CreateDefaultClientOptions()
     {
-        var asmName = (Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly()).GetName();
+        var asmName = (Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly()).GetName();
         return new()
         {
             ClientInfo = new()

--- a/src/ModelContextProtocol/Client/McpClientFactory.cs
+++ b/src/ModelContextProtocol/Client/McpClientFactory.cs
@@ -13,6 +13,23 @@ namespace ModelContextProtocol.Client;
 /// <summary>Provides factory methods for creating MCP clients.</summary>
 public static class McpClientFactory
 {
+    /// <summary>Default client options to use when none are supplied.</summary>
+    private static readonly McpClientOptions s_defaultClientOptions = CreateDefaultClientOptions();
+
+    /// <summary>Creates default client options to use when no options are supplied.</summary>
+    private static McpClientOptions CreateDefaultClientOptions()
+    {
+        var asmName = (Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly()).GetName();
+        return new()
+        {
+            ClientInfo = new()
+            {
+                Name = asmName.Name ?? "McpClient",
+                Version = asmName.Version?.ToString() ?? "1.0.0",
+            },
+        };
+    }
+
     /// <summary>Creates an <see cref="IMcpClient"/>, connecting it to the specified server.</summary>
     /// <param name="serverConfig">Configuration for the target server to which the client should connect.</param>
     /// <param name="clientOptions">
@@ -36,20 +53,7 @@ public static class McpClientFactory
     {
         Throw.IfNull(serverConfig);
 
-        if (clientOptions is null)
-        {
-            var asmName = (Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly()).GetName();
-
-            clientOptions ??= new()
-            {
-                ClientInfo = new()
-                {
-                    Name = asmName.Name ?? "McpClient",
-                    Version = asmName.Version?.ToString() ?? "1.0.0",
-                },
-            };
-        }
-
+        clientOptions ??= s_defaultClientOptions;
         createTransportFunc ??= CreateTransport;
         
         string endpointName = $"Client ({serverConfig.Id}: {serverConfig.Name})";

--- a/tests/ModelContextProtocol.Tests/Client/McpClientFactoryTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientFactoryTests.cs
@@ -19,13 +19,6 @@ public class McpClientFactoryTests
     {
         await Assert.ThrowsAsync<ArgumentNullException>("serverConfig", () => McpClientFactory.CreateAsync((McpServerConfig)null!, _defaultOptions, cancellationToken: TestContext.Current.CancellationToken));
 
-        await Assert.ThrowsAsync<ArgumentNullException>("clientOptions", () => McpClientFactory.CreateAsync(new McpServerConfig()
-            {
-                Name = "name",
-                Id = "id",
-                TransportType = TransportTypes.StdIo,
-            }, (McpClientOptions)null!, cancellationToken: TestContext.Current.CancellationToken));
-
         await Assert.ThrowsAsync<ArgumentException>("serverConfig", () => McpClientFactory.CreateAsync(new McpServerConfig()
             {
                 Name = "name",
@@ -39,6 +32,28 @@ public class McpClientFactoryTests
                 Id = "id",
                 TransportType = TransportTypes.StdIo,
             }, _defaultOptions, (_, __) => null!, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CreateAsync_NullOptions_EntryAssemblyInferred()
+    {
+        // Arrange
+        var serverConfig = new McpServerConfig
+        {
+            Id = "test-server",
+            Name = "Test Server",
+            TransportType = TransportTypes.StdIo,
+            Location = "/path/to/server",
+        };
+
+        // Act
+        await using var client = await McpClientFactory.CreateAsync(
+            serverConfig,
+            null,
+            (_, __) => new NopTransport(),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(client);
     }
 
     [Fact]


### PR DESCRIPTION
Unless you're specifying capabilities (sampling/rooting) or need a specific client name/version, the client information can be inferred from the assembly, simplifying the getting-started experience.
