### PR TITLE
Add links to API docs from README.md

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,5 @@
+name: Publish Docs
+
 on:
   release:
     types: [published]

--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
 
 [![NuGet preview version](https://img.shields.io/nuget/vpre/ModelContextProtocol.svg)](https://www.nuget.org/packages/ModelContextProtocol/absoluteLatest)
 
-The official C# SDK for the [Model Context Protocol](https://modelcontextprotocol.io/), enabling .NET applications, services, and libraries to implement and interact with MCP clients and servers.
+The official C# SDK for the [Model Context Protocol](https://modelcontextprotocol.io/), enabling .NET applications, services, and libraries to implement and interact with MCP clients and servers. Please visit our [API documentation](https://modelcontextprotocol.github.io/csharp-sdk/api/ModelContextProtocol.html) for more details on available functionality.
 
 > [!NOTE]
 > This repo is still in preview, breaking changes can be introduced without prior notice.


### PR DESCRIPTION
Following up on #86 this adds a link to the generated API docs.