### PR TITLE
Remove Assembly.GetCallingAssembly

### DIFF
--- a/src/ModelContextProtocol/Configuration/McpServerOptionsSetup.cs
+++ b/src/ModelContextProtocol/Configuration/McpServerOptionsSetup.cs
@@ -27,11 +27,11 @@ internal sealed class McpServerOptionsSetup(
         // if it otherwise lacks server information.
         if (options.ServerInfo is not { } serverInfo)
         {
-            var assemblyName = (Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly()).GetName();
+            var assemblyName = Assembly.GetEntryAssembly()?.GetName();
             options.ServerInfo = new()
             {
-                Name = assemblyName.Name ?? "McpServer",
-                Version = assemblyName.Version?.ToString() ?? "1.0.0",
+                Name = assemblyName?.Name ?? "McpServer",
+                Version = assemblyName?.Version?.ToString() ?? "1.0.0",
             };
         }
 


### PR DESCRIPTION
This is always called from M.E.DI. That's not a good name to use here.