### PR TITLE
complete fix for SampleLlmTool discovery

### DIFF
--- a/samples/TestServerWithHosting/Tools/SampleLlmTool.cs
+++ b/samples/TestServerWithHosting/Tools/SampleLlmTool.cs
@@ -8,23 +8,17 @@ namespace TestServerWithHosting.Tools;
 /// This tool uses depenency injection and async method
 /// </summary>
 [McpServerToolType]
-public class SampleLlmTool
+public static class SampleLlmTool
 {
-    private readonly IMcpServer _server;
-
-    public SampleLlmTool(IMcpServer server)
-    {
-        _server = server ?? throw new ArgumentNullException(nameof(server));
-    }
-
     [McpServerTool("sampleLLM"), Description("Samples from an LLM using MCP's sampling feature")]
-    public async Task<string> SampleLLM(
+    public static async Task<string> SampleLLM(
+        IMcpServer thisServer,
         [Description("The prompt to send to the LLM")] string prompt,
         [Description("Maximum number of tokens to generate")] int maxTokens,
         CancellationToken cancellationToken)
     {
         var samplingParams = CreateRequestSamplingParams(prompt ?? string.Empty, "sampleLLM", maxTokens);
-        var sampleResult = await _server.RequestSamplingAsync(samplingParams, cancellationToken);
+        var sampleResult = await thisServer.RequestSamplingAsync(samplingParams, cancellationToken);
 
         return $"LLM sampling result: {sampleResult.Content.Text}";
     }


### PR DESCRIPTION

<!-- Provide a brief summary of your changes -->
fix the sample TestServerWithHosting according to AspNetCoreSseServer and below issues
https://github.com/modelcontextprotocol/csharp-sdk/issues/80
https://github.com/modelcontextprotocol/csharp-sdk/issues/79
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
SampleLlmTool can not be found in TestServerWithHosting 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Run ChatWithTools with command "TestServerWithHosting .exe" ,show two tools besides SampleLlmTool 
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
no
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
