### PR TITLE
Adding support for returning collections from tools

### DIFF
--- a/src/ModelContextProtocol/AIContentExtensions.cs
+++ b/src/ModelContextProtocol/AIContentExtensions.cs
@@ -104,13 +104,7 @@ public static class AIContentExtensions
 #endif
     }
 
-    /// <summary>
-    /// Converts different types of <see cref="AIContent"/> into a standardized <see cref="Content"/> object with specific properties based on the
-    /// content type.
-    /// </summary>
-    /// <param name="content"></param>
-    /// <returns>A <see cref="Content"/> object that encapsulates the relevant properties derived from the input content.</returns>
-    public static Content ToContent(this AIContent content) =>
+    internal static Content ToContent(this AIContent content) =>
         content switch
         {
             TextContent textContent => new()
@@ -123,9 +117,9 @@ public static class AIContentExtensions
                 Data = dataContent.GetBase64Data(),
                 MimeType = dataContent.MediaType,
                 Type =
-                dataContent.HasTopLevelMediaType("image") ? "image" :
-                dataContent.HasTopLevelMediaType("audio") ? "audio" :
-                "resource",
+                    dataContent.HasTopLevelMediaType("image") ? "image" :
+                    dataContent.HasTopLevelMediaType("audio") ? "audio" :
+                    "resource",
             },
             _ => new()
             {

--- a/src/ModelContextProtocol/AIContentExtensions.cs
+++ b/src/ModelContextProtocol/AIContentExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.Extensions.AI;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Utils;
+using ModelContextProtocol.Utils.Json;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 
 namespace ModelContextProtocol;
 
@@ -101,4 +103,34 @@ public static class AIContentExtensions
             Convert.ToBase64String(dataContent.Data.ToArray());
 #endif
     }
+
+    /// <summary>
+    /// Converts different types of <see cref="AIContent"/> into a standardized <see cref="Content"/> object with specific properties based on the
+    /// content type.
+    /// </summary>
+    /// <param name="content"></param>
+    /// <returns>A <see cref="Content"/> object that encapsulates the relevant properties derived from the input content.</returns>
+    public static Content ToContent(this AIContent content) =>
+        content switch
+        {
+            TextContent textContent => new()
+            {
+                Text = textContent.Text,
+                Type = "text",
+            },
+            DataContent dataContent => new()
+            {
+                Data = dataContent.GetBase64Data(),
+                MimeType = dataContent.MediaType,
+                Type =
+                dataContent.HasTopLevelMediaType("image") ? "image" :
+                dataContent.HasTopLevelMediaType("audio") ? "audio" :
+                "resource",
+            },
+            _ => new()
+            {
+                Text = JsonSerializer.Serialize(content, McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(object))),
+                Type = "text",
+            }
+        };
 }

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -197,6 +197,10 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
 
         return result switch
         {
+            AIContent aiContent => new()
+            {
+                Content = [aiContent.ToContent()]
+            },
             null => new()
             {
                 Content = []
@@ -205,15 +209,11 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
             {
                 Content = [new() { Text = text, Type = "text" }]
             },
-            TextContent textContent => new()
+            Content content => new()
             {
-                Content = [textContent.ToContent()]
+                Content = [content]
             },
-            DataContent dataContent => new()
-            {
-                Content = [dataContent.ToContent()]
-            },
-            string[] texts => new()
+            IEnumerable<string> texts => new()
             {
                 Content = [.. texts.Select(x => new Content() { Type = "text", Text = x ?? string.Empty })]
             },

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -207,35 +207,23 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
             },
             TextContent textContent => new()
             {
-                Content = [new() { Text = textContent.Text, Type = "text" }]
+                Content = [textContent.ToContent()]
             },
             DataContent dataContent => new()
             {
-                Content = [new()
-                    {
-                        Data = dataContent.GetBase64Data(),
-                        MimeType = dataContent.MediaType,
-                        Type = dataContent.HasTopLevelMediaType("image") ? "image" : "resource",
-                    }]
+                Content = [dataContent.ToContent()]
             },
             string[] texts => new()
             {
                 Content = [.. texts.Select(x => new Content() { Type = "text", Text = x ?? string.Empty })]
             },
-
             IEnumerable<AIContent> contentItems => new()
             {
-                Content = [.. contentItems.Select(static item => item switch
-                        {
-                            TextContent textContent => new Content() { Type = "text", Text = textContent.Text },
-                            DataContent dataContent => new Content()
-                            {
-                                Data = dataContent.GetBase64Data(),
-                                MimeType = dataContent.MediaType,
-                                Type = dataContent.HasTopLevelMediaType("image") ? "image" : "resource",
-                            },
-                            _ => new Content() { Type = "text", Text = item.ToString() ?? string.Empty }
-                        })]
+                Content = [.. contentItems.Select(static item => item.ToContent())]
+            },
+            IEnumerable<Content> contents => new()
+            {
+                Content = [.. contents]
             },
 
             // TODO https://github.com/modelcontextprotocol/csharp-sdk/issues/69:
@@ -250,4 +238,5 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
             },
         };
     }
+
 }

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -225,6 +225,7 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
             {
                 Content = [.. contents]
             },
+            CallToolResponse callToolResponse => callToolResponse,
 
             // TODO https://github.com/modelcontextprotocol/csharp-sdk/issues/69:
             // Add specialization for annotations.

--- a/tests/ModelContextProtocol.Tests/Server/McpServerToolReturnTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerToolReturnTests.cs
@@ -164,4 +164,31 @@ public  class McpServerToolReturnTests
         Assert.Equal("image/png", result.Content[1].MimeType);
         Assert.Null(result.Content[1].Text);
     }
+
+    [Fact]
+    public async Task CanReturnCallToolResponse()
+    {
+        CallToolResponse response = new()
+        {
+            Content = [new() { Text = "text", Type = "text" }, new() { Data = "1234", Type = "image" }]
+        };
+
+        Mock<IMcpServer> mockServer = new();
+        McpServerTool tool = McpServerTool.Create((IMcpServer server) =>
+        {
+            Assert.Same(mockServer.Object, server);
+            return response;
+        });
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            TestContext.Current.CancellationToken);
+
+        Assert.Same(response, result);
+
+        Assert.Equal(2, result.Content.Count);
+        Assert.Equal("text", result.Content[0].Text);
+        Assert.Equal("text", result.Content[0].Type);
+        Assert.Equal("1234", result.Content[1].Data);
+        Assert.Equal("image", result.Content[1].Type);
+    }
 }

--- a/tests/ModelContextProtocol.Tests/Server/McpServerToolReturnTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerToolReturnTests.cs
@@ -1,0 +1,167 @@
+﻿using Microsoft.Extensions.AI;
+using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Server;
+using Moq;
+
+namespace ModelContextProtocol.Tests.Server;
+public  class McpServerToolReturnTests
+{
+    [Fact]
+    public async Task CanReturnCollectionOfAIContent()
+    {
+        Mock<IMcpServer> mockServer = new();
+        McpServerTool tool = McpServerTool.Create((IMcpServer server) =>
+        {
+            Assert.Same(mockServer.Object, server);
+            return new List<AIContent>() {
+                new TextContent("text"),
+                new DataContent("data:image/png;base64,1234"),
+                new DataContent("data:audio/wav;base64,1234")
+            };
+        });
+
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, result.Content.Count);
+
+        Assert.Equal("text", result.Content[0].Text);
+        Assert.Equal("text", result.Content[0].Type);
+
+        Assert.Equal("1234", result.Content[1].Data);
+        Assert.Equal("image/png", result.Content[1].MimeType);
+        Assert.Equal("image", result.Content[1].Type);
+
+        Assert.Equal("1234", result.Content[2].Data);
+        Assert.Equal("audio/wav", result.Content[2].MimeType);
+        Assert.Equal("audio", result.Content[2].Type);
+    }
+
+    [Theory]
+    [InlineData("text", "text")]
+    [InlineData("data:image/png;base64,1234", "image")]
+    [InlineData("data:audio/wav;base64,1234", "audio")]
+    public async Task CanReturnSingleAIContent(string data, string type)
+    {
+        Mock<IMcpServer> mockServer = new();
+        McpServerTool tool = McpServerTool.Create((IMcpServer server) =>
+        {
+            Assert.Same(mockServer.Object, server);
+            return type switch 
+            {
+                "text" => (AIContent)new TextContent(data),
+                "image" => new DataContent(data),
+                "audio" => new DataContent(data),
+                _ => throw new ArgumentException("Invalid type")
+            };
+        });
+
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            TestContext.Current.CancellationToken);
+
+        Assert.Single(result.Content);
+        Assert.Equal(type, result.Content[0].Type);
+        
+        if (type != "text")
+        {
+            Assert.NotNull(result.Content[0].MimeType);
+            Assert.Equal(data.Split(',').Last(), result.Content[0].Data);
+        }
+        else
+        {
+            Assert.Null(result.Content[0].MimeType);
+            Assert.Equal(data, result.Content[0].Text);
+        }
+    }
+
+    [Fact]
+    public async Task CanReturnNullAIContent()
+    {
+        Mock<IMcpServer> mockServer = new();
+        McpServerTool tool = McpServerTool.Create((IMcpServer server) =>
+        {
+            Assert.Same(mockServer.Object, server);
+            return (string?)null;
+        });
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            TestContext.Current.CancellationToken);
+        Assert.Empty(result.Content);
+    }
+
+    [Fact]
+    public async Task CanReturnString()
+    {
+        Mock<IMcpServer> mockServer = new();
+        McpServerTool tool = McpServerTool.Create((IMcpServer server) =>
+        {
+            Assert.Same(mockServer.Object, server);
+            return "42";
+        });
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            TestContext.Current.CancellationToken);
+        Assert.Single(result.Content);
+        Assert.Equal("42", result.Content[0].Text);
+        Assert.Equal("text", result.Content[0].Type);
+    }
+
+    [Fact]
+    public async Task CanReturnCollectionOfStrings()
+    {
+        Mock<IMcpServer> mockServer = new();
+        McpServerTool tool = McpServerTool.Create((IMcpServer server) =>
+        {
+            Assert.Same(mockServer.Object, server);
+            return new List<string>() { "42", "43" };
+        });
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            TestContext.Current.CancellationToken);
+        Assert.Equal(2, result.Content.Count);
+        Assert.Equal("42", result.Content[0].Text);
+        Assert.Equal("text", result.Content[0].Type);
+        Assert.Equal("43", result.Content[1].Text);
+        Assert.Equal("text", result.Content[1].Type);
+    }
+
+    [Fact]
+    public async Task CanReturnMcpContent()
+    {
+        Mock<IMcpServer> mockServer = new();
+        McpServerTool tool = McpServerTool.Create((IMcpServer server) =>
+        {
+            Assert.Same(mockServer.Object, server);
+            return new Content { Text = "42", Type = "text" };
+        });
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            TestContext.Current.CancellationToken);
+        Assert.Single(result.Content);
+        Assert.Equal("42", result.Content[0].Text);
+        Assert.Equal("text", result.Content[0].Type);
+    }
+
+    [Fact]
+    public async Task CanReturnCollectionOfMcpContent()
+    {
+        Mock<IMcpServer> mockServer = new();
+        McpServerTool tool = McpServerTool.Create((IMcpServer server) =>
+        {
+            Assert.Same(mockServer.Object, server);
+            return new List<Content>() { new() { Text = "42", Type = "text" }, new() { Data = "1234", Type = "image", MimeType = "image/png" } };
+        });
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            TestContext.Current.CancellationToken);
+        Assert.Equal(2, result.Content.Count);
+        Assert.Equal("42", result.Content[0].Text);
+        Assert.Equal("text", result.Content[0].Type);
+        Assert.Equal("1234", result.Content[1].Data);
+        Assert.Equal("image", result.Content[1].Type);
+        Assert.Equal("image/png", result.Content[1].MimeType);
+        Assert.Null(result.Content[1].Text);
+    }
+}

--- a/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;
 using Moq;


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
This will mean we can return multiple AIContent objects from a tool, such as a mixed text/image set

Contributes to #68

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
