### PR TITLE
Use different logger categories for client and server in McpJsonRpcEndpoint

### DIFF
--- a/src/ModelContextProtocol/Client/McpClient.cs
+++ b/src/ModelContextProtocol/Client/McpClient.cs
@@ -27,7 +27,7 @@ internal sealed class McpClient : McpJsonRpcEndpoint, IMcpClient
     /// <param name="serverConfig">The server configuration.</param>
     /// <param name="loggerFactory">The logger factory.</param>
     public McpClient(IClientTransport transport, McpClientOptions options, McpServerConfig serverConfig, ILoggerFactory? loggerFactory)
-        : base(transport, loggerFactory?.CreateLogger<McpClient>())
+        : base(transport, loggerFactory)
     {
         _options = options;
         _clientTransport = transport;

--- a/src/ModelContextProtocol/Client/McpClient.cs
+++ b/src/ModelContextProtocol/Client/McpClient.cs
@@ -15,7 +15,6 @@ namespace ModelContextProtocol.Client;
 internal sealed class McpClient : McpJsonRpcEndpoint, IMcpClient
 {
     private readonly McpClientOptions _options;
-    private readonly ILogger _logger;
     private readonly IClientTransport _clientTransport;
 
     private volatile bool _isInitializing;
@@ -28,10 +27,9 @@ internal sealed class McpClient : McpJsonRpcEndpoint, IMcpClient
     /// <param name="serverConfig">The server configuration.</param>
     /// <param name="loggerFactory">The logger factory.</param>
     public McpClient(IClientTransport transport, McpClientOptions options, McpServerConfig serverConfig, ILoggerFactory? loggerFactory)
-        : base(transport, loggerFactory)
+        : base(transport, loggerFactory?.CreateLogger<McpClient>())
     {
         _options = options;
-        _logger = (ILogger?)loggerFactory?.CreateLogger<McpClient>() ?? NullLogger.Instance;
         _clientTransport = transport;
 
         EndpointName = $"Client ({serverConfig.Id}: {serverConfig.Name})";

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -14,7 +14,6 @@ namespace ModelContextProtocol.Server;
 internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
 {
     private readonly IServerTransport? _serverTransport;
-    private readonly ILogger _logger;
     private readonly string _serverDescription;
     private volatile bool _isInitializing;
 
@@ -28,12 +27,11 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
     /// <param name="serviceProvider">Optional service provider to use for dependency injection</param>
     /// <exception cref="McpServerException"></exception>
     public McpServer(ITransport transport, McpServerOptions options, ILoggerFactory? loggerFactory, IServiceProvider? serviceProvider)
-        : base(transport, loggerFactory)
+        : base(transport, loggerFactory?.CreateLogger<McpServer>())
     {
         Throw.IfNull(options);
 
         _serverTransport = transport as IServerTransport;
-        _logger = (ILogger?)loggerFactory?.CreateLogger<McpServer>() ?? NullLogger.Instance;
         ServerInstructions = options.ServerInstructions;
         Services = serviceProvider;
         _serverDescription = $"{options.ServerInfo.Name} {options.ServerInfo.Version}";

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -27,7 +27,7 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
     /// <param name="serviceProvider">Optional service provider to use for dependency injection</param>
     /// <exception cref="McpServerException"></exception>
     public McpServer(ITransport transport, McpServerOptions options, ILoggerFactory? loggerFactory, IServiceProvider? serviceProvider)
-        : base(transport, loggerFactory?.CreateLogger<McpServer>())
+        : base(transport, loggerFactory)
     {
         Throw.IfNull(options);
 

--- a/src/ModelContextProtocol/Shared/McpJsonRpcEndpoint.cs
+++ b/src/ModelContextProtocol/Shared/McpJsonRpcEndpoint.cs
@@ -36,8 +36,8 @@ internal abstract class McpJsonRpcEndpoint : IAsyncDisposable
     /// Initializes a new instance of the <see cref="McpJsonRpcEndpoint"/> class.
     /// </summary>
     /// <param name="transport">An MCP transport implementation.</param>
-    /// <param name="logger">The logger.</param>
-    protected McpJsonRpcEndpoint(ITransport transport, ILogger? logger = null)
+    /// <param name="loggerFactory">The logger factory.</param>
+    protected McpJsonRpcEndpoint(ITransport transport, ILoggerFactory? loggerFactory = null)
     {
         Throw.IfNull(transport);
 
@@ -46,7 +46,7 @@ internal abstract class McpJsonRpcEndpoint : IAsyncDisposable
         _notificationHandlers = new();
         _nextRequestId = 1;
         _jsonOptions = McpJsonUtilities.DefaultOptions;
-        _logger = logger ?? NullLogger.Instance;
+        _logger = loggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance;
     }
 
     /// <summary>

--- a/src/ModelContextProtocol/Shared/McpJsonRpcEndpoint.cs
+++ b/src/ModelContextProtocol/Shared/McpJsonRpcEndpoint.cs
@@ -28,26 +28,25 @@ internal abstract class McpJsonRpcEndpoint : IAsyncDisposable
     private readonly Dictionary<string, Func<JsonRpcRequest, CancellationToken, Task<object?>>> _requestHandlers = [];
     private int _nextRequestId;
     private readonly JsonSerializerOptions _jsonOptions;
-    private readonly ILogger _logger;
     private bool _isDisposed;
+
+    protected readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="McpJsonRpcEndpoint"/> class.
     /// </summary>
     /// <param name="transport">An MCP transport implementation.</param>
-    /// <param name="loggerFactory">The logger factory.</param>
-    protected McpJsonRpcEndpoint(ITransport transport, ILoggerFactory? loggerFactory = null)
+    /// <param name="logger">The logger.</param>
+    protected McpJsonRpcEndpoint(ITransport transport, ILogger? logger = null)
     {
         Throw.IfNull(transport);
-
-        loggerFactory ??= NullLoggerFactory.Instance;
 
         _transport = transport;
         _pendingRequests = new();
         _notificationHandlers = new();
         _nextRequestId = 1;
         _jsonOptions = McpJsonUtilities.DefaultOptions;
-        _logger = (ILogger?)loggerFactory?.CreateLogger<McpClient>() ?? NullLogger.Instance;
+        _logger = logger ?? NullLogger.Instance;
     }
 
     /// <summary>


### PR DESCRIPTION
Seeing ModelContextProtocol.Server.McpClient logs in the AspNetCoreSseServer sample is weird. This would get even more confusing if the project actually did include the client.

I know we had a discussion about how it's better to take an ILoggerFactory than an ILogger in public APIs, and I still generally think that true. Fortunately, these APIs are not currently public.