### PR TITLE
 Make supposedly unreachable code less reachable

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs
@@ -85,7 +85,7 @@ public static class McpEndpointRouteBuilderExtensions
 
             if (!_sessions.TryGetValue(sessionId.ToString(), out var transport))
             {
-                await Results.BadRequest($"Session {sessionId} not found.").ExecuteAsync(context);
+                await Results.BadRequest($"Session ID not found.").ExecuteAsync(context);
                 return;
             }
 

--- a/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs
@@ -47,11 +47,11 @@ public static class McpEndpointRouteBuilderExtensions
             {
                 throw new Exception($"Unreachable given good entropy! Session with ID '{sessionId}' has already been created.");
             }
-            await using var server = McpServerFactory.Create(transport, mcpServerOptions.Value, loggerFactory, endpoints.ServiceProvider);
 
             try
             {
                 var transportTask = transport.RunAsync(cancellationToken: requestAborted);
+                await using var server = McpServerFactory.Create(transport, mcpServerOptions.Value, loggerFactory, endpoints.ServiceProvider);
 
                 try
                 {

--- a/src/ModelContextProtocol/Client/McpClient.cs
+++ b/src/ModelContextProtocol/Client/McpClient.cs
@@ -90,21 +90,21 @@ internal sealed class McpClient : McpJsonRpcEndpoint, IMcpClient
             using var initializationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             initializationCts.CancelAfter(_options.InitializationTimeout);
 
-        try
-        {
-            // Send initialize request
-            var initializeResponse = await SendRequestAsync<InitializeResult>(
-                new JsonRpcRequest
-                {
-                    Method = RequestMethods.Initialize,
-                    Params = new InitializeRequestParams()
+            try
+            {
+                // Send initialize request
+                var initializeResponse = await SendRequestAsync<InitializeResult>(
+                    new JsonRpcRequest
                     {
-                        ProtocolVersion = _options.ProtocolVersion,
-                        Capabilities = _options.Capabilities ?? new ClientCapabilities(),
-                        ClientInfo = _options.ClientInfo
-                    }
-                },
-                initializationCts.Token).ConfigureAwait(false);
+                        Method = RequestMethods.Initialize,
+                        Params = new InitializeRequestParams()
+                        {
+                            ProtocolVersion = _options.ProtocolVersion,
+                            Capabilities = _options.Capabilities ?? new ClientCapabilities(),
+                            ClientInfo = _options.ClientInfo
+                        }
+                    },
+                    initializationCts.Token).ConfigureAwait(false);
 
                 // Store server information
                 _logger.ServerCapabilitiesReceived(EndpointName,

--- a/src/ModelContextProtocol/Client/McpClient.cs
+++ b/src/ModelContextProtocol/Client/McpClient.cs
@@ -82,9 +82,7 @@ internal sealed class McpClient : McpJsonRpcEndpoint, IMcpClient
         {
             // Connect transport
             _sessionTransport = await _clientTransport.ConnectAsync(cancellationToken).ConfigureAwait(false);
-            // We don't want the ConnectAsync token to cancel the session after we've successfully connected.
-            // The base class handles cleaning up the session in DisposeAsync without our help.
-            StartSession(_sessionTransport, fullSessionCancellationToken: CancellationToken.None);
+            StartSession(_sessionTransport);
 
             // Perform initialization sequence
             using var initializationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -15,6 +15,7 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
     private readonly EventHandler? _promptsChangedDelegate;
 
     private string _endpointName;
+    private int _started;
 
     /// <summary>
     /// Creates a new instance of <see cref="McpServer"/>.
@@ -96,6 +97,11 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
     /// <inheritdoc />
     public async Task RunAsync(CancellationToken cancellationToken = default)
     {
+        if (Interlocked.Exchange(ref _started, 1) != 0)
+        {
+            throw new InvalidOperationException($"{nameof(RunAsync)} must only be called once.");
+        }
+
         try
         {
             using var _ = cancellationToken.Register(static s => ((McpServer)s!).CancelSession(), this);

--- a/tests/ModelContextProtocol.Tests/Server/McpServerFactoryTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerFactoryTests.cs
@@ -1,8 +1,6 @@
-﻿using ModelContextProtocol.Protocol.Transport;
-using ModelContextProtocol.Protocol.Types;
+﻿using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Tests.Utils;
-using Moq;
 
 namespace ModelContextProtocol.Tests.Server;
 
@@ -25,7 +23,8 @@ public class McpServerFactoryTests : LoggedTest
     public async Task Create_Should_Initialize_With_Valid_Parameters()
     {
         // Arrange & Act
-        await using IMcpServer server = McpServerFactory.Create(Mock.Of<ITransport>(), _options, LoggerFactory);
+        await using var transport = new TestServerTransport();
+        await using IMcpServer server = McpServerFactory.Create(transport, _options, LoggerFactory);
 
         // Assert
         Assert.NotNull(server);
@@ -39,9 +38,10 @@ public class McpServerFactoryTests : LoggedTest
     }
 
     [Fact]
-    public void Create_Throws_For_Null_Options()
+    public async Task Create_Throws_For_Null_Options()
     {
         // Arrange, Act & Assert
-        Assert.Throws<ArgumentNullException>("serverOptions", () => McpServerFactory.Create(Mock.Of<ITransport>(), null!, LoggerFactory));
+        await using var transport = new TestServerTransport();
+        Assert.Throws<ArgumentNullException>("serverOptions", () => McpServerFactory.Create(transport, null!, LoggerFactory));
     }
 }


### PR DESCRIPTION
When I removed IServerTransport, I combined `StartSession` and `InitializeSession`, but I should have moved the call to StartSession into the McpServer constructor so you don't run into the following "unreachable" exception from McpServer.SendMessageAsync and SendRequestAsync called after McpServerFactory.Create but before McpServerFactory.RunAsync.

```
 ModelContextProtocol.Tests.Server.McpServerTests.Can_SendMessage_Before_RunAsync
   Source: McpServerTests.cs line 588
   Duration: 81 ms

  Message: 
System.InvalidOperationException : This should be unreachable from public API! Call StartSession before sending messages.

  Stack Trace: 
McpJsonRpcEndpoint.GetSessionOrThrow() line 126
McpJsonRpcEndpoint.SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken) line 51
McpServerTests.Can_SendMessage_Before_RunAsync() line 597
McpServerTests.Can_SendMessage_Before_RunAsync() line 604
--- End of stack trace from previous location ---

  Standard Output: 
| [2025-04-01T15:47:33] ModelContextProtocol.Server.McpServer Information: Cleaning up endpoint Server (TestServer 1.0)
| [2025-04-01T15:47:33] ModelContextProtocol.Server.McpServer Information: Endpoint cleaned up for Server (TestServer 1.0)
```

It's unusual to send a message before handling any client requests like the initialization request, which is why this wasn't caught by our earlier tests, but it's possible that something like a log is fired off as fire-and-forget message, and there's no reason that should cause any issues like the exception fixed by this PR.