### PR TITLE
Configurable messages endpoint for SSE transport

### DIFF
--- a/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
@@ -1,4 +1,5 @@
-﻿using System.Buffers;
+﻿using System.Text;
+using System.Buffers;
 using System.Net.ServerSentEvents;
 using System.Text.Json;
 using System.Threading.Channels;
@@ -11,7 +12,8 @@ namespace ModelContextProtocol.Protocol.Transport;
 /// Implements the MCP SSE server transport protocol using the SSE response <see cref="Stream"/>.
 /// </summary>
 /// <param name="sseResponseStream">The stream to write the SSE response body to.</param>
-public sealed class SseResponseStreamTransport(Stream sseResponseStream) : ITransport
+/// <param name="messageEndpoint">The endpoint to send JSON-RPC messages to. Defaults to "/message".</param> 
+public sealed class SseResponseStreamTransport(Stream sseResponseStream, string messageEndpoint = "/message") : ITransport
 {
     private readonly Channel<IJsonRpcMessage> _incomingChannel = CreateSingleItemChannel<IJsonRpcMessage>();
     private readonly Channel<SseItem<IJsonRpcMessage?>> _outgoingSseChannel = CreateSingleItemChannel<SseItem<IJsonRpcMessage?>>();
@@ -34,7 +36,7 @@ public sealed class SseResponseStreamTransport(Stream sseResponseStream) : ITran
         {
             if (item.EventType == "endpoint")
             {
-                writer.Write("/message"u8);
+                writer.Write(Encoding.UTF8.GetBytes(messageEndpoint));
                 return;
             }
 


### PR DESCRIPTION
Add a configurable value for messages endpoint in `SseResponseStreamTransport`.

## Motivation and Context
The SseResponseStreamTransport has a hard-coded `/messages` endpoint but the MCP spec states that this should be set by the implementation. 
```
When a client connects, the server MUST send an endpoint event
containing a URI for the client to use for sending messages.
All subsequent client messages MUST be sent as HTTP POST requests to this endpoint.
```
https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/

## How Has This Been Tested?
This was tested in the sample application.

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

