### PR TITLE
Fix and enhance cancellation operations across MCP Sessions. 

### DIFF
--- a/samples/EverythingServer/LoggingUpdateMessageSender.cs
+++ b/samples/EverythingServer/LoggingUpdateMessageSender.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+﻿using Microsoft.Extensions.Hosting;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;

--- a/samples/EverythingServer/ResourceGenerator.cs
+++ b/samples/EverythingServer/ResourceGenerator.cs
@@ -1,7 +1,4 @@
 using ModelContextProtocol.Protocol.Types;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace EverythingServer;
 

--- a/samples/EverythingServer/Tools/LongRunningTool.cs
+++ b/samples/EverythingServer/Tools/LongRunningTool.cs
@@ -1,5 +1,4 @@
 ﻿using ModelContextProtocol;
-using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;
 using System.ComponentModel;

--- a/src/ModelContextProtocol/Client/McpClientFactory.cs
+++ b/src/ModelContextProtocol/Client/McpClientFactory.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-using System.Runtime.InteropServices;
-using ModelContextProtocol.Logging;
+﻿using ModelContextProtocol.Logging;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Utils;
 using Microsoft.Extensions.Logging;

--- a/src/ModelContextProtocol/McpEndpointExtensions.cs
+++ b/src/ModelContextProtocol/McpEndpointExtensions.cs
@@ -155,14 +155,14 @@ public static class McpEndpointExtensions
     {
         Throw.IfNull(endpoint);
 
-        return endpoint.SendMessageAsync(new JsonRpcNotification()
-        {
-            Method = NotificationMethods.ProgressNotification,
-            Params = JsonSerializer.SerializeToNode(new ProgressNotification
+        return endpoint.SendNotificationAsync(
+            NotificationMethods.ProgressNotification,
+            new ProgressNotification
             {
                 ProgressToken = progressToken,
                 Progress = progress,
-            }, McpJsonUtilities.JsonContext.Default.ProgressNotification),
-        }, cancellationToken);
+            },
+            McpJsonUtilities.JsonContext.Default.ProgressNotification,
+            cancellationToken);
     }
 }

--- a/src/ModelContextProtocol/Protocol/Types/ClientCapabilities.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ClientCapabilities.cs
@@ -1,5 +1,4 @@
 ﻿using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Server;
 using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;

--- a/src/ModelContextProtocol/Protocol/Types/LoggingCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/LoggingCapability.cs
@@ -1,5 +1,4 @@
-﻿using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Server;
+﻿using ModelContextProtocol.Server;
 using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;

--- a/src/ModelContextProtocol/Protocol/Types/PromptsCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/PromptsCapability.cs
@@ -1,5 +1,4 @@
-﻿using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Server;
+﻿using ModelContextProtocol.Server;
 using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;

--- a/src/ModelContextProtocol/Protocol/Types/ResourcesCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ResourcesCapability.cs
@@ -1,5 +1,4 @@
-﻿using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Server;
+﻿using ModelContextProtocol.Server;
 using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;

--- a/src/ModelContextProtocol/Protocol/Types/RootsCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/RootsCapability.cs
@@ -1,6 +1,4 @@
-﻿using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Server;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;
 

--- a/src/ModelContextProtocol/Protocol/Types/SamplingCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/SamplingCapability.cs
@@ -1,6 +1,4 @@
-﻿using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Server;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;
 

--- a/src/ModelContextProtocol/Protocol/Types/ToolsCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ToolsCapability.cs
@@ -1,5 +1,4 @@
-﻿using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Server;
+﻿using ModelContextProtocol.Server;
 using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;

--- a/src/ModelContextProtocol/Server/McpServerOptions.cs
+++ b/src/ModelContextProtocol/Server/McpServerOptions.cs
@@ -1,6 +1,5 @@
 ﻿
 using ModelContextProtocol.Protocol.Types;
-using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Server;
 

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -338,6 +338,8 @@ internal sealed class McpSession : IDisposable
             throw new McpException("Transport is not connected");
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         Histogram<double> durationMetric = _isServer ? s_serverRequestDuration : s_clientRequestDuration;
         string method = request.Method;
 
@@ -424,6 +426,8 @@ internal sealed class McpSession : IDisposable
             _logger.ClientNotConnected(EndpointName);
             throw new McpException("Transport is not connected");
         }
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         Histogram<double> durationMetric = _isServer ? s_serverRequestDuration : s_clientRequestDuration;
         string method = GetMethodName(message);

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -296,6 +296,24 @@ internal sealed class McpSession : IDisposable
         }, cancellationToken).ConfigureAwait(false);
     }
 
+    private CancellationTokenRegistration RegisterCancellation(CancellationToken cancellationToken, RequestId requestId)
+    {
+        if (!cancellationToken.CanBeCanceled)
+        {
+            return default;
+        }
+
+        return cancellationToken.Register(static objState =>
+        {
+            var state = (Tuple<McpSession, RequestId>)objState!;
+            _ = state.Item1.SendMessageAsync(new JsonRpcNotification
+            {
+                Method = NotificationMethods.CancelledNotification,
+                Params = JsonSerializer.SerializeToNode(new CancelledNotification { RequestId = state.Item2 }, McpJsonUtilities.JsonContext.Default.CancelledNotification)
+            });
+        }, Tuple.Create(this, requestId));
+    }
+
     public IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, Task> handler)
     {
         Throw.IfNullOrWhiteSpace(method);
@@ -357,9 +375,16 @@ internal sealed class McpSession : IDisposable
             _logger.SendingRequest(EndpointName, request.Method);
 
             await _transport.SendMessageAsync(request, cancellationToken).ConfigureAwait(false);
-
             _logger.RequestSentAwaitingResponse(EndpointName, request.Method, request.Id.ToString());
-            var response = await tcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            // Now that the request has been sent, register for cancellation. If we registered before,
+            // a cancellation request could arrive before the server knew about that request ID, in which
+            // case the server could ignore it.
+            IJsonRpcMessage? response;
+            using (var registration = RegisterCancellation(cancellationToken, request.Id))
+            {
+                response = await tcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             if (response is JsonRpcError error)
             {

--- a/tests/ModelContextProtocol.Tests/ClientServerTestBase.cs
+++ b/tests/ModelContextProtocol.Tests/ClientServerTestBase.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Tests.Utils;
+using System.IO.Pipelines;
+
+namespace ModelContextProtocol.Tests;
+
+public abstract class ClientServerTestBase : LoggedTest, IAsyncDisposable
+{
+    private readonly Pipe _clientToServerPipe = new();
+    private readonly Pipe _serverToClientPipe = new();
+    private readonly IMcpServerBuilder _builder;
+    private readonly CancellationTokenSource _cts;
+    private readonly Task _serverTask;
+
+    public ClientServerTestBase(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+        ServiceCollection sc = new();
+        sc.AddSingleton(LoggerFactory);
+        _builder = sc
+            .AddMcpServer()
+            .WithStreamServerTransport(_clientToServerPipe.Reader.AsStream(), _serverToClientPipe.Writer.AsStream());
+        ConfigureServices(sc, _builder);
+        ServiceProvider = sc.BuildServiceProvider();
+
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        Server = ServiceProvider.GetRequiredService<IMcpServer>();
+        _serverTask = Server.RunAsync(_cts.Token);
+    }
+
+    protected IMcpServer Server { get; }
+
+    protected IServiceProvider ServiceProvider { get; }
+
+    protected virtual void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
+    {
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cts.CancelAsync();
+
+        _clientToServerPipe.Writer.Complete();
+        _serverToClientPipe.Writer.Complete();
+
+        await _serverTask;
+
+        if (ServiceProvider is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+        else if (ServiceProvider is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        _cts.Dispose();
+        Dispose();
+    }
+
+    protected async Task<IMcpClient> CreateMcpClientForServer(McpClientOptions? options = null)
+    {
+        return await McpClientFactory.CreateAsync(
+            new StreamClientTransport(
+                serverInput: _clientToServerPipe.Writer.AsStream(),
+                _serverToClientPipe.Reader.AsStream(),
+                LoggerFactory),
+            loggerFactory: LoggerFactory,
+            cancellationToken: TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/ModelContextProtocol.Tests/Protocol/CancellationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Protocol/CancellationTests.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol.Messages;
+using ModelContextProtocol.Server;
+
+namespace ModelContextProtocol.Tests;
+
+public class CancellationTests : ClientServerTestBase
+{
+    public CancellationTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
+    {
+        services.AddSingleton(McpServerTool.Create(WaitForCancellation));
+    }
+
+    private static async Task WaitForCancellation(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(-1, cancellationToken);
+            throw new InvalidOperationException("Unexpected completion without exception");
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+    }
+
+    [Fact]
+    public async Task PrecancelRequest_CancelsBeforeSending()
+    {
+        var client = await CreateMcpClientForServer();
+
+        bool gotCancellation = false;
+        await using (Server.RegisterNotificationHandler(NotificationMethods.CancelledNotification, (notification, cancellationToken) =>
+        {
+            gotCancellation = true;
+            return Task.CompletedTask;
+        }))
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(() => client.ListToolsAsync(cancellationToken: new CancellationToken(true)));
+        }
+
+        Assert.False(gotCancellation);
+    }
+
+    [Fact]
+    public async Task CancellationPropagation_RequestingCancellationCancelsPendingRequest()
+    {
+        var client = await CreateMcpClientForServer();
+
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var waitTool = tools.First(t => t.Name == nameof(WaitForCancellation));
+
+        CancellationTokenSource cts = new();
+        var waitTask = waitTool.InvokeAsync(cancellationToken: cts.Token);
+        Assert.False(waitTask.IsCompleted);
+
+        await Task.Delay(1, TestContext.Current.CancellationToken);
+        Assert.False(waitTask.IsCompleted);
+
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await waitTask);
+    }
+}

--- a/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
- made requests notify cancellation when cancellation tokens are used.
- added extension methods to make sending these custom cancellation notifications simpler.

## Motivation and Context

This helps adherence to the spec, specifically for requests - since notifications aren't cancellable according to the spec.

## How Has This Been Tested?

Tests were added to cover the usage.

## Breaking Changes

NA

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
NA
