### PR TITLE
Add InMemoryTransport

### DIFF
--- a/src/ModelContextProtocol/Configuration/McpServerBuilderExtensions.Transports.cs
+++ b/src/ModelContextProtocol/Configuration/McpServerBuilderExtensions.Transports.cs
@@ -1,8 +1,10 @@
-﻿using ModelContextProtocol.Configuration;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Configuration;
 using ModelContextProtocol.Hosting;
+using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Utils;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace ModelContextProtocol;
 
@@ -17,11 +19,7 @@ public static partial class McpServerBuilderExtensions
     /// <param name="builder">The builder instance.</param>
     public static IMcpServerBuilder WithStdioServerTransport(this IMcpServerBuilder builder)
     {
-        Throw.IfNull(builder);
-
-        builder.Services.AddSingleton<IServerTransport, StdioServerTransport>();
-        builder.Services.AddHostedService<McpServerHostedService>();
-        return builder;
+        return builder.WithServerTransport<StdioServerTransport>();
     }
 
     /// <summary>
@@ -30,9 +28,57 @@ public static partial class McpServerBuilderExtensions
     /// <param name="builder">The builder instance.</param>
     public static IMcpServerBuilder WithHttpListenerSseServerTransport(this IMcpServerBuilder builder)
     {
+        return builder.WithServerTransport<HttpListenerSseServerTransport>();
+    }
+
+    /// <summary>
+    /// Adds a server transport for in-memory communication.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    public static IMcpServerBuilder WithInMemoryServerTransport(this IMcpServerBuilder builder)
+    {
+        return builder.WithServerTransport<InMemoryServerTransport>();
+    }
+
+    /// <summary>
+    /// Adds a server transport for in-memory communication.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="handleMessageDelegate">Delegate to handle messages.</param>
+    public static IMcpServerBuilder WithInMemoryServerTransport(this IMcpServerBuilder builder, Func<IJsonRpcMessage, CancellationToken, Task<IJsonRpcMessage?>> handleMessageDelegate)
+    {
+        var transport = new InMemoryServerTransport
+        {
+            HandleMessage = handleMessageDelegate
+        };
+
+        return builder.WithServerTransport(transport);
+    }
+
+    /// <summary>
+    /// Adds a server transport for communication.
+    /// </summary>
+    /// <typeparam name="TTransport">The type of the server transport to use.</typeparam>
+    /// <param name="builder">The builder instance.</param>
+    public static IMcpServerBuilder WithServerTransport<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTransport>(this IMcpServerBuilder builder) where TTransport : class, IServerTransport
+    {
         Throw.IfNull(builder);
 
-        builder.Services.AddSingleton<IServerTransport, HttpListenerSseServerTransport>();
+        builder.Services.AddSingleton<IServerTransport, TTransport>();
+        builder.Services.AddHostedService<McpServerHostedService>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a server transport for communication.
+    /// </summary>
+    /// <param name="serverTransport">Instance of the server transport.</param>
+    /// <param name="builder">The builder instance.</param>
+    public static IMcpServerBuilder WithServerTransport(this IMcpServerBuilder builder, IServerTransport serverTransport)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.AddSingleton<IServerTransport>(serverTransport);
         builder.Services.AddHostedService<McpServerHostedService>();
         return builder;
     }

--- a/src/ModelContextProtocol/Protocol/Transport/InMemoryServerTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/InMemoryServerTransport.cs
@@ -1,0 +1,102 @@
+﻿using System.Threading.Channels;
+using ModelContextProtocol.Protocol.Messages;
+
+namespace ModelContextProtocol.Protocol.Transport;
+
+/// <summary>
+/// InMemory server transport for special scenarios or testing. 
+/// </summary>
+public class InMemoryServerTransport : IServerTransport
+{
+    private readonly Channel<IJsonRpcMessage> _messageChannel;
+    private bool _isStarted;
+
+    /// <inheritdoc/>
+    public bool IsConnected => _isStarted;
+
+    /// <inheritdoc/>
+    public ChannelReader<IJsonRpcMessage> MessageReader => _messageChannel;
+
+    /// <summary>
+    /// Delegate to handle messages before sending them.
+    /// </summary>
+    public Func<IJsonRpcMessage, CancellationToken, Task<IJsonRpcMessage?>>? HandleMessage { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InMemoryServerTransport"/> class.
+    /// </summary>
+    public InMemoryServerTransport()
+    {
+        _messageChannel = Channel.CreateUnbounded<IJsonRpcMessage>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = true,
+        });
+
+        // default message handler
+        HandleMessage = (m, _) => Task.FromResult(CreateResponseMessage(m));
+    }
+
+    /// <inheritdoc/>
+#if NET8_0_OR_GREATER
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+#else
+    public ValueTask DisposeAsync() => new ValueTask(Task.CompletedTask);
+#endif
+
+    /// <inheritdoc/>
+    public virtual async Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
+    {
+        IJsonRpcMessage? response = message;
+
+        if (HandleMessage != null)
+            response = await HandleMessage(message, cancellationToken);
+
+        if (response != null)
+            await WriteMessageAsync(response, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public virtual Task StartListeningAsync(CancellationToken cancellationToken = default)
+    {
+        _isStarted = true;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Writes a message to the channel.
+    /// </summary>
+    protected virtual async Task WriteMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
+    {
+        await _messageChannel.Writer.WriteAsync(message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a response message for the given request.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <returns></returns>
+    protected virtual IJsonRpcMessage? CreateResponseMessage(IJsonRpcMessage message)
+    {
+        if (message is JsonRpcRequest request)
+        {
+            return new JsonRpcResponse
+            {
+                Id = request.Id,
+                Result = CreateMessageResult(request)
+            };
+        }
+
+        return message;
+    }
+
+    /// <summary>
+    /// Creates a result object for the given request.
+    /// </summary>
+    /// <param name="request"></param>
+    /// <returns></returns>
+    protected virtual object? CreateMessageResult(JsonRpcRequest request)
+    {
+        return null;
+    }
+}

--- a/tests/ModelContextProtocol.Tests/Utils/TestServerTransport.cs
+++ b/tests/ModelContextProtocol.Tests/Utils/TestServerTransport.cs
@@ -1,83 +1,33 @@
-﻿using System.Threading.Channels;
-using ModelContextProtocol.Protocol.Messages;
+﻿using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Protocol.Types;
 
 namespace ModelContextProtocol.Tests.Utils;
 
-public class TestServerTransport : IServerTransport
+public class TestServerTransport : InMemoryServerTransport
 {
-    private readonly Channel<IJsonRpcMessage> _messageChannel;
-    private bool _isStarted;
-
-    public bool IsConnected => _isStarted;
-
-    public ChannelReader<IJsonRpcMessage> MessageReader => _messageChannel;
-
     public List<IJsonRpcMessage> SentMessages { get; } = [];
 
-    public Action<IJsonRpcMessage>? OnMessageSent { get; set; }
-
-    public TestServerTransport()
-    {
-        _messageChannel = Channel.CreateUnbounded<IJsonRpcMessage>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = true,
-        });
-    }
-
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-
-    public async Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
+    public override Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
     {
         SentMessages.Add(message);
-        if (message is JsonRpcRequest request)
-        {
-            if (request.Method == "roots/list")
-                await ListRoots(request, cancellationToken);
-            else if (request.Method == "sampling/createMessage")
-                await Sampling(request, cancellationToken);
-            else
-                await WriteMessageAsync(request, cancellationToken);
-        }
-        else if (message is JsonRpcNotification notification)
-        {
-            await WriteMessageAsync(notification, cancellationToken);
-        }
 
-        OnMessageSent?.Invoke(message);
+        return base.SendMessageAsync(message, cancellationToken);
     }
 
-    public Task StartListeningAsync(CancellationToken cancellationToken = default)
+    protected override object? CreateMessageResult(JsonRpcRequest request)
     {
-        _isStarted = true;
-        return Task.CompletedTask;
-    }
-
-    private async Task ListRoots(JsonRpcRequest request, CancellationToken cancellationToken)
-    {
-        await WriteMessageAsync(new JsonRpcResponse
+        if (request.Method == "roots/list")
         {
-            Id = request.Id,
-            Result = new ModelContextProtocol.Protocol.Types.ListRootsResult
+            return new ModelContextProtocol.Protocol.Types.ListRootsResult
             {
                 Roots = []
-            }
-        }, cancellationToken);
-    }
+            };
+        }
 
-    private async Task Sampling(JsonRpcRequest request, CancellationToken cancellationToken)
-    {
-        await WriteMessageAsync(new JsonRpcResponse
-        {
-            Id = request.Id,
-            Result = new CreateMessageResult { Content = new(), Model = "model", Role = "role" }
-        }, cancellationToken);
-    }
+        if (request.Method == "sampling/createMessage")
+            return new CreateMessageResult { Content = new(), Model = "model", Role = "role" };
 
-    protected async Task WriteMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
-    {
-        await _messageChannel.Writer.WriteAsync(message, cancellationToken);
+        return base.CreateMessageResult(request);
     }
 }


### PR DESCRIPTION
This PR adds a third server transport: InMemoryServerTransport.

## Motivation and Context
It can be used for testing or other special scenarios. Due to the fact, that McpServer requires a registered IServerTransport we need to provide at least a "dumb" one.


