### PR TITLE
fix for WeatherTools.cs

### DIFF
--- a/samples/QuickstartWeatherServer/Tools/WeatherTools.cs
+++ b/samples/QuickstartWeatherServer/Tools/WeatherTools.cs
@@ -40,8 +40,11 @@ public static class WeatherTools
         [Description("Latitude of the location.")] double latitude,
         [Description("Longitude of the location.")] double longitude)
     {
-        var jsonElement = await client.GetFromJsonAsync<JsonElement>($"/points/{latitude},{longitude}");
-        var periods = jsonElement.GetProperty("properties").GetProperty("periods").EnumerateArray();
+        var gridId = jsonElement.GetProperty("properties").GetProperty("gridId");
+        var gridX = jsonElement.GetProperty("properties").GetProperty("gridX");
+        var gridY = jsonElement.GetProperty("properties").GetProperty("gridY");
+        var pointsData = await client.GetFromJsonAsync<JsonElement>($"/gridpoints/{gridId}/{gridX},{gridY}/forecast");
+        var periods = pointsData.GetProperty("properties").GetProperty("periods").EnumerateArray();
 
         return string.Join("\n---\n", periods.Select(period => $"""
                 {period.GetProperty("name").GetString()}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

The WeatherTool.cs does not point to the right endpoint to get a forecast, which results in an error. For example, https://api.weather.gov/points/47.6163,-122.0356 does not return a forecast. However, switching to https://api.weather.gov/gridpoints/SEW/134,67/forecast does. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
