### PR TITLE
Fix pagination handling in McpServer

### DIFF
--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol.Types;
-using ModelContextProtocol.Shared;
 using ModelContextProtocol.Utils;
 using ModelContextProtocol.Utils.Json;
 using System.Diagnostics.CodeAnalysis;

--- a/src/ModelContextProtocol/TokenProgress.cs
+++ b/src/ModelContextProtocol/TokenProgress.cs
@@ -1,6 +1,5 @@
 ﻿using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Server;
-using ModelContextProtocol.Shared;
 
 namespace ModelContextProtocol;
 

--- a/tests/ModelContextProtocol.Tests/Client/McpClientExtensionsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientExtensionsTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Server;
-using ModelContextProtocol.Tests.Transport;
 using ModelContextProtocol.Tests.Utils;
 using System.IO.Pipelines;
 

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsPromptsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsPromptsTests.cs
@@ -6,11 +6,12 @@ using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;
-using ModelContextProtocol.Tests.Transport;
 using ModelContextProtocol.Tests.Utils;
 using System.ComponentModel;
 using System.IO.Pipelines;
 using System.Threading.Channels;
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
 namespace ModelContextProtocol.Tests.Configuration;
 
@@ -28,7 +29,70 @@ public class McpServerBuilderExtensionsPromptsTests : LoggedTest, IAsyncDisposab
     {
         ServiceCollection sc = new();
         sc.AddSingleton(LoggerFactory);
-        _builder = sc.AddMcpServer().WithStdioServerTransport().WithPrompts<SimplePrompts>();
+        _builder = sc
+            .AddMcpServer()
+            .WithStdioServerTransport()
+            .WithListPromptsHandler(async (request, cancellationToken) =>
+            {
+                var cursor = request.Params?.Cursor;
+                switch (cursor)
+                {
+                    case null:
+                        return new()
+                        {
+                            NextCursor = "abc",
+                            Prompts = [new()
+                            {
+                                Name = "FirstCustomPrompt",
+                                Description = "First prompt returned by custom handler",
+                            }],
+                        };
+
+                    case "abc":
+                        return new()
+                        {
+                            NextCursor = "def",
+                            Prompts = [new()
+                            {
+                                Name = "SecondCustomPrompt",
+                                Description = "Second prompt returned by custom handler",
+                            }],
+                        };
+
+                    case "def":
+                        return new()
+                        {
+                            NextCursor = null,
+                            Prompts = [new()
+                            {
+                                Name = "FinalCustomPrompt",
+                                Description = "Final prompt returned by custom handler",
+                            }],
+                        };
+
+                    default:
+                        throw new Exception("Unexpected cursor");
+                }
+            })
+            .WithGetPromptHandler(async (request, cancellationToken) =>
+            {
+                switch (request.Params?.Name)
+                {
+                    case "FirstCustomPrompt":
+                    case "SecondCustomPrompt":
+                    case "FinalCustomPrompt":
+                        return new GetPromptResult()
+                        {
+                            Messages = [new() { Role = Role.User, Content = new() { Text = $"hello from {request.Params.Name}", Type = "text" } }],
+                        };
+
+                    default:
+                        throw new Exception($"Unknown prompt '{request.Params?.Name}'");
+                }
+            })
+            .WithPrompts<SimplePrompts>();
+
+
         // Call WithStdioServerTransport to get the IMcpServer registration, then overwrite default transport with a pipe transport.
         sc.AddSingleton<ITransport>(new StreamServerTransport(_clientToServerPipe.Reader.AsStream(), _serverToClientPipe.Writer.AsStream(), loggerFactory: LoggerFactory));
         sc.AddSingleton(new ObjectWithId());
@@ -85,7 +149,7 @@ public class McpServerBuilderExtensionsPromptsTests : LoggedTest, IAsyncDisposab
         IMcpClient client = await CreateMcpClientForServer();
 
         var prompts = await client.ListPromptsAsync(TestContext.Current.CancellationToken);
-        Assert.Equal(3, prompts.Count);
+        Assert.Equal(6, prompts.Count);
 
         var prompt = prompts.First(t => t.Name == nameof(SimplePrompts.ReturnsChatMessages));
         Assert.Equal("Returns chat messages", prompt.Description);
@@ -98,6 +162,14 @@ public class McpServerBuilderExtensionsPromptsTests : LoggedTest, IAsyncDisposab
         Assert.Equal(2, chatMessages.Count);
         Assert.Equal("The prompt is: hello", chatMessages[0].Text);
         Assert.Equal("Summarize.", chatMessages[1].Text);
+
+        prompt = prompts.First(t => t.Name == "SecondCustomPrompt");
+        Assert.Equal("Second prompt returned by custom handler", prompt.Description);
+        result = await prompt.GetAsync(cancellationToken: TestContext.Current.CancellationToken);
+        chatMessages = result.ToChatMessages();
+        Assert.NotNull(chatMessages);
+        Assert.Single(chatMessages);
+        Assert.Equal("hello from SecondCustomPrompt", chatMessages[0].Text);
     }
 
     [Fact]
@@ -106,7 +178,7 @@ public class McpServerBuilderExtensionsPromptsTests : LoggedTest, IAsyncDisposab
         IMcpClient client = await CreateMcpClientForServer();
 
         var prompts = await client.ListPromptsAsync(TestContext.Current.CancellationToken);
-        Assert.Equal(3, prompts.Count);
+        Assert.Equal(6, prompts.Count);
 
         Channel<JsonRpcNotification> listChanged = Channel.CreateUnbounded<JsonRpcNotification>();
         client.AddNotificationHandler("notifications/prompts/list_changed", notification =>
@@ -127,7 +199,7 @@ public class McpServerBuilderExtensionsPromptsTests : LoggedTest, IAsyncDisposab
         await notificationRead;
 
         prompts = await client.ListPromptsAsync(TestContext.Current.CancellationToken);
-        Assert.Equal(4, prompts.Count);
+        Assert.Equal(7, prompts.Count);
         Assert.Contains(prompts, t => t.Name == "NewPrompt");
 
         notificationRead = listChanged.Reader.ReadAsync(TestContext.Current.CancellationToken);
@@ -136,7 +208,7 @@ public class McpServerBuilderExtensionsPromptsTests : LoggedTest, IAsyncDisposab
         await notificationRead;
 
         prompts = await client.ListPromptsAsync(TestContext.Current.CancellationToken);
-        Assert.Equal(3, prompts.Count);
+        Assert.Equal(6, prompts.Count);
         Assert.DoesNotContain(prompts, t => t.Name == "NewPrompt");
     }
 

--- a/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Protocol.Types;

--- a/tests/ModelContextProtocol.Tests/SseServerIntegrationTestFixture.cs
+++ b/tests/ModelContextProtocol.Tests/SseServerIntegrationTestFixture.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using ModelContextProtocol.Client;
+﻿using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Test.Utils;
 using ModelContextProtocol.Tests.Utils;


### PR DESCRIPTION
- We were defeating the purpose of pagination by doing all of the aggregation in the server. If a custom handler returns a paginated result, we should instead propagate that back to the client, who can choose to get more results when needed.
- We were adding tools/prompts from the collections on every request, even if there was a cursor. If multiple requests came in with different cursors, we'd re-add the same tools each time.