### PR TITLE
Add McpLogger/McpLoggerProvider for server logs

### DIFF
--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -14,6 +14,19 @@ namespace ModelContextProtocol.Client;
 public static class McpClientExtensions
 {
     /// <summary>
+    /// A request from the client to the server, to enable or adjust logging.
+    /// </summary>
+    /// <param name="client">The client.</param>
+    /// <param name="loggingLevel">The logging level severity to set.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns></returns>
+    public static Task SetLogLevelAsync(this IMcpClient client, LoggingLevel loggingLevel, CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(client);
+        return client.SendNotificationAsync("logging/setLevel", new SetLoggingLevelRequestParams { Level = loggingLevel }, cancellationToken);
+    }
+
+    /// <summary>
     /// Sends a notification to the server with parameters.
     /// </summary>
     /// <param name="client">The client.</param>

--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -23,7 +23,7 @@ public static class McpClientExtensions
     public static Task SetLogLevelAsync(this IMcpClient client, LoggingLevel loggingLevel, CancellationToken cancellationToken = default)
     {
         Throw.IfNull(client);
-        return client.SendNotificationAsync("logging/setLevel", new SetLoggingLevelRequestParams { Level = loggingLevel }, cancellationToken);
+        return client.SendNotificationAsync("logging/setLevel", new SetLevelRequestParams { Level = loggingLevel }, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModelContextProtocol/Logging/McpLogger.cs
+++ b/src/ModelContextProtocol/Logging/McpLogger.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Server;
+using System.Text.Json;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModelContextProtocol.Logging;
+
+internal class McpLogger(string categoryName, IMcpServer mcpServer) : ILogger
+{
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        => default;
+
+    public bool IsEnabled(LogLevel logLevel)
+        => logLevel.ToLoggingLevel() <= mcpServer.LoggingLevel;
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "<Pending>")]
+    public async void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+            return;
+
+        var message = formatter(state, exception);
+        if (string.IsNullOrEmpty(message))
+            return;
+
+        // Use JsonSerializer to properly escape the string for JSON and turn it into a JsonElement
+        var json = JsonSerializer.Serialize(message);
+        var element = JsonSerializer.Deserialize<JsonElement>(json);
+
+        await mcpServer.SendLogNotificationAsync(new LoggingMessageNotificationParams
+        {
+            Data = element,
+            Level = logLevel.ToLoggingLevel(),
+            Logger = categoryName
+        });
+    }
+}

--- a/src/ModelContextProtocol/Logging/McpLoggerProvider.cs
+++ b/src/ModelContextProtocol/Logging/McpLoggerProvider.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+using System;
+using System.Collections.Concurrent;
+
+namespace ModelContextProtocol.Logging
+{
+    /// <summary>
+    /// Provides logging over MCP's notifications to send log messages to the client
+    /// </summary>
+    /// <param name="mcpServer">MCP Server.</param>
+    public class McpLoggerProvider(IMcpServer mcpServer) : ILoggerProvider
+    {
+        /// <summary>
+        /// Creates a new instance of an MCP logger
+        /// </summary>
+        /// <param name="categoryName">Logger Category Name</param>
+        /// <returns>New Logger instance</returns>
+        public ILogger CreateLogger(string categoryName)
+            => new McpLogger(categoryName, mcpServer);
+
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/ModelContextProtocol/Logging/McpLoggingLevelExtensions.cs
+++ b/src/ModelContextProtocol/Logging/McpLoggingLevelExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol.Types;
+
+namespace ModelContextProtocol.Logging;
+
+    internal static class McpLoggingLevelExtensions
+{
+    public static LogLevel ToLogLevel(this LoggingLevel level)
+        => level switch
+        {
+            LoggingLevel.Emergency or LoggingLevel.Alert or LoggingLevel.Critical => LogLevel.Critical,
+            LoggingLevel.Error => LogLevel.Error,
+            LoggingLevel.Warning => LogLevel.Warning,
+            LoggingLevel.Notice or LoggingLevel.Info => LogLevel.Information,
+            LoggingLevel.Debug => LogLevel.Debug,
+            _ => LogLevel.None,
+        };
+
+    public static LoggingLevel ToLoggingLevel(this LogLevel level)
+        => level switch
+        {
+            LogLevel.Critical => LoggingLevel.Critical,
+            LogLevel.Error => LoggingLevel.Error,
+            LogLevel.Warning => LoggingLevel.Warning,
+            LogLevel.Information => LoggingLevel.Info,
+            LogLevel.Debug or LogLevel.Trace => LoggingLevel.Debug,
+            _ => LoggingLevel.Info,
+        };
+}

--- a/src/ModelContextProtocol/Server/IMcpServer.cs
+++ b/src/ModelContextProtocol/Server/IMcpServer.cs
@@ -29,6 +29,11 @@ public interface IMcpServer : IAsyncDisposable
     IServiceProvider? ServiceProvider { get; }
 
     /// <summary>
+    /// Current Logging level
+    /// </summary>
+    LoggingLevel LoggingLevel { get; }
+
+    /// <summary>
     /// Adds a handler for client notifications of a specific method.
     /// </summary>
     /// <param name="method">The notification method to handle.</param>

--- a/src/ModelContextProtocol/Server/McpServerExtensions.cs
+++ b/src/ModelContextProtocol/Server/McpServerExtensions.cs
@@ -11,6 +11,22 @@ namespace ModelContextProtocol.Server;
 public static class McpServerExtensions
 {
     /// <summary>
+    /// Sends a logging message notification to the client.
+    /// </summary>
+    /// <param name="server">The server instance that will handle the log notification request.</param>
+    /// <param name="loggingMessageNotification">Contains the details of the log message to be sent.</param>
+    /// <param name="cancellationToken">Allows the operation to be canceled if needed.</param>
+    /// <returns>Returns a task representing the asynchronous operation.</returns>
+    public static Task SendLogNotificationAsync(this IMcpServer server, LoggingMessageNotificationParams loggingMessageNotification, CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(server);
+        Throw.IfNull(loggingMessageNotification);
+        return server.SendRequestAsync<EmptyResult>(
+            new JsonRpcRequest { Method = "notifications/message", Params = loggingMessageNotification },
+            cancellationToken);
+    }
+
+    /// <summary>
     /// Requests to sample an LLM via the client.
     /// </summary>
     /// <exception cref="ArgumentNullException"><paramref name="server"/> is <see langword="null"/>.</exception>


### PR DESCRIPTION
Adds a new ILoggerProvider to the McpServer's logging factory which can then relay server logs which occur within the System.Extensions.Logging pattern back to the client via a notification message as per the spec.

## Motivation and Context
I started writing this code before I saw #53 was merged and now see #59 open, so thought I'd push this code up anyway even if it's ultimately just throwaway code.

## How Has This Been Tested?
Not yet

## Breaking Changes
Logging from the server now will all go back to the client, so it is more a behavioural change, but could be unexpected noise.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed


