### PR TITLE
Put MapMcp in Microsoft.AspNetCore.Builder namespace

### DIFF
--- a/samples/AspNetCoreSseServer/Program.cs
+++ b/samples/AspNetCoreSseServer/Program.cs
@@ -1,5 +1,3 @@
-using ModelContextProtocol.AspNetCore;
-
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddMcpServer().WithToolsFromAssembly();
 var app = builder.Build();

--- a/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,7 +11,7 @@ using ModelContextProtocol.Utils.Json;
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
 
-namespace ModelContextProtocol.AspNetCore;
+namespace Microsoft.AspNetCore.Builder;
 
 /// <summary>
 /// Extension methods for <see cref="IEndpointRouteBuilder"/> to add MCP endpoints.

--- a/src/ModelContextProtocol.AspNetCore/README.md
+++ b/src/ModelContextProtocol.AspNetCore/README.md
@@ -30,7 +30,6 @@ dotnet add package ModelContextProtocol.AspNetCore --prerelease
 
 ```csharp
 // Program.cs
-using ModelContextProtocol.AspNetCore;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
 

--- a/tests/ModelContextProtocol.TestSseServer/Program.cs
+++ b/tests/ModelContextProtocol.TestSseServer/Program.cs
@@ -1,5 +1,4 @@
-﻿using ModelContextProtocol.AspNetCore;
-using ModelContextProtocol.Protocol.Types;
+﻿using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;
 using Serilog;
 using System.Text;


### PR DESCRIPTION
This was an oversight where I blindly went with VS defaults. Much like DI's `Add*` extension methods belonging in Microsoft.Extensions.DependencyInjection, we conventionally put all `Map*` extension methods like `MapGet`, `MapControllerRoute`, `MapHub`, `MapOpenApi`, etc... in the Microsoft.AspNetCore.Builder namespace that's likely to already be in an implicit or explicit using.
