### PR TITLE
Bump to version 0.1.0-preview.4

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
     <RepositoryUrl>https://github.com/modelcontextprotocol/csharp-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>preview.3</VersionSuffix>
+    <VersionSuffix>preview.4</VersionSuffix>
     <Authors>ModelContextProtocolOfficial</Authors>
     <Copyright>© Anthropic and Contributors.</Copyright>
     <PackageTags>ModelContextProtocol;mcp;ai;llm</PackageTags>


### PR DESCRIPTION
With https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v0.1.0-preview.3 published, we bump to `preview.4`.

_Maybe_ we'll get to where we automate this PR creation as part of the release workflow. Updating by hand for now.