### PR TITLE
Add XunitLoggerProvider

### DIFF
--- a/tests/ModelContextProtocol.TestSseServer/Program.cs
+++ b/tests/ModelContextProtocol.TestSseServer/Program.cs
@@ -10,9 +10,10 @@ namespace ModelContextProtocol.TestSseServer;
 
 public class Program
 {
-    private static ILoggerFactory CreateLoggerFactory()
+    private static ILoggerFactory CreateLoggerFactory() => LoggerFactory.Create(ConfigureSerilog);
+
+    public static void ConfigureSerilog(ILoggingBuilder loggingBuilder)
     {
-        // Use serilog
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Verbose() // Capture all log levels
             .WriteTo.File(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "logs", "TestServer_.log"),
@@ -21,15 +22,12 @@ public class Program
             .CreateLogger();
 
         var logsPath = Path.Combine(AppContext.BaseDirectory, "testserver.log");
-        return LoggerFactory.Create(builder =>
-        {
-            builder.AddSerilog();
-        });
+        loggingBuilder.AddSerilog();
     }
 
     public static Task Main(string[] args) => MainAsync(args);
 
-    public static async Task MainAsync(string[] args, CancellationToken cancellationToken = default)
+    public static async Task MainAsync(string[] args, ILoggerFactory? loggerFactory = null, CancellationToken cancellationToken = default)
     {
         Console.WriteLine("Starting server...");
 
@@ -385,7 +383,7 @@ public class Program
             },
         };
 
-        using var loggerFactory = CreateLoggerFactory();
+        loggerFactory ??= CreateLoggerFactory();
         server = McpServerFactory.Create(new HttpListenerSseServerTransport("TestServer", 3001, loggerFactory), options, loggerFactory);
 
         Console.WriteLine("Server initialized.");

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTestFixture.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTestFixture.cs
@@ -5,9 +5,10 @@ using Microsoft.Extensions.Logging;
 
 namespace ModelContextProtocol.Tests;
 
-public class ClientIntegrationTestFixture : IDisposable
+public class ClientIntegrationTestFixture
 {
-    public ILoggerFactory LoggerFactory { get; }
+    private ILoggerFactory? _loggerFactory;
+
     public McpClientOptions DefaultOptions { get; }
     public McpServerConfig EverythingServerConfig { get; }
     public McpServerConfig TestServerConfig { get; }
@@ -16,10 +17,6 @@ public class ClientIntegrationTestFixture : IDisposable
 
     public ClientIntegrationTestFixture()
     {
-        LoggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
-            builder.AddConsole()
-            .SetMinimumLevel(LogLevel.Debug));
-
         DefaultOptions = new()
         {
             ClientInfo = new() { Name = "IntegrationTestClient", Version = "1.0.0" },
@@ -56,17 +53,16 @@ public class ClientIntegrationTestFixture : IDisposable
         }
     }
 
+    public void Initialize(ILoggerFactory loggerFactory)
+    {
+        _loggerFactory = loggerFactory;
+    }
+
     public Task<IMcpClient> CreateClientAsync(string clientId, McpClientOptions? clientOptions = null) =>
         McpClientFactory.CreateAsync(clientId switch
         {
             "everything" => EverythingServerConfig,
             "test_server" => TestServerConfig,
             _ => throw new ArgumentException($"Unknown client ID: {clientId}")
-        }, clientOptions ?? DefaultOptions, loggerFactory: LoggerFactory);
-
-    public void Dispose()
-    {
-        LoggerFactory?.Dispose();
-        GC.SuppressFinalize(this);
-    }
+        }, clientOptions ?? DefaultOptions, loggerFactory: _loggerFactory);
 }

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -6,6 +6,7 @@ using ModelContextProtocol.Protocol.Messages;
 using System.Text.Json;
 using ModelContextProtocol.Configuration;
 using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Tests.Utils;
 using Xunit.Sdk;
 using System.Text.Encodings.Web;
 using System.Text.Json.Serialization.Metadata;
@@ -13,15 +14,17 @@ using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Tests;
 
-public class ClientIntegrationTests : IClassFixture<ClientIntegrationTestFixture>
+public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegrationTestFixture>
 {
     private static readonly string? s_openAIKey = Environment.GetEnvironmentVariable("AI:OpenAI:ApiKey")!;
 
     private readonly ClientIntegrationTestFixture _fixture;
 
-    public ClientIntegrationTests(ClientIntegrationTestFixture fixture)
+    public ClientIntegrationTests(ClientIntegrationTestFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
     {
         _fixture = fixture;
+        _fixture.Initialize(LoggerFactory);
     }
 
     public static IEnumerable<object[]> GetClients() =>
@@ -474,7 +477,7 @@ public class ClientIntegrationTests : IClassFixture<ClientIntegrationTestFixture
         await using var client = await McpClientFactory.CreateAsync(
             serverConfig, 
             clientOptions, 
-            loggerFactory: _fixture.LoggerFactory, 
+            loggerFactory: LoggerFactory, 
             cancellationToken: TestContext.Current.CancellationToken);
 
         // act

--- a/tests/ModelContextProtocol.Tests/SseServerIntegrationTestFixture.cs
+++ b/tests/ModelContextProtocol.Tests/SseServerIntegrationTestFixture.cs
@@ -2,23 +2,29 @@
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Configuration;
 using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Test.Utils;
+using ModelContextProtocol.TestSseServer;
 
 namespace ModelContextProtocol.Tests;
 
 public class SseServerIntegrationTestFixture : IAsyncDisposable
 {
-    private readonly CancellationTokenSource _stopCts = new();
     private readonly Task _serverTask;
+    private readonly CancellationTokenSource _stopCts = new();
+    private DelegatingTestOutputHelper _delegatingTestOutputHelper = new();
 
-    public ILoggerFactory LoggerFactory { get; }
+    private ILoggerFactory _redirectingLoggerFactory;
+
     public McpClientOptions DefaultOptions { get; }
     public McpServerConfig DefaultConfig { get; }
 
     public SseServerIntegrationTestFixture()
     {
-        LoggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
-            builder.AddConsole()
-            .SetMinimumLevel(LogLevel.Debug));
+        _redirectingLoggerFactory = LoggerFactory.Create(builder =>
+        {
+            Program.ConfigureSerilog(builder);
+            builder.AddProvider(new XunitLoggerProvider(_delegatingTestOutputHelper));
+        });
 
         DefaultOptions = new()
         {
@@ -34,12 +40,17 @@ public class SseServerIntegrationTestFixture : IAsyncDisposable
             Location = "http://localhost:3001/sse"
         };
 
-        _serverTask = TestSseServer.Program.MainAsync([], _stopCts.Token);
+        _serverTask = Program.MainAsync([], _redirectingLoggerFactory, _stopCts.Token);
+    }
+
+    public void Initialize(ITestOutputHelper output)
+    {
+        _delegatingTestOutputHelper.CurrentTestOutputHelper = output;
     }
 
     public async ValueTask DisposeAsync()
     {
-        LoggerFactory.Dispose();
+        _redirectingLoggerFactory.Dispose();
         _stopCts.Cancel();
         try
         {
@@ -49,5 +60,17 @@ public class SseServerIntegrationTestFixture : IAsyncDisposable
         {
         }
         _stopCts.Dispose();
+    }
+
+    private class DelegatingTestOutputHelper() : ITestOutputHelper
+    {
+        public ITestOutputHelper? CurrentTestOutputHelper { get; set; }
+
+        public string Output => CurrentTestOutputHelper?.Output ?? string.Empty;
+
+        public void Write(string message) => CurrentTestOutputHelper?.Write(message);
+        public void Write(string format, params object[] args) => CurrentTestOutputHelper?.Write(format, args);
+        public void WriteLine(string message) => CurrentTestOutputHelper?.WriteLine(message);
+        public void WriteLine(string format, params object[] args) => CurrentTestOutputHelper?.WriteLine(format, args);
     }
 }

--- a/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
@@ -1,15 +1,18 @@
 ﻿using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Tests.Utils;
 
 namespace ModelContextProtocol.Tests;
 
-public class SseServerIntegrationTests : IClassFixture<SseServerIntegrationTestFixture>
+public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerIntegrationTestFixture>
 {
     private readonly SseServerIntegrationTestFixture _fixture;
 
-    public SseServerIntegrationTests(SseServerIntegrationTestFixture fixture)
+    public SseServerIntegrationTests(SseServerIntegrationTestFixture fixture, ITestOutputHelper output)
+        : base(output)
     {
         _fixture = fixture;
+        _fixture.Initialize(output);
     }
 
     private Task<IMcpClient> GetClientAsync(McpClientOptions? options = null)
@@ -17,7 +20,7 @@ public class SseServerIntegrationTests : IClassFixture<SseServerIntegrationTestF
         return McpClientFactory.CreateAsync(
             _fixture.DefaultConfig,
             options ?? _fixture.DefaultOptions,
-            loggerFactory: _fixture.LoggerFactory);
+            loggerFactory: LoggerFactory);
     }
 
     [Fact]

--- a/tests/ModelContextProtocol.Tests/Utils/LoggedTest.cs
+++ b/tests/ModelContextProtocol.Tests/Utils/LoggedTest.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Test.Utils;
+
+namespace ModelContextProtocol.Tests.Utils;
+
+public class LoggedTest(ITestOutputHelper testOutputHelper)
+{
+    public ITestOutputHelper TestOutputHelper { get; } = testOutputHelper;
+    public ILoggerFactory LoggerFactory { get; } = CreateLoggerFactory(testOutputHelper);
+
+    private static ILoggerFactory CreateLoggerFactory(ITestOutputHelper testOutputHelper)
+    {
+        return Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
+        {
+            builder.AddProvider(new XunitLoggerProvider(testOutputHelper));
+        });
+    }
+}

--- a/tests/ModelContextProtocol.Tests/Utils/XunitLoggerProvider.cs
+++ b/tests/ModelContextProtocol.Tests/Utils/XunitLoggerProvider.cs
@@ -1,0 +1,52 @@
+﻿using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace ModelContextProtocol.Test.Utils;
+
+public class XunitLoggerProvider(ITestOutputHelper output) : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new XunitLogger(output, categoryName);
+    }
+
+    public void Dispose()
+    {
+    }
+
+    private class XunitLogger(ITestOutputHelper output, string category) : ILogger
+    {
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var sb = new StringBuilder();
+
+            var timestamp = DateTimeOffset.UtcNow.ToString("s", CultureInfo.InvariantCulture);
+            var prefix = $"| [{timestamp}] {category} {logLevel}: ";
+            var lines = formatter(state, exception);
+            sb.Append(prefix);
+            sb.Append(lines);
+
+            if (exception is not null)
+            {
+                sb.AppendLine();
+                sb.Append(exception.ToString());
+            }
+
+            output.WriteLine(sb.ToString());
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
+            => new NoopDisposable();
+
+        private sealed class NoopDisposable : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
So far, I'm only using the XunitLoggerProvider in SseServerIntegrationTests.cs and ClientIntegrationTests.cs since those previously logged to the console which can be hard to see when using the xunit test runner. After this change, you can easily see logs in the test runner like this.

![Logs in VS Test Explorer Window](https://github.com/user-attachments/assets/2b6f405e-8e8b-46fd-a3dd-29713743f090)

We can probably integrate this in more places, and that should be easier to do going forward with the XunitLoggerProvider  and LoggedTest base class.