### PR TITLE
Adding a base class for request params that exposes the progressToken

### DIFF
--- a/src/ModelContextProtocol/Protocol/Types/CallToolRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/CallToolRequestParams.cs
@@ -4,7 +4,7 @@
 /// Used by the client to invoke a tool provided by the server.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public class CallToolRequestParams
+public class CallToolRequestParams : RequestParams
 {
     /// <summary>
     /// Tool name.

--- a/src/ModelContextProtocol/Protocol/Types/CompleteRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/CompleteRequestParams.cs
@@ -4,7 +4,7 @@
 /// A request from the client to the server, to ask for completion options.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public class CompleteRequestParams
+public class CompleteRequestParams : RequestParams
 {
     /// <summary>
     /// The reference's information

--- a/src/ModelContextProtocol/Protocol/Types/CreateMessageRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/CreateMessageRequestParams.cs
@@ -9,7 +9,7 @@
 /// clients have full discretion over model selection and should inform users before sampling.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public class CreateMessageRequestParams
+public class CreateMessageRequestParams : RequestParams
 {
     /// <summary>
     /// A request to include context from one or more MCP servers (including the caller), to be attached to the prompt. The client MAY ignore this request.

--- a/src/ModelContextProtocol/Protocol/Types/GetPromptRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/GetPromptRequestParams.cs
@@ -4,7 +4,7 @@
 /// Used by the client to get a prompt provided by the server.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public class GetPromptRequestParams
+public class GetPromptRequestParams : RequestParams
 {
     /// <summary>
     /// he name of the prompt or prompt template.

--- a/src/ModelContextProtocol/Protocol/Types/InitializeRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/InitializeRequestParams.cs
@@ -6,7 +6,7 @@ namespace ModelContextProtocol.Protocol.Types;
 /// Parameters for an initialization request sent to the server.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public record InitializeRequestParams
+public class InitializeRequestParams : RequestParams
 {
     /// <summary>
     /// The version of the Model Context Protocol that the client wants to use.

--- a/src/ModelContextProtocol/Protocol/Types/ReadResourceRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ReadResourceRequestParams.cs
@@ -4,7 +4,7 @@
 /// Sent from the client to the server, to read a specific resource URI.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public class ReadResourceRequestParams
+public class ReadResourceRequestParams : RequestParams
 {
     /// <summary>
     /// The URI of the resource to read. The URI can use any protocol; it is up to the server how to interpret it.

--- a/src/ModelContextProtocol/Protocol/Types/RequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/RequestParams.cs
@@ -1,6 +1,3 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;

--- a/src/ModelContextProtocol/Protocol/Types/RequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/RequestParams.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ModelContextProtocol.Protocol.Types;
+
+/// <summary>
+/// Base class for all request parameters.
+/// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json#L771-L806">See the schema for details</see>
+/// </summary>
+public abstract class RequestParams
+{
+    /// <summary>
+    /// Metadata related to the tool invocation.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("_meta")]
+    public RequestParamsMetadata? Meta { get; init; }
+}

--- a/src/ModelContextProtocol/Protocol/Types/RequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/RequestParams.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
+
 namespace ModelContextProtocol.Protocol.Types;
 
 /// <summary>
@@ -12,6 +14,6 @@ public abstract class RequestParams
     /// <summary>
     /// Metadata related to the tool invocation.
     /// </summary>
-    [System.Text.Json.Serialization.JsonPropertyName("_meta")]
+    [JsonPropertyName("_meta")]
     public RequestParamsMetadata? Meta { get; init; }
 }

--- a/src/ModelContextProtocol/Protocol/Types/RequestParamsMetadata.cs
+++ b/src/ModelContextProtocol/Protocol/Types/RequestParamsMetadata.cs
@@ -1,6 +1,3 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;

--- a/src/ModelContextProtocol/Protocol/Types/RequestParamsMetadata.cs
+++ b/src/ModelContextProtocol/Protocol/Types/RequestParamsMetadata.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
+
 namespace ModelContextProtocol.Protocol.Types;
 
 /// <summary>
@@ -11,6 +13,6 @@ public class RequestParamsMetadata
     /// <summary>
     /// If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
     /// </summary>
-    [System.Text.Json.Serialization.JsonPropertyName("progressToken")]
+    [JsonPropertyName("progressToken")]
     public object ProgressToken { get; set; } = default!;
 }

--- a/src/ModelContextProtocol/Protocol/Types/RequestParamsMetadata.cs
+++ b/src/ModelContextProtocol/Protocol/Types/RequestParamsMetadata.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ModelContextProtocol.Protocol.Types;
+
+/// <summary>
+/// Metadata related to the request.
+/// </summary>
+public class RequestParamsMetadata
+{
+    /// <summary>
+    /// If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("progressToken")]
+    public object ProgressToken { get; set; } = default!;
+}

--- a/src/ModelContextProtocol/Protocol/Types/SetLevelRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/SetLevelRequestParams.cs
@@ -6,7 +6,7 @@ namespace ModelContextProtocol.Protocol.Types;
 /// A request from the client to the server, to enable or adjust logging.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public class SetLevelRequestParams
+public class SetLevelRequestParams : RequestParams
 {
     /// <summary>
     /// The level of logging that the client wants to receive from the server. 

--- a/src/ModelContextProtocol/Protocol/Types/SubscribeRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/SubscribeRequestParams.cs
@@ -4,7 +4,7 @@
 /// Sent from the client to request updated notifications from the server whenever a particular primitive changes.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public class SubscribeRequestParams
+public class SubscribeRequestParams : RequestParams
 {
     /// <summary>
     /// The URI of the resource to subscribe to. The URI can use any protocol; it is up to the server how to interpret it.

--- a/src/ModelContextProtocol/Protocol/Types/UnsubscribeRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/UnsubscribeRequestParams.cs
@@ -4,7 +4,7 @@
 /// Sent from the client to request not receiving updated notifications from the server whenever a primitive resource changes.
 /// <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json">See the schema for details</see>
 /// </summary>
-public class UnsubscribeRequestParams
+public class UnsubscribeRequestParams : RequestParams
 {
     /// <summary>
     /// The URI of the resource to unsubscribe fro. The URI can use any protocol; it is up to the server how to interpret it.


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
This aligns more with the type structure see in the other SDK's (eg: https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/types.py#L41) while also ensuring they are exposing the JSONRPCRequest (https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json#L771-L806) data.

Storing progressToken as an object as it could be an int or string (per https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json#L1268-L1274).

Fixes #67

## How Has This Been Tested?
I'm using this to implement the "everything server" (not in this branch).

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
