### PR TITLE
Allow JsonSerializerOptions parameters for user-defined and inputs and hardcode everything else to the source generator.

### DIFF
--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -188,6 +188,7 @@ public static class McpClientExtensions
         Throw.IfNull(client);
         Throw.IfNullOrWhiteSpace(name);
         serializerOptions ??= McpJsonUtilities.DefaultOptions;
+        McpJsonUtilities.ValidateSerializerOptions(serializerOptions);
         var parametersTypeInfo = serializerOptions.GetTypeInfo<IReadOnlyDictionary<string, object?>>();
 
         return client.SendRequestAsync(
@@ -454,6 +455,7 @@ public static class McpClientExtensions
         Throw.IfNull(client);
         Throw.IfNull(toolName);
         serializerOptions ??= McpJsonUtilities.DefaultOptions;
+        McpJsonUtilities.ValidateSerializerOptions(serializerOptions);
         var parametersTypeInfo = serializerOptions.GetTypeInfo<IReadOnlyDictionary<string, object?>>();
 
         return client.SendRequestAsync(

--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -1,33 +1,16 @@
-﻿using ModelContextProtocol.Protocol.Messages;
+﻿using Microsoft.Extensions.AI;
+using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Utils;
 using ModelContextProtocol.Utils.Json;
-using Microsoft.Extensions.AI;
-using System.Text.Json;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 
 namespace ModelContextProtocol.Client;
 
 /// <summary>Provides extension methods for interacting with an <see cref="IMcpClient"/>.</summary>
 public static class McpClientExtensions
 {
-    /// <summary>
-    /// Sends a notification to the server with parameters.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="method">The notification method name.</param>
-    /// <param name="parameters">The parameters to send with the notification.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    public static Task SendNotificationAsync(this IMcpClient client, string method, object? parameters = null, CancellationToken cancellationToken = default)
-    {
-        Throw.IfNull(client);
-        Throw.IfNullOrWhiteSpace(method);
-
-        return client.SendMessageAsync(
-            new JsonRpcNotification { Method = method, Params = parameters },
-            cancellationToken);
-    }
-
     /// <summary>
     /// Sends a ping request to verify server connectivity.
     /// </summary>
@@ -38,9 +21,12 @@ public static class McpClientExtensions
     {
         Throw.IfNull(client);
 
-        return client.SendRequestAsync<dynamic>(
-            CreateRequest(RequestMethods.Ping, null),
-            cancellationToken);
+        return client.SendRequestAsync(
+            RequestMethods.Ping, 
+            parameters: null,
+            McpJsonUtilities.JsonContext.Default.Object,
+            McpJsonUtilities.JsonContext.Default.Object,
+            cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -58,9 +44,12 @@ public static class McpClientExtensions
         string? cursor = null;
         do
         {
-            var toolResults = await client.SendRequestAsync<ListToolsResult>(
-                CreateRequest(RequestMethods.ToolsList, CreateCursorDictionary(cursor)),
-                cancellationToken).ConfigureAwait(false);
+            var toolResults = await client.SendRequestAsync(
+                RequestMethods.ToolsList, 
+                CreateCursorDictionary(cursor),
+                McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+                McpJsonUtilities.JsonContext.Default.ListToolsResult,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             tools ??= new List<McpClientTool>(toolResults.Tools.Count);
             foreach (var tool in toolResults.Tools)
@@ -93,9 +82,12 @@ public static class McpClientExtensions
         string? cursor = null;
         do
         {
-            var toolResults = await client.SendRequestAsync<ListToolsResult>(
-                CreateRequest(RequestMethods.ToolsList, CreateCursorDictionary(cursor)),
-                cancellationToken).ConfigureAwait(false);
+            var toolResults = await client.SendRequestAsync(
+                RequestMethods.ToolsList, 
+                CreateCursorDictionary(cursor),
+                McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+                McpJsonUtilities.JsonContext.Default.ListToolsResult,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             foreach (var tool in toolResults.Tools)
             {
@@ -122,9 +114,12 @@ public static class McpClientExtensions
         string? cursor = null;
         do
         {
-            var promptResults = await client.SendRequestAsync<ListPromptsResult>(
-                CreateRequest(RequestMethods.PromptsList, CreateCursorDictionary(cursor)),
-                cancellationToken).ConfigureAwait(false);
+            var promptResults = await client.SendRequestAsync(
+                RequestMethods.PromptsList, 
+                CreateCursorDictionary(cursor),
+                McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+                McpJsonUtilities.JsonContext.Default.ListPromptsResult,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             prompts ??= new List<McpClientPrompt>(promptResults.Prompts.Count);
             foreach (var prompt in promptResults.Prompts)
@@ -157,9 +152,12 @@ public static class McpClientExtensions
         string? cursor = null;
         do
         {
-            var promptResults = await client.SendRequestAsync<ListPromptsResult>(
-                CreateRequest(RequestMethods.PromptsList, CreateCursorDictionary(cursor)),
-                cancellationToken).ConfigureAwait(false);
+            var promptResults = await client.SendRequestAsync(
+                RequestMethods.PromptsList,
+                CreateCursorDictionary(cursor),
+                McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+                McpJsonUtilities.JsonContext.Default.ListPromptsResult,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             foreach (var prompt in promptResults.Prompts)
             {
@@ -177,17 +175,27 @@ public static class McpClientExtensions
     /// <param name="client">The client.</param>
     /// <param name="name">The name of the prompt to retrieve</param>
     /// <param name="arguments">Optional arguments for the prompt</param>
+    /// <param name="serializerOptions">The serialization options governing argument serialization.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task containing the prompt's content and messages.</returns>
     public static Task<GetPromptResult> GetPromptAsync(
-        this IMcpClient client, string name, IReadOnlyDictionary<string, object?>? arguments = null, CancellationToken cancellationToken = default)
+        this IMcpClient client,
+        string name,
+        IReadOnlyDictionary<string, object?>? arguments = null,
+        JsonSerializerOptions? serializerOptions = null,
+        CancellationToken cancellationToken = default)
     {
         Throw.IfNull(client);
         Throw.IfNullOrWhiteSpace(name);
+        serializerOptions ??= McpJsonUtilities.DefaultOptions;
+        var parametersTypeInfo = serializerOptions.GetTypeInfo<IReadOnlyDictionary<string, object?>>();
 
-        return client.SendRequestAsync<GetPromptResult>(
-            CreateRequest(RequestMethods.PromptsGet, CreateParametersDictionary(name, arguments)),
-            cancellationToken);
+        return client.SendRequestAsync(
+            RequestMethods.PromptsGet,
+            CreateParametersDictionary(name, arguments),
+            parametersTypeInfo,
+            McpJsonUtilities.JsonContext.Default.GetPromptResult,
+            cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -206,9 +214,12 @@ public static class McpClientExtensions
         string? cursor = null;
         do
         {
-            var templateResults = await client.SendRequestAsync<ListResourceTemplatesResult>(
-                CreateRequest(RequestMethods.ResourcesTemplatesList, CreateCursorDictionary(cursor)),
-                cancellationToken).ConfigureAwait(false);
+            var templateResults = await client.SendRequestAsync(
+                RequestMethods.ResourcesTemplatesList, 
+                CreateCursorDictionary(cursor),
+                McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+                McpJsonUtilities.JsonContext.Default.ListResourceTemplatesResult,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (templates is null)
             {
@@ -244,9 +255,12 @@ public static class McpClientExtensions
         string? cursor = null;
         do
         {
-            var templateResults = await client.SendRequestAsync<ListResourceTemplatesResult>(
-                CreateRequest(RequestMethods.ResourcesTemplatesList, CreateCursorDictionary(cursor)),
-                cancellationToken).ConfigureAwait(false);
+            var templateResults = await client.SendRequestAsync(
+                RequestMethods.ResourcesTemplatesList, 
+                CreateCursorDictionary(cursor),
+                McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+                McpJsonUtilities.JsonContext.Default.ListResourceTemplatesResult,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             foreach (var template in templateResults.ResourceTemplates)
             {
@@ -274,9 +288,12 @@ public static class McpClientExtensions
         string? cursor = null;
         do
         {
-            var resourceResults = await client.SendRequestAsync<ListResourcesResult>(
-                CreateRequest(RequestMethods.ResourcesList, CreateCursorDictionary(cursor)),
-                cancellationToken).ConfigureAwait(false);
+            var resourceResults = await client.SendRequestAsync(
+                RequestMethods.ResourcesList, 
+                CreateCursorDictionary(cursor),
+                McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+                McpJsonUtilities.JsonContext.Default.ListResourcesResult,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (resources is null)
             {
@@ -312,9 +329,12 @@ public static class McpClientExtensions
         string? cursor = null;
         do
         {
-            var resourceResults = await client.SendRequestAsync<ListResourcesResult>(
-                CreateRequest(RequestMethods.ResourcesList, CreateCursorDictionary(cursor)),
-                cancellationToken).ConfigureAwait(false);
+            var resourceResults = await client.SendRequestAsync(
+                RequestMethods.ResourcesList, 
+                CreateCursorDictionary(cursor),
+                McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+                McpJsonUtilities.JsonContext.Default.ListResourcesResult,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             foreach (var resource in resourceResults.Resources)
             {
@@ -338,9 +358,12 @@ public static class McpClientExtensions
         Throw.IfNull(client);
         Throw.IfNullOrWhiteSpace(uri);
 
-        return client.SendRequestAsync<ReadResourceResult>(
-            CreateRequest(RequestMethods.ResourcesRead, new Dictionary<string, object?>() { ["uri"] = uri }),
-            cancellationToken);
+        return client.SendRequestAsync(
+            RequestMethods.ResourcesRead, 
+            new Dictionary<string, object?> { ["uri"] = uri },
+            McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+            McpJsonUtilities.JsonContext.Default.ReadResourceResult,
+            cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -362,13 +385,16 @@ public static class McpClientExtensions
             throw new ArgumentException($"Invalid reference: {validationMessage}", nameof(reference));
         }
 
-        return client.SendRequestAsync<CompleteResult>(
-            CreateRequest(RequestMethods.CompletionComplete, new Dictionary<string, object?>()
+        return client.SendRequestAsync(
+            RequestMethods.CompletionComplete, 
+            new Dictionary<string, object?>
             {
                 ["ref"] = reference,
                 ["argument"] = new Argument { Name = argumentName, Value = argumentValue }
-            }),
-            cancellationToken);
+            },
+            McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+            McpJsonUtilities.JsonContext.Default.CompleteResult,
+            cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -382,9 +408,12 @@ public static class McpClientExtensions
         Throw.IfNull(client);
         Throw.IfNullOrWhiteSpace(uri);
 
-        return client.SendRequestAsync<EmptyResult>(
-            CreateRequest(RequestMethods.ResourcesSubscribe, new Dictionary<string, object?>() { ["uri"] = uri }),
-            cancellationToken);
+        return client.SendRequestAsync(
+            RequestMethods.ResourcesSubscribe, 
+            new Dictionary<string, object?> { ["uri"] = uri },
+            McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+            McpJsonUtilities.JsonContext.Default.EmptyResult,
+            cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -398,9 +427,12 @@ public static class McpClientExtensions
         Throw.IfNull(client);
         Throw.IfNullOrWhiteSpace(uri);
 
-        return client.SendRequestAsync<EmptyResult>(
-            CreateRequest(RequestMethods.ResourcesUnsubscribe, new Dictionary<string, object?>() { ["uri"] = uri }),
-            cancellationToken);
+        return client.SendRequestAsync(
+            RequestMethods.ResourcesUnsubscribe,
+            new Dictionary<string, object?> { ["uri"] = uri },
+            McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+            McpJsonUtilities.JsonContext.Default.EmptyResult,
+            cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -409,17 +441,27 @@ public static class McpClientExtensions
     /// <param name="client">The client.</param>
     /// <param name="toolName">The name of the tool to call.</param>
     /// <param name="arguments">Optional arguments for the tool.</param>
+    /// <param name="serializerOptions">The serialization options governing argument serialization.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task containing the tool's response.</returns>
     public static Task<CallToolResponse> CallToolAsync(
-        this IMcpClient client, string toolName, IReadOnlyDictionary<string, object?>? arguments = null, CancellationToken cancellationToken = default)
+        this IMcpClient client,
+        string toolName,
+        IReadOnlyDictionary<string, object?>? arguments = null,
+        JsonSerializerOptions? serializerOptions = null,
+        CancellationToken cancellationToken = default)
     {
         Throw.IfNull(client);
         Throw.IfNull(toolName);
+        serializerOptions ??= McpJsonUtilities.DefaultOptions;
+        var parametersTypeInfo = serializerOptions.GetTypeInfo<IReadOnlyDictionary<string, object?>>();
 
-        return client.SendRequestAsync<CallToolResponse>(
-            CreateRequest(RequestMethods.ToolsCall, CreateParametersDictionary(toolName, arguments)),
-            cancellationToken);
+        return client.SendRequestAsync(
+            RequestMethods.ToolsCall, 
+            CreateParametersDictionary(toolName, arguments),
+            parametersTypeInfo,
+            McpJsonUtilities.JsonContext.Default.CallToolResponse,
+            cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -569,17 +611,13 @@ public static class McpClientExtensions
     {
         Throw.IfNull(client);
 
-        return client.SendRequestAsync<EmptyResult>(
-            CreateRequest(RequestMethods.LoggingSetLevel, new Dictionary<string, object?>() { ["level"] = level }),
-            cancellationToken);
+        return client.SendRequestAsync(
+            RequestMethods.LoggingSetLevel,
+            new Dictionary<string, object?> { ["level"] = level },
+            McpJsonUtilities.JsonContext.Default.DictionaryStringObject,
+            McpJsonUtilities.JsonContext.Default.EmptyResult,
+            cancellationToken: cancellationToken);
     }
-
-    private static JsonRpcRequest CreateRequest(string method, IReadOnlyDictionary<string, object?>? parameters) =>
-        new()
-        {
-            Method = method,
-            Params = parameters
-        };
 
     private static Dictionary<string, object?>? CreateCursorDictionary(string? cursor) =>
         cursor != null ? new() { ["cursor"] = cursor } : null;
@@ -598,37 +636,5 @@ public static class McpClientExtensions
         }
 
         return parameters;
-    }
-
-    /// <summary>Provides an AI function that calls a tool through <see cref="IMcpClient"/>.</summary>
-    private sealed class McpAIFunction(IMcpClient client, Tool tool) : AIFunction
-    {
-        /// <inheritdoc/>
-        public override string Name => tool.Name;
-
-        /// <inheritdoc/>
-        public override string Description => tool.Description ?? string.Empty;
-
-        /// <inheritdoc/>
-        public override JsonElement JsonSchema => tool.InputSchema;
-
-        /// <inheritdoc/>
-        public override JsonSerializerOptions JsonSerializerOptions => McpJsonUtilities.DefaultOptions;
-
-        /// <inheritdoc/>
-        protected async override Task<object?> InvokeCoreAsync(
-            IEnumerable<KeyValuePair<string, object?>> arguments, CancellationToken cancellationToken)
-        {
-            IReadOnlyDictionary<string, object?> argDict =
-                arguments as IReadOnlyDictionary<string, object?> ??
-#if NET
-                arguments.ToDictionary();
-#else
-                arguments.ToDictionary(kv => kv.Key, kv => kv.Value);   
-#endif
-
-            CallToolResponse result = await client.CallToolAsync(tool.Name, argDict, cancellationToken).ConfigureAwait(false);
-            return JsonSerializer.SerializeToElement(result, McpJsonUtilities.JsonContext.Default.CallToolResponse);
-        }
     }
 }

--- a/src/ModelContextProtocol/Client/McpClientPrompt.cs
+++ b/src/ModelContextProtocol/Client/McpClientPrompt.cs
@@ -1,4 +1,5 @@
 ﻿using ModelContextProtocol.Protocol.Types;
+using System.Text.Json;
 
 namespace ModelContextProtocol.Client;
 
@@ -20,17 +21,19 @@ public sealed class McpClientPrompt
     /// Retrieves a specific prompt with optional arguments.
     /// </summary>
     /// <param name="arguments">Optional arguments for the prompt</param>
+    /// <param name="serializerOptions">The serialization options governing argument serialization.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task containing the prompt's content and messages.</returns>
     public async ValueTask<GetPromptResult> GetAsync(
         IEnumerable<KeyValuePair<string, object?>>? arguments = null,
+        JsonSerializerOptions? serializerOptions = null,
         CancellationToken cancellationToken = default)
     {
         IReadOnlyDictionary<string, object?>? argDict =
             arguments as IReadOnlyDictionary<string, object?> ??
             arguments?.ToDictionary();
 
-        return await _client.GetPromptAsync(ProtocolPrompt.Name, argDict, cancellationToken).ConfigureAwait(false);
+        return await _client.GetPromptAsync(ProtocolPrompt.Name, argDict, serializerOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Gets the name of the prompt.</summary>

--- a/src/ModelContextProtocol/Client/McpClientTool.cs
+++ b/src/ModelContextProtocol/Client/McpClientTool.cs
@@ -10,10 +10,11 @@ public sealed class McpClientTool : AIFunction
 {
     private readonly IMcpClient _client;
 
-    internal McpClientTool(IMcpClient client, Tool tool)
+    internal McpClientTool(IMcpClient client, Tool tool, JsonSerializerOptions serializerOptions)
     {
         _client = client;
         ProtocolTool = tool;
+        JsonSerializerOptions = serializerOptions;
     }
 
     /// <summary>Gets the protocol <see cref="Tool"/> type for this instance.</summary>
@@ -29,7 +30,7 @@ public sealed class McpClientTool : AIFunction
     public override JsonElement JsonSchema => ProtocolTool.InputSchema;
 
     /// <inheritdoc/>
-    public override JsonSerializerOptions JsonSerializerOptions => McpJsonUtilities.DefaultOptions;
+    public override JsonSerializerOptions JsonSerializerOptions { get; }
 
     /// <inheritdoc/>
     protected async override Task<object?> InvokeCoreAsync(
@@ -39,7 +40,7 @@ public sealed class McpClientTool : AIFunction
             arguments as IReadOnlyDictionary<string, object?> ??
             arguments.ToDictionary();
 
-        CallToolResponse result = await _client.CallToolAsync(ProtocolTool.Name, argDict, cancellationToken: cancellationToken).ConfigureAwait(false);
+        CallToolResponse result = await _client.CallToolAsync(ProtocolTool.Name, argDict, JsonSerializerOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
         return JsonSerializer.SerializeToElement(result, McpJsonUtilities.JsonContext.Default.CallToolResponse);
     }
 }

--- a/src/ModelContextProtocol/Client/McpClientTool.cs
+++ b/src/ModelContextProtocol/Client/McpClientTool.cs
@@ -39,7 +39,7 @@ public sealed class McpClientTool : AIFunction
             arguments as IReadOnlyDictionary<string, object?> ??
             arguments.ToDictionary();
 
-        CallToolResponse result = await _client.CallToolAsync(ProtocolTool.Name, argDict, cancellationToken).ConfigureAwait(false);
+        CallToolResponse result = await _client.CallToolAsync(ProtocolTool.Name, argDict, cancellationToken: cancellationToken).ConfigureAwait(false);
         return JsonSerializer.SerializeToElement(result, McpJsonUtilities.JsonContext.Default.CallToolResponse);
     }
 }

--- a/src/ModelContextProtocol/IMcpEndpoint.cs
+++ b/src/ModelContextProtocol/IMcpEndpoint.cs
@@ -5,12 +5,11 @@ namespace ModelContextProtocol;
 /// <summary>Represents a client or server MCP endpoint.</summary>
 public interface IMcpEndpoint : IAsyncDisposable
 {
-    /// <summary>Sends a generic JSON-RPC request to the connected endpoint.</summary>
-    /// <typeparam name="TResult">The expected response type.</typeparam>
+    /// <summary>Sends a JSON-RPC request to the connected endpoint.</summary>
     /// <param name="request">The JSON-RPC request to send.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task containing the client's response.</returns>
-    Task<TResult> SendRequestAsync<TResult>(JsonRpcRequest request, CancellationToken cancellationToken = default) where TResult : class;
+    Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>Sends a message to the connected endpoint.</summary>
     /// <param name="message">The message.</param>

--- a/src/ModelContextProtocol/Logging/Log.cs
+++ b/src/ModelContextProtocol/Logging/Log.cs
@@ -77,9 +77,6 @@ internal static partial class Log
     [LoggerMessage(Level = LogLevel.Information, Message = "Request response received for {endpointName} with method {method}")]
     internal static partial void RequestResponseReceived(this ILogger logger, string endpointName, string method);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Request response type conversion error for {endpointName} with method {method}: expected {expectedType}")]
-    internal static partial void RequestResponseTypeConversionError(this ILogger logger, string endpointName, string method, Type expectedType);
-
     [LoggerMessage(Level = LogLevel.Error, Message = "Request invalid response type for {endpointName} with method {method}")]
     internal static partial void RequestInvalidResponseType(this ILogger logger, string endpointName, string method);
 

--- a/src/ModelContextProtocol/McpEndpointExtensions.cs
+++ b/src/ModelContextProtocol/McpEndpointExtensions.cs
@@ -75,6 +75,7 @@ public static class McpEndpointExtensions
         where TResult : notnull
     {
         serializerOptions ??= McpJsonUtilities.DefaultOptions;
+        McpJsonUtilities.ValidateSerializerOptions(serializerOptions);
         JsonTypeInfo<TParameters> paramsTypeInfo = serializerOptions.GetTypeInfo<TParameters>();
         JsonTypeInfo<TResult> resultTypeInfo = serializerOptions.GetTypeInfo<TResult>();
         return SendRequestAsync(endpoint, method, parameters, paramsTypeInfo, resultTypeInfo, requestId, cancellationToken);
@@ -132,6 +133,7 @@ public static class McpEndpointExtensions
         CancellationToken cancellationToken = default)
     {
         serializerOptions ??= McpJsonUtilities.DefaultOptions;
+        McpJsonUtilities.ValidateSerializerOptions(serializerOptions);
         JsonTypeInfo<TParameters> parametersTypeInfo = serializerOptions.GetTypeInfo<TParameters>();
         return SendNotificationAsync(endpoint, method, parameters, parametersTypeInfo, cancellationToken);
     }

--- a/src/ModelContextProtocol/McpEndpointExtensions.cs
+++ b/src/ModelContextProtocol/McpEndpointExtensions.cs
@@ -1,13 +1,143 @@
 ﻿using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Utils;
+using ModelContextProtocol.Utils.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 
 namespace ModelContextProtocol;
 
 /// <summary>Provides extension methods for interacting with an <see cref="IMcpEndpoint"/>.</summary>
 public static class McpEndpointExtensions
 {
+    /// <summary>
+    /// Sends a JSON-RPC request and attempts to deserialize the result to <typeparamref name="TResult"/>.
+    /// </summary>
+    /// <typeparam name="TParameters">The type of the request parameters to serialize from.</typeparam>
+    /// <typeparam name="TResult">The type of the result to deserialize to.</typeparam>
+    /// <param name="endpoint">The MCP client or server instance.</param>
+    /// <param name="method">The JSON-RPC method name to invoke.</param>
+    /// <param name="parameters">Object representing the request parameters.</param>
+    /// <param name="parametersTypeInfo">The type information for request parameter serialization.</param>
+    /// <param name="resultTypeInfo">The type information for request parameter deserialization.</param>
+    /// <param name="requestId">The request id for the request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the deserialized result.</returns>
+    public static async Task<TResult> SendRequestAsync<TParameters, TResult>(
+        this IMcpEndpoint endpoint,
+        string method,
+        TParameters parameters,
+        JsonTypeInfo<TParameters> parametersTypeInfo,
+        JsonTypeInfo<TResult> resultTypeInfo,
+        RequestId? requestId = null,
+        CancellationToken cancellationToken = default)
+        where TResult : notnull
+    {
+        Throw.IfNull(endpoint);
+        Throw.IfNullOrWhiteSpace(method);
+        Throw.IfNull(parametersTypeInfo);
+        Throw.IfNull(resultTypeInfo);
+
+        JsonRpcRequest jsonRpcRequest = new()
+        {
+            Method = method,
+            Params = JsonSerializer.SerializeToNode(parameters, parametersTypeInfo),
+        };
+
+        if (requestId is { } id)
+        {
+            jsonRpcRequest.Id = id;
+        }
+
+        JsonRpcResponse response = await endpoint.SendRequestAsync(jsonRpcRequest, cancellationToken).ConfigureAwait(false);
+        return JsonSerializer.Deserialize(response.Result, resultTypeInfo) ?? throw new JsonException("Unexpected JSON result in response.");
+    }
+
+    /// <summary>
+    /// Sends a JSON-RPC request and attempts to deserialize the result to <typeparamref name="TResult"/>.
+    /// </summary>
+    /// <typeparam name="TParameters">The type of the request parameters to serialize from.</typeparam>
+    /// <typeparam name="TResult">The type of the result to deserialize to.</typeparam>
+    /// <param name="endpoint">The MCP client or server instance.</param>
+    /// <param name="method">The JSON-RPC method name to invoke.</param>
+    /// <param name="parameters">Object representing the request parameters.</param>
+    /// <param name="serializerOptions">The options governing request serialization.</param>
+    /// <param name="requestId">The request id for the request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the deserialized result.</returns>
+    public static Task<TResult> SendRequestAsync<TParameters, TResult>(
+        this IMcpEndpoint endpoint,
+        string method,
+        TParameters parameters,
+        JsonSerializerOptions? serializerOptions = null,
+        RequestId? requestId = null,
+        CancellationToken cancellationToken = default)
+        where TResult : notnull
+    {
+        serializerOptions ??= McpJsonUtilities.DefaultOptions;
+        JsonTypeInfo<TParameters> paramsTypeInfo = serializerOptions.GetTypeInfo<TParameters>();
+        JsonTypeInfo<TResult> resultTypeInfo = serializerOptions.GetTypeInfo<TResult>();
+        return SendRequestAsync(endpoint, method, parameters, paramsTypeInfo, resultTypeInfo, requestId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a notification to the server with parameters.
+    /// </summary>
+    /// <param name="client">The client.</param>
+    /// <param name="method">The notification method name.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    public static Task SendNotificationAsync(this IMcpEndpoint client, string method, CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(client);
+        Throw.IfNullOrWhiteSpace(method);
+        return client.SendMessageAsync(new JsonRpcNotification { Method = method }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a notification to the server with parameters.
+    /// </summary>
+    /// <param name="endpoint">The MCP client or server instance.</param>
+    /// <param name="method">The JSON-RPC method name to invoke.</param>
+    /// <param name="parameters">Object representing the request parameters.</param>
+    /// <param name="parametersTypeInfo">The type information for request parameter serialization.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    public static Task SendNotificationAsync<TParameters>(
+        this IMcpEndpoint endpoint,
+        string method,
+        TParameters parameters,
+        JsonTypeInfo<TParameters> parametersTypeInfo,
+        CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(endpoint);
+        Throw.IfNullOrWhiteSpace(method);
+        Throw.IfNull(parametersTypeInfo);
+
+        JsonNode? parametersJson = JsonSerializer.SerializeToNode(parameters, parametersTypeInfo);
+        return endpoint.SendMessageAsync(new JsonRpcNotification { Method = method, Params = parametersJson }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a notification to the server with parameters.
+    /// </summary>
+    /// <param name="endpoint">The MCP client or server instance.</param>
+    /// <param name="method">The JSON-RPC method name to invoke.</param>
+    /// <param name="parameters">Object representing the request parameters.</param>
+    /// <param name="serializerOptions">The options governing request serialization.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    public static Task SendNotificationAsync<TParameters>(
+        this IMcpEndpoint endpoint,
+        string method,
+        TParameters parameters,
+        JsonSerializerOptions? serializerOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        serializerOptions ??= McpJsonUtilities.DefaultOptions;
+        JsonTypeInfo<TParameters> parametersTypeInfo = serializerOptions.GetTypeInfo<TParameters>();
+        return SendNotificationAsync(endpoint, method, parameters, parametersTypeInfo, cancellationToken);
+    }
+
     /// <summary>Notifies the connected endpoint of progress.</summary>
-    /// <param name="endpoint">The endpoint issueing the notification.</param>
+    /// <param name="endpoint">The endpoint issuing the notification.</param>
     /// <param name="progressToken">The <see cref="ProgressToken"/> identifying the operation.</param>
     /// <param name="progress">The progress update to send.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
@@ -24,11 +154,11 @@ public static class McpEndpointExtensions
         return endpoint.SendMessageAsync(new JsonRpcNotification()
         {
             Method = NotificationMethods.ProgressNotification,
-            Params = new ProgressNotification()
+            Params = JsonSerializer.SerializeToNode(new ProgressNotification
             {
                 ProgressToken = progressToken,
                 Progress = progress,
-            },
+            }, McpJsonUtilities.JsonContext.Default.ProgressNotification),
         }, cancellationToken);
     }
 }

--- a/src/ModelContextProtocol/Protocol/Messages/JsonRpcNotification.cs
+++ b/src/ModelContextProtocol/Protocol/Messages/JsonRpcNotification.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Messages;
 
@@ -23,5 +24,5 @@ public record JsonRpcNotification : IJsonRpcMessage
     /// Optional parameters for the notification.
     /// </summary>
     [JsonPropertyName("params")]
-    public object? Params { get; init; }
+    public JsonNode? Params { get; init; }
 }

--- a/src/ModelContextProtocol/Protocol/Messages/JsonRpcRequest.cs
+++ b/src/ModelContextProtocol/Protocol/Messages/JsonRpcRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Messages;
 
@@ -29,5 +30,5 @@ public record JsonRpcRequest : IJsonRpcMessageWithId
     /// Optional parameters for the method.
     /// </summary>
     [JsonPropertyName("params")]
-    public object? Params { get; init; }
+    public JsonNode? Params { get; init; }
 }

--- a/src/ModelContextProtocol/Protocol/Messages/JsonRpcResponse.cs
+++ b/src/ModelContextProtocol/Protocol/Messages/JsonRpcResponse.cs
@@ -1,4 +1,4 @@
-﻿
+﻿using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Messages;
@@ -23,5 +23,5 @@ public record JsonRpcResponse : IJsonRpcMessageWithId
     /// The result of the method invocation.
     /// </summary>
     [JsonPropertyName("result")]
-    public required object? Result { get; init; }
+    public required JsonNode? Result { get; init; }
 }

--- a/src/ModelContextProtocol/Protocol/Transport/SseClientSessionTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseClientSessionTransport.cs
@@ -24,7 +24,6 @@ internal sealed class SseClientSessionTransport : TransportBase
     private Task? _receiveTask;
     private readonly ILogger _logger;
     private readonly McpServerConfig _serverConfig;
-    private readonly JsonSerializerOptions _jsonOptions;
     private readonly TaskCompletionSource<bool> _connectionEstablished;
 
     private string EndpointName => $"Client (SSE) for ({_serverConfig.Id}: {_serverConfig.Name})";
@@ -50,7 +49,6 @@ internal sealed class SseClientSessionTransport : TransportBase
         _httpClient = httpClient;
         _connectionCts = new CancellationTokenSource();
         _logger = (ILogger?)loggerFactory?.CreateLogger<SseClientTransport>() ?? NullLogger.Instance;
-        _jsonOptions = McpJsonUtilities.DefaultOptions;
         _connectionEstablished = new TaskCompletionSource<bool>();
     }
 
@@ -94,7 +92,7 @@ internal sealed class SseClientSessionTransport : TransportBase
             throw new InvalidOperationException("Transport not connected");
 
         using var content = new StringContent(
-            JsonSerializer.Serialize(message, _jsonOptions.GetTypeInfo<IJsonRpcMessage>()),
+            JsonSerializer.Serialize(message, McpJsonUtilities.JsonContext.Default.IJsonRpcMessage),
             Encoding.UTF8,
             "application/json"
         );
@@ -127,7 +125,7 @@ internal sealed class SseClientSessionTransport : TransportBase
             }
             else
             {
-                JsonRpcResponse initializeResponse = JsonSerializer.Deserialize(responseContent, _jsonOptions.GetTypeInfo<JsonRpcResponse>()) ??
+                JsonRpcResponse initializeResponse = JsonSerializer.Deserialize(responseContent, McpJsonUtilities.JsonContext.Default.JsonRpcResponse) ??
                     throw new McpTransportException("Failed to initialize client");
 
                 _logger.TransportReceivedMessageParsed(EndpointName, messageId);
@@ -259,7 +257,7 @@ internal sealed class SseClientSessionTransport : TransportBase
 
         try
         {
-            var message = JsonSerializer.Deserialize(data, _jsonOptions.GetTypeInfo<IJsonRpcMessage>());
+            var message = JsonSerializer.Deserialize(data, McpJsonUtilities.JsonContext.Default.IJsonRpcMessage);
             if (message == null)
             {
                 _logger.TransportMessageParseUnexpectedType(EndpointName, data);

--- a/src/ModelContextProtocol/Protocol/Types/CallToolRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/CallToolRequestParams.cs
@@ -1,4 +1,6 @@
-﻿namespace ModelContextProtocol.Protocol.Types;
+﻿using System.Text.Json;
+
+namespace ModelContextProtocol.Protocol.Types;
 
 /// <summary>
 /// Used by the client to invoke a tool provided by the server.
@@ -16,5 +18,5 @@ public class CallToolRequestParams : RequestParams
     /// Optional arguments to pass to the tool.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("arguments")]
-    public Dictionary<string,object>? Arguments { get; init; }
+    public Dictionary<string, JsonElement>? Arguments { get; init; }
 }

--- a/src/ModelContextProtocol/Protocol/Types/LoggingMessageNotificationParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/LoggingMessageNotificationParams.cs
@@ -24,7 +24,7 @@ public class LoggingMessageNotificationParams
     public string? Logger { get; init; }
 
     /// <summary>
-    /// The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here.
+    /// The data to be logged, such as a string message or an object.
     /// </summary>
     [JsonPropertyName("data")]
     public JsonElement? Data { get; init; }

--- a/src/ModelContextProtocol/Protocol/Types/ResourceContents.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ResourceContents.cs
@@ -61,6 +61,8 @@ public abstract class ResourceContents
                 }
 
                 string? propertyName = reader.GetString();
+                bool success = reader.Read();
+                Debug.Assert(success, "STJ must have buffered the entire object for us.");
 
                 switch (propertyName)
                 {

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -255,8 +255,8 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
         cancellationToken.ThrowIfCancellationRequested();
 
         // TODO: Once we shift to the real AIFunctionFactory, the request should be passed via AIFunctionArguments.Context.
-        Dictionary<string, object?> arguments = request.Params?.Arguments is IDictionary<string, object?> existingArgs ?
-            new(existingArgs) :
+        Dictionary<string, object?> arguments = request.Params?.Arguments is { } paramArgs ?
+            paramArgs.ToDictionary(entry => entry.Key, entry => entry.Value.AsObject()) :
             [];
         arguments[RequestContextKey] = request;
 

--- a/src/ModelContextProtocol/Server/McpServerExtensions.cs
+++ b/src/ModelContextProtocol/Server/McpServerExtensions.cs
@@ -1,7 +1,9 @@
-﻿using ModelContextProtocol.Protocol.Messages;
+﻿using Microsoft.Extensions.AI;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Utils;
-using Microsoft.Extensions.AI;
+using ModelContextProtocol.Utils.Json;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -25,9 +27,12 @@ public static class McpServerExtensions
             throw new ArgumentException("Client connected to the server does not support sampling.", nameof(server));
         }
 
-        return server.SendRequestAsync<CreateMessageResult>(
-            new JsonRpcRequest { Method = RequestMethods.SamplingCreateMessage, Params = request },
-            cancellationToken);
+        return server.SendRequestAsync(
+            RequestMethods.SamplingCreateMessage,
+            request, 
+            McpJsonUtilities.JsonContext.Default.CreateMessageRequestParams,
+            McpJsonUtilities.JsonContext.Default.CreateMessageResult,
+            cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -164,9 +169,12 @@ public static class McpServerExtensions
             throw new ArgumentException("Client connected to the server does not support roots.", nameof(server));
         }
 
-        return server.SendRequestAsync<ListRootsResult>(
-            new JsonRpcRequest { Method = RequestMethods.RootsList, Params = request },
-            cancellationToken);
+        return server.SendRequestAsync(
+            RequestMethods.RootsList,
+            request,
+            McpJsonUtilities.JsonContext.Default.ListRootsRequestParams,
+            McpJsonUtilities.JsonContext.Default.ListRootsResult,
+            cancellationToken: cancellationToken);
     }
 
     /// <summary>Provides an <see cref="IChatClient"/> implementation that's implemented via client sampling.</summary>

--- a/src/ModelContextProtocol/Server/TemporaryAIFunctionFactory.cs
+++ b/src/ModelContextProtocol/Server/TemporaryAIFunctionFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Utils;
+using ModelContextProtocol.Utils.Json;
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -476,7 +477,7 @@ internal static partial class TemporaryAIFunctionFactory
                     description: parameter.GetCustomAttribute<DescriptionAttribute>(inherit: true)?.Description,
                     hasDefaultValue: parameter.HasDefaultValue,
                     defaultValue: parameter.HasDefaultValue ? parameter.DefaultValue : null,
-                    serializerOptions), AIJsonUtilities.DefaultOptions.GetTypeInfo<JsonElement>());
+                    serializerOptions), McpJsonUtilities.JsonContext.Default.JsonElement);
 
                 parameterSchemas.Add(parameter.Name, parameterSchema);
                 if (!parameter.IsOptional)

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -369,7 +369,6 @@ internal sealed class McpSession : IDisposable
 
             if (response is JsonRpcResponse success)
             {
-                // Not expensive logging because we're already converting to JSON in order to get the result object
                 _logger.RequestResponseReceivedPayload(EndpointName, success.Result?.ToJsonString() ?? "null");
                 _logger.RequestResponseReceived(EndpointName, request.Method);
                 return success;

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -11,6 +11,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace ModelContextProtocol.Shared;
 
@@ -43,7 +44,6 @@ internal sealed class McpSession : IDisposable
     /// that can be used to request cancellation of the in-flight handler.
     /// </summary>
     private readonly ConcurrentDictionary<RequestId, CancellationTokenSource> _handlingRequests = new();
-    private readonly JsonSerializerOptions _jsonOptions;
     private readonly ILogger _logger;
     
     private readonly string _id = Guid.NewGuid().ToString("N");
@@ -81,7 +81,6 @@ internal sealed class McpSession : IDisposable
         EndpointName = endpointName;
         _requestHandlers = requestHandlers;
         _notificationHandlers = notificationHandlers;
-        _jsonOptions = McpJsonUtilities.DefaultOptions;
         _logger = logger ?? NullLogger.Instance;
     }
 
@@ -155,7 +154,7 @@ internal sealed class McpSession : IDisposable
                         }
                         else if (ex is not OperationCanceledException)
                         {
-                            var payload = JsonSerializer.Serialize(message, _jsonOptions.GetTypeInfo<IJsonRpcMessage>());
+                            var payload = JsonSerializer.Serialize(message, McpJsonUtilities.JsonContext.Default.IJsonRpcMessage);
                             _logger.MessageHandlerError(EndpointName, message.GetType().Name, payload, ex);
                         }
                     }
@@ -295,7 +294,7 @@ internal sealed class McpSession : IDisposable
         }
 
         _logger.RequestHandlerCalled(EndpointName, request.Method);
-        var result = await handler(request, cancellationToken).ConfigureAwait(false);
+        JsonNode? result = await handler(request, cancellationToken).ConfigureAwait(false);
         _logger.RequestHandlerCompleted(EndpointName, request.Method);
         await _transport.SendMessageAsync(new JsonRpcResponse
         {
@@ -306,15 +305,14 @@ internal sealed class McpSession : IDisposable
     }
 
     /// <summary>
-    /// Sends a generic JSON-RPC request to the server.
+    /// Sends a JSON-RPC request to the server.
     /// It is strongly recommended use the capability-specific methods instead of this one.
     /// Use this method for custom requests or those not yet covered explicitly by the endpoint implementation.
     /// </summary>
-    /// <typeparam name="TResult">The expected response type.</typeparam>
     /// <param name="request">The JSON-RPC request to send.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task containing the server's response.</returns>
-    public async Task<TResult> SendRequestAsync<TResult>(JsonRpcRequest request, CancellationToken cancellationToken) where TResult : class
+    public async Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken)
     {
         if (!_transport.IsConnected)
         {
@@ -352,7 +350,7 @@ internal sealed class McpSession : IDisposable
             // Expensive logging, use the logging framework to check if the logger is enabled
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.SendingRequestPayload(EndpointName, JsonSerializer.Serialize(request, _jsonOptions.GetTypeInfo<JsonRpcRequest>()));
+                _logger.SendingRequestPayload(EndpointName, JsonSerializer.Serialize(request, McpJsonUtilities.JsonContext.Default.JsonRpcRequest));
             }
 
             // Less expensive information logging
@@ -371,22 +369,10 @@ internal sealed class McpSession : IDisposable
 
             if (response is JsonRpcResponse success)
             {
-                // Convert the Result object to JSON and back to get our strongly-typed result
-                var resultJson = JsonSerializer.Serialize(success.Result, _jsonOptions.GetTypeInfo<object?>());
-                var resultObject = JsonSerializer.Deserialize(resultJson, _jsonOptions.GetTypeInfo<TResult>());
-
                 // Not expensive logging because we're already converting to JSON in order to get the result object
-                _logger.RequestResponseReceivedPayload(EndpointName, resultJson);
+                _logger.RequestResponseReceivedPayload(EndpointName, success.Result?.ToJsonString() ?? "null");
                 _logger.RequestResponseReceived(EndpointName, request.Method);
-
-                if (resultObject != null)
-                {
-                    return resultObject;
-                }
-
-                // Result object was null, this is unexpected
-                _logger.RequestResponseTypeConversionError(EndpointName, request.Method, typeof(TResult));
-                throw new McpClientException($"Unexpected response type {JsonSerializer.Serialize(success.Result, _jsonOptions.GetTypeInfo<TResult>())}, expected {typeof(TResult)}");
+                return success;
             }
 
             // Unexpected response type
@@ -435,7 +421,7 @@ internal sealed class McpSession : IDisposable
 
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.SendingMessage(EndpointName, JsonSerializer.Serialize(message, _jsonOptions.GetTypeInfo<IJsonRpcMessage>()));
+                _logger.SendingMessage(EndpointName, JsonSerializer.Serialize(message, McpJsonUtilities.JsonContext.Default.IJsonRpcMessage));
             }
 
             await _transport.SendMessageAsync(message, cancellationToken).ConfigureAwait(false);
@@ -461,26 +447,11 @@ internal sealed class McpSession : IDisposable
         }
     }
 
-    private static CancelledNotification? GetCancelledNotificationParams(object? notificationParams)
+    private static CancelledNotification? GetCancelledNotificationParams(JsonNode? notificationParams)
     {
         try
         {
-            switch (notificationParams)
-            {
-                case null:
-                    return null;
-
-                case CancelledNotification cn:
-                    return cn;
-
-                case JsonElement je:
-                    return JsonSerializer.Deserialize(je, McpJsonUtilities.DefaultOptions.GetTypeInfo<CancelledNotification>());
-
-                default:
-                    return JsonSerializer.Deserialize(
-                        JsonSerializer.Serialize(notificationParams, McpJsonUtilities.DefaultOptions.GetTypeInfo<object?>()),
-                        McpJsonUtilities.DefaultOptions.GetTypeInfo<CancelledNotification>());
-            }
+            return JsonSerializer.Deserialize(notificationParams, McpJsonUtilities.JsonContext.Default.CancelledNotification);
         }
         catch
         {
@@ -515,15 +486,15 @@ internal sealed class McpSession : IDisposable
     {
         tags.Add("rpc.jsonrpc.request_id", request.Id.ToString());
 
-        if (request.Params is JsonElement je)
+        if (request.Params is JsonObject paramsObj)
         {
             switch (request.Method)
             {
                 case RequestMethods.ToolsCall:
                 case RequestMethods.PromptsGet:
-                    if (je.TryGetProperty("name", out var prop) && prop.ValueKind == JsonValueKind.String)
+                    if (paramsObj.TryGetPropertyValue("name", out var prop) && prop?.GetValueKind() is JsonValueKind.String)
                     {
-                        string name = prop.GetString()!;
+                        string name = prop.GetValue<string>();
                         tags.Add("mcp.request.params.name", name);
                         if (activity is not null)
                         {
@@ -533,9 +504,9 @@ internal sealed class McpSession : IDisposable
                     break;
 
                 case RequestMethods.ResourcesRead:
-                    if (je.TryGetProperty("uri", out prop) && prop.ValueKind == JsonValueKind.String)
+                    if (paramsObj.TryGetPropertyValue("uri", out prop) && prop?.GetValueKind() is JsonValueKind.String)
                     {
-                        string uri = prop.GetString()!;
+                        string uri = prop.GetValue<string>();
                         tags.Add("mcp.request.params.uri", uri);
                         if (activity is not null)
                         {

--- a/src/ModelContextProtocol/Shared/RequestHandlers.cs
+++ b/src/ModelContextProtocol/Shared/RequestHandlers.cs
@@ -1,11 +1,12 @@
 ﻿using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Utils;
-using ModelContextProtocol.Utils.Json;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 
 namespace ModelContextProtocol.Shared;
 
-internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, CancellationToken, Task<object?>>>
+internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, CancellationToken, Task<JsonNode?>>>
 {
     /// <summary>
     /// Registers a handler for incoming requests of a specific method.
@@ -14,18 +15,24 @@ internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, 
     /// <typeparam name="TResponse">Type of response payload (not full RPC response</typeparam>
     /// <param name="method">Method identifier to register for</param>
     /// <param name="handler">Handler to be called when a request with specified method identifier is received</param>
-    public void Set<TRequest, TResponse>(string method, Func<TRequest?, CancellationToken, Task<TResponse>> handler)
+    /// <param name="requestTypeInfo">The JSON contract governing request serialization.</param>
+    /// <param name="responseTypeInfo">The JSON contract governing response serialization.</param>
+    public void Set<TRequest, TResponse>(
+        string method,
+        Func<TRequest?, CancellationToken, Task<TResponse>> handler,
+        JsonTypeInfo<TRequest> requestTypeInfo,
+        JsonTypeInfo<TResponse> responseTypeInfo)
     {
         Throw.IfNull(method);
         Throw.IfNull(handler);
+        Throw.IfNull(requestTypeInfo);
+        Throw.IfNull(responseTypeInfo);
 
         this[method] = async (request, cancellationToken) =>
         {
-            // Convert the params JsonElement to our type using the same options
-            var jsonString = JsonSerializer.Serialize(request.Params, McpJsonUtilities.DefaultOptions.GetTypeInfo<object?>());
-            var typedRequest = JsonSerializer.Deserialize(jsonString, McpJsonUtilities.DefaultOptions.GetTypeInfo<TRequest>());
-
-            return await handler(typedRequest, cancellationToken).ConfigureAwait(false);
+            TRequest? typedRequest = JsonSerializer.Deserialize(request.Params, requestTypeInfo);
+            object? result = await handler(typedRequest, cancellationToken).ConfigureAwait(false);
+            return JsonSerializer.SerializeToNode(result, responseTypeInfo);
         };
     }
 }

--- a/src/ModelContextProtocol/Utils/Json/McpJsonUtilities.cs
+++ b/src/ModelContextProtocol/Utils/Json/McpJsonUtilities.cs
@@ -74,16 +74,6 @@ public static partial class McpJsonUtilities
     internal static JsonTypeInfo<T> GetTypeInfo<T>(this JsonSerializerOptions options) =>
         (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
 
-    internal static void ValidateSerializerOptions(JsonSerializerOptions options)
-    {
-        if (options.WriteIndented)
-        {
-            throw new InvalidOperationException("JsonSerializerOptions.WriteIndented is not supported for JSON-RPC workloads.");
-        }
-
-        options.MakeReadOnly();
-    }
-
     internal static JsonElement DefaultMcpToolSchema { get; } = ParseJsonElement("""{"type":"object"}"""u8);
     internal static object? AsObject(this JsonElement element) => element.ValueKind is JsonValueKind.Null ? null : element;
 

--- a/src/ModelContextProtocol/Utils/Json/McpJsonUtilities.cs
+++ b/src/ModelContextProtocol/Utils/Json/McpJsonUtilities.cs
@@ -75,6 +75,7 @@ public static partial class McpJsonUtilities
         (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
 
     internal static JsonElement DefaultMcpToolSchema { get; } = ParseJsonElement("""{"type":"object"}"""u8);
+    internal static object? AsObject(this JsonElement element) => element.ValueKind is JsonValueKind.Null ? null : element;
 
     internal static bool IsValidMcpToolSchema(JsonElement element)
     {
@@ -151,6 +152,7 @@ public static partial class McpJsonUtilities
     [JsonSerializable(typeof(SubscribeRequestParams))]
     [JsonSerializable(typeof(UnsubscribeFromResourceRequestParams))]
     [JsonSerializable(typeof(UnsubscribeRequestParams))]
+    [JsonSerializable(typeof(IReadOnlyDictionary<string, object>))]
 
     [ExcludeFromCodeCoverage]
     internal sealed partial class JsonContext : JsonSerializerContext;

--- a/src/ModelContextProtocol/Utils/Json/McpJsonUtilities.cs
+++ b/src/ModelContextProtocol/Utils/Json/McpJsonUtilities.cs
@@ -74,6 +74,16 @@ public static partial class McpJsonUtilities
     internal static JsonTypeInfo<T> GetTypeInfo<T>(this JsonSerializerOptions options) =>
         (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
 
+    internal static void ValidateSerializerOptions(JsonSerializerOptions options)
+    {
+        if (options.WriteIndented)
+        {
+            throw new InvalidOperationException("JsonSerializerOptions.WriteIndented is not supported for JSON-RPC workloads.");
+        }
+
+        options.MakeReadOnly();
+    }
+
     internal static JsonElement DefaultMcpToolSchema { get; } = ParseJsonElement("""{"type":"object"}"""u8);
     internal static object? AsObject(this JsonElement element) => element.ValueKind is JsonValueKind.Null ? null : element;
 

--- a/tests/ModelContextProtocol.TestServer/Program.cs
+++ b/tests/ModelContextProtocol.TestServer/Program.cs
@@ -79,11 +79,11 @@ internal static class Program
                     await server.SendMessageAsync(new JsonRpcNotification()
                     {
                         Method = NotificationMethods.LoggingMessageNotification,
-                        Params = new LoggingMessageNotificationParams
+                        Params = JsonSerializer.SerializeToNode(new LoggingMessageNotificationParams
                         {
                             Level = logLevel,
                             Data = JsonSerializer.Deserialize<JsonElement>("\"Random log message\"")
-                        }
+                        })
                     }, cancellationToken);
                 }
 
@@ -91,10 +91,10 @@ internal static class Program
                 foreach (var resource in _subscribedResources)
                 {
                     ResourceUpdatedNotificationParams notificationParams = new() { Uri = resource.Key };
-                    await server.SendMessageAsync(new JsonRpcNotification()
+                    await server.SendMessageAsync(new JsonRpcNotification
                     {
                         Method = NotificationMethods.ResourceUpdatedNotification,
-                        Params = notificationParams
+                        Params = JsonSerializer.SerializeToNode(notificationParams),
                     }, cancellationToken);
                 }
             }
@@ -168,7 +168,7 @@ internal static class Program
                     }
                     return new CallToolResponse()
                     {
-                        Content = [new Content() { Text = "Echo: " + message?.ToString(), Type = "text" }]
+                        Content = [new Content() { Text = "Echo: " + message.ToString(), Type = "text" }]
                     };
                 }
                 else if (request.Params?.Name == "sampleLLM")
@@ -179,7 +179,7 @@ internal static class Program
                     {
                         throw new McpServerException("Missing required arguments 'prompt' and 'maxTokens'");
                     }
-                    var sampleResult = await request.Server.RequestSamplingAsync(CreateRequestSamplingParams(prompt?.ToString() ?? "", "sampleLLM", Convert.ToInt32(maxTokens?.ToString())),
+                    var sampleResult = await request.Server.RequestSamplingAsync(CreateRequestSamplingParams(prompt.ToString(), "sampleLLM", Convert.ToInt32(maxTokens.GetRawText())),
                         cancellationToken);
 
                     return new CallToolResponse()

--- a/tests/ModelContextProtocol.TestSseServer/Program.cs
+++ b/tests/ModelContextProtocol.TestSseServer/Program.cs
@@ -175,7 +175,7 @@ public class Program
                         {
                             throw new McpServerException("Missing required arguments 'prompt' and 'maxTokens'");
                         }
-                        var sampleResult = await request.Server.RequestSamplingAsync(CreateRequestSamplingParams(prompt?.ToString() ?? "", "sampleLLM", Convert.ToInt32(maxTokens?.ToString())),
+                        var sampleResult = await request.Server.RequestSamplingAsync(CreateRequestSamplingParams(prompt.ToString(), "sampleLLM", Convert.ToInt32(maxTokens.ToString())),
                             cancellationToken);
 
                         return new CallToolResponse()

--- a/tests/ModelContextProtocol.Tests/Client/McpClientFactoryTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientFactoryTests.cs
@@ -1,8 +1,9 @@
-using System.Threading.Channels;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Protocol.Types;
+using System.Text.Json;
+using System.Threading.Channels;
 
 namespace ModelContextProtocol.Tests.Client;
 
@@ -206,16 +207,16 @@ public class McpClientFactoryTests
                     _channel.Writer.TryWrite(new JsonRpcResponse
                     {
                         Id = ((JsonRpcRequest)message).Id,
-                        Result = new InitializeResult()
+                        Result = JsonSerializer.SerializeToNode(new InitializeResult
                         {
                             Capabilities = new ServerCapabilities(),
                             ProtocolVersion = "2024-11-05",
-                            ServerInfo = new Implementation()
+                            ServerInfo = new Implementation
                             {
                                 Name = "NopTransport",
                                 Version = "1.0.0"
                             },
-                        }
+                        }),
                     });
                     break;
             }

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -88,7 +88,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
             {
                 ["message"] = "Hello MCP!"
             },
-            TestContext.Current.CancellationToken
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         // assert
@@ -140,7 +140,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
 
         // act
         await using var client = await _fixture.CreateClientAsync(clientId);
-        var result = await client.GetPromptAsync("simple_prompt", null, TestContext.Current.CancellationToken);
+        var result = await client.GetPromptAsync("simple_prompt", null, cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotNull(result);
@@ -160,7 +160,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
             { "temperature", "0.7" },
             { "style", "formal" }
         };
-        var result = await client.GetPromptAsync("complex_prompt", arguments, TestContext.Current.CancellationToken);
+        var result = await client.GetPromptAsync("complex_prompt", arguments, cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotNull(result);
@@ -176,7 +176,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
         // act
         await using var client = await _fixture.CreateClientAsync(clientId);
         await Assert.ThrowsAsync<McpClientException>(() =>
-            client.GetPromptAsync("non_existent_prompt", null, TestContext.Current.CancellationToken));
+            client.GetPromptAsync("non_existent_prompt", null, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Theory]
@@ -259,7 +259,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
         await using var client = await _fixture.CreateClientAsync(clientId);
         client.AddNotificationHandler(NotificationMethods.ResourceUpdatedNotification, (notification) =>
         {
-            var notificationParams = JsonSerializer.Deserialize<ResourceUpdatedNotificationParams>(notification.Params!.ToString() ?? string.Empty);
+            var notificationParams = JsonSerializer.Deserialize<ResourceUpdatedNotificationParams>(notification.Params);
             tcs.TrySetResult(true);
             return Task.CompletedTask;
         });
@@ -280,7 +280,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
         await using var client = await _fixture.CreateClientAsync(clientId);
         client.AddNotificationHandler(NotificationMethods.ResourceUpdatedNotification, (notification) =>
         {
-            var notificationParams = JsonSerializer.Deserialize<ResourceUpdatedNotificationParams>(notification.Params!.ToString() ?? string.Empty);
+            var notificationParams = JsonSerializer.Deserialize<ResourceUpdatedNotificationParams>(notification.Params);
             receivedNotification.TrySetResult(true);
             return Task.CompletedTask;
         });
@@ -381,7 +381,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
                 ["prompt"] = "Test prompt",
                 ["maxTokens"] = 100
             },
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotNull(result);
@@ -429,7 +429,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
 
         // Verify we can send notifications without errors
         await client.SendNotificationAsync(NotificationMethods.RootsUpdatedNotification, cancellationToken: TestContext.Current.CancellationToken);
-        await client.SendNotificationAsync("test/notification", new { test = true }, TestContext.Current.CancellationToken);
+        await client.SendNotificationAsync("test/notification", new { test = true }, cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         // no response to check, if no exception is thrown, it's a success
@@ -467,7 +467,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
         var result = await client.CallToolAsync(
             "read_graph",
             new Dictionary<string, object?>(),
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotNull(result);
@@ -529,7 +529,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
         var result = await client.CallToolAsync("sampleLLM", new Dictionary<string, object?>()
         {
             ["prompt"] = "In just a few words, what is the most famous tower in Paris?",
-        }, TestContext.Current.CancellationToken);
+        }, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.NotEmpty(result.Content);
@@ -556,8 +556,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
         await using var client = await _fixture.CreateClientAsync(clientId);
         client.AddNotificationHandler(NotificationMethods.LoggingMessageNotification, (notification) =>
         {
-            var loggingMessageNotificationParameters = JsonSerializer.Deserialize<LoggingMessageNotificationParams>(notification.Params!.ToString() ?? string.Empty,
-                jsonSerializerOptions);
+            var loggingMessageNotificationParameters = JsonSerializer.Deserialize<LoggingMessageNotificationParams>(notification.Params, jsonSerializerOptions);
             if (loggingMessageNotificationParameters is not null)
             {
                 receivedNotification.TrySetResult(true);

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -68,7 +68,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
 
         // act
         await using var client = await _fixture.CreateClientAsync(clientId);
-        var tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotEmpty(tools);
@@ -106,7 +106,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
 
         // act
         await using var client = await _fixture.CreateClientAsync(clientId);
-        var aiFunctions = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        var aiFunctions = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
         var echo = aiFunctions.Single(t => t.Name == "echo");
         var result = await echo.InvokeAsync([new KeyValuePair<string, object?>("message", "Hello MCP!")], TestContext.Current.CancellationToken);
 
@@ -485,7 +485,7 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
             _fixture.EverythingServerConfig, 
             _fixture.DefaultOptions, 
             cancellationToken: TestContext.Current.CancellationToken);
-        var mappedTools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        var mappedTools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // Create the chat client.
         using IChatClient chatClient = new OpenAIClient(s_openAIKey).AsChatClient("gpt-4o-mini")

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsPromptsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsPromptsTests.cs
@@ -154,7 +154,7 @@ public class McpServerBuilderExtensionsPromptsTests : LoggedTest, IAsyncDisposab
         var prompt = prompts.First(t => t.Name == nameof(SimplePrompts.ReturnsChatMessages));
         Assert.Equal("Returns chat messages", prompt.Description);
 
-        var result = await prompt.GetAsync(new Dictionary<string, object?>() { ["message"] = "hello" }, TestContext.Current.CancellationToken);
+        var result = await prompt.GetAsync(new Dictionary<string, object?>() { ["message"] = "hello" }, cancellationToken: TestContext.Current.CancellationToken);
         var chatMessages = result.ToChatMessages();
 
         Assert.NotNull(chatMessages);

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
@@ -172,7 +172,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
     {
         IMcpClient client = await CreateMcpClientForServer();
 
-        var tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(16, tools.Count);
 
         McpClientTool echoTool = tools.First(t => t.Name == "Echo");
@@ -217,7 +217,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
                 loggerFactory: LoggerFactory,
                 cancellationToken: TestContext.Current.CancellationToken))
             {
-                var tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+                var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
                 Assert.Equal(16, tools.Count);
 
                 McpClientTool echoTool = tools.First(t => t.Name == "Echo");
@@ -244,7 +244,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
     {
         IMcpClient client = await CreateMcpClientForServer();
 
-        var tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(16, tools.Count);
 
         Channel<JsonRpcNotification> listChanged = Channel.CreateUnbounded<JsonRpcNotification>();
@@ -265,7 +265,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
         serverTools.Add(newTool);
         await notificationRead;
 
-        tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(17, tools.Count);
         Assert.Contains(tools, t => t.Name == "NewTool");
 
@@ -274,7 +274,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
         serverTools.Remove(newTool);
         await notificationRead;
 
-        tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(16, tools.Count);
         Assert.DoesNotContain(tools, t => t.Name == "NewTool");
     }
@@ -536,7 +536,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
     {
         IMcpClient client = await CreateMcpClientForServer();
 
-        var tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(tools);
         Assert.NotEmpty(tools);
@@ -617,7 +617,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
             return Task.CompletedTask;
         });
 
-        var tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(tools);
         Assert.NotEmpty(tools);
 
@@ -651,7 +651,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
     {
         IMcpClient client = await CreateMcpClientForServer();
 
-        var tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(tools);
         Assert.NotEmpty(tools);
         McpClientTool cancelableTool = tools.First(t => t.Name == nameof(EchoTool.InfiniteCancelableOperation));

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
@@ -287,7 +287,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
         var result = await client.CallToolAsync(
             "Echo",
             new Dictionary<string, object?>() { ["message"] = "Peter" }, 
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Content);
@@ -305,7 +305,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
         var result = await client.CallToolAsync(
             "EchoArray",
             new Dictionary<string, object?>() { ["message"] = "Peter" },
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result.Content);
         Assert.NotEmpty(result.Content);
@@ -612,7 +612,7 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
         IMcpClient client = await CreateMcpClientForServer();
         client.AddNotificationHandler(NotificationMethods.ProgressNotification, notification =>
         {
-            ProgressNotification pn = JsonSerializer.Deserialize<ProgressNotification>((JsonElement)notification.Params!)!;
+            ProgressNotification pn = JsonSerializer.Deserialize<ProgressNotification>(notification.Params)!;
             notifications.Enqueue(pn);
             return Task.CompletedTask;
         });
@@ -623,15 +623,14 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
 
         McpClientTool progressTool = tools.First(t => t.Name == nameof(EchoTool.SendsProgressNotifications));
 
-        var result = await client.SendRequestAsync<CallToolResponse>(new JsonRpcRequest()
-        {
-            Method = RequestMethods.ToolsCall,
-            Params = new CallToolRequestParams()
+        var result = await client.SendRequestAsync<CallToolRequestParams, CallToolResponse>(
+            RequestMethods.ToolsCall,
+            new CallToolRequestParams
             {
                 Name = progressTool.ProtocolTool.Name,
                 Meta = new() { ProgressToken = new("abc123") },
             },
-        }, TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Contains("done", JsonSerializer.Serialize(result));
         SpinWait.SpinUntil(() => notifications.Count == 10, TimeSpan.FromSeconds(10));
@@ -658,12 +657,11 @@ public class McpServerBuilderExtensionsToolsTests : LoggedTest, IAsyncDisposable
         McpClientTool cancelableTool = tools.First(t => t.Name == nameof(EchoTool.InfiniteCancelableOperation));
 
         var requestId = new RequestId(Guid.NewGuid().ToString());
-        var invokeTask = client.SendRequestAsync<CallToolResponse>(new JsonRpcRequest()
-        {
-            Method = RequestMethods.ToolsCall,
-            Id = requestId,
-            Params = new CallToolRequestParams() { Name = cancelableTool.ProtocolTool.Name },
-        }, TestContext.Current.CancellationToken);
+        var invokeTask = client.SendRequestAsync<CallToolRequestParams, CallToolResponse>(
+            RequestMethods.ToolsCall,
+            new CallToolRequestParams { Name = cancelableTool.ProtocolTool.Name },
+            requestId: requestId,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await client.SendNotificationAsync(
             NotificationMethods.CancelledNotification,

--- a/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
+++ b/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
@@ -23,7 +23,7 @@ public class DiagnosticTests
         {
             await RunConnected(async (client, server) =>
             {
-                var tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+                var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
                 Assert.NotNull(tools);
                 Assert.NotEmpty(tools);
 

--- a/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
@@ -3,7 +3,6 @@ using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Tests.Utils;
-using System.Text.Json;
 
 namespace ModelContextProtocol.Tests;
 
@@ -41,7 +40,7 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
         await server.WaitForConnectionAsync(TimeSpan.FromSeconds(10));
 
         // Send a test message through POST endpoint
-        await client.SendNotificationAsync("test/message", new { message = "Hello, SSE!" }, TestContext.Current.CancellationToken);
+        await client.SendNotificationAsync("test/message", new { message = "Hello, SSE!" }, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(true);
@@ -145,7 +144,7 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
             {
                 ["prompt"] = "Test prompt",
                 ["maxTokens"] = 100
-            }, TestContext.Current.CancellationToken);
+            }, cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotNull(result);
@@ -188,7 +187,7 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
         await server.WaitForConnectionAsync(TimeSpan.FromSeconds(10));
 
         // Send a test message through POST endpoint
-        await client.SendNotificationAsync("test/message", new { message = "Hello, SSE!" }, TestContext.Current.CancellationToken);
+        await client.SendNotificationAsync("test/message", new { message = "Hello, SSE!" }, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(true);
@@ -229,7 +228,7 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
         var receivedNotification = new TaskCompletionSource<string?>();
         client.AddNotificationHandler("test/notification", (args) =>
             {
-                var msg = ((JsonElement?)args.Params)?.GetProperty("message").GetString();
+                var msg = args.Params?["message"]?.GetValue<string>();
                 receivedNotification.SetResult(msg);
 
                 return Task.CompletedTask;

--- a/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
@@ -77,7 +77,7 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
             defaultOptions, 
             loggerFactory: LoggerFactory,
             cancellationToken: TestContext.Current.CancellationToken);
-        var tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotEmpty(tools);

--- a/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
@@ -82,7 +82,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
             {
                 ["message"] = "Hello MCP!"
             },
-            TestContext.Current.CancellationToken
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         // assert
@@ -168,7 +168,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
 
         // act
         await using var client = await GetClientAsync();
-        var result = await client.GetPromptAsync("simple_prompt", null, TestContext.Current.CancellationToken);
+        var result = await client.GetPromptAsync("simple_prompt", null, cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotNull(result);
@@ -187,7 +187,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
             { "temperature", "0.7" },
             { "style", "formal" }
         };
-        var result = await client.GetPromptAsync("complex_prompt", arguments, TestContext.Current.CancellationToken);
+        var result = await client.GetPromptAsync("complex_prompt", arguments, cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotNull(result);
@@ -202,7 +202,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
         // act
         await using var client = await GetClientAsync();
         await Assert.ThrowsAsync<McpClientException>(() =>
-            client.GetPromptAsync("non_existent_prompt", null, TestContext.Current.CancellationToken));
+            client.GetPromptAsync("non_existent_prompt", null, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -238,7 +238,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
                 ["prompt"] = "Test prompt",
                 ["maxTokens"] = 100
             },
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotNull(result);
@@ -262,7 +262,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
                 {
                     ["message"] = $"Hello MCP! {i}"
                 },
-                TestContext.Current.CancellationToken
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
             Assert.NotNull(result);

--- a/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
@@ -63,7 +63,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
 
         // act
         await using var client = await GetClientAsync();
-        var tools = await client.ListToolsAsync(TestContext.Current.CancellationToken);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
         Assert.NotNull(tools);

--- a/tests/ModelContextProtocol.Tests/Transport/StdioServerTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioServerTransportTests.cs
@@ -8,6 +8,7 @@ using ModelContextProtocol.Utils.Json;
 using System.IO.Pipelines;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace ModelContextProtocol.Tests.Transport;
 
@@ -153,10 +154,10 @@ public class StdioServerTransportTests : LoggedTest
         {
             Method = "test",
             Id = new RequestId(44),
-            Params = new Dictionary<string, JsonElement>
+            Params = new JsonObject
             {
-                ["text"] = JsonSerializer.SerializeToElement(chineseText)
-            }
+                ["text"] = chineseText
+            },
         };
 
         // Clear output and send message
@@ -175,10 +176,10 @@ public class StdioServerTransportTests : LoggedTest
         {
             Method = "test",
             Id = new RequestId(45),
-            Params = new Dictionary<string, JsonElement>
+            Params = new JsonObject
             {
-                ["text"] = JsonSerializer.SerializeToElement(emojiText)
-            }
+                ["text"] = emojiText
+            },
         };
 
         // Clear output and send message

--- a/tests/ModelContextProtocol.Tests/Utils/InMemoryTestSseServer.cs
+++ b/tests/ModelContextProtocol.Tests/Utils/InMemoryTestSseServer.cs
@@ -289,7 +289,7 @@ public sealed class InMemoryTestSseServer : IAsyncDisposable
         var jsonRpcResponse = new JsonRpcResponse()
         {
             Id = jsonRpcRequest.Id,
-            Result = new InitializeResult()
+            Result = JsonSerializer.SerializeToNode(new InitializeResult
             {
                 ProtocolVersion = "2024-11-05",
                 Capabilities = new(),
@@ -298,7 +298,7 @@ public sealed class InMemoryTestSseServer : IAsyncDisposable
                     Name = "ExampleServer",
                     Version = "1.0.0"
                 }
-            }
+            })
         };
 
         // Echo back to the HTTP response
@@ -369,7 +369,7 @@ public sealed class InMemoryTestSseServer : IAsyncDisposable
         {
             JsonRpc = "2.0",
             Method = "test/notification",
-            Params = new { message = content }
+            Params = JsonSerializer.SerializeToNode(new { message = content }),
         };
 
         var serialized = JsonSerializer.Serialize(notification);

--- a/tests/ModelContextProtocol.Tests/Utils/TestServerTransport.cs
+++ b/tests/ModelContextProtocol.Tests/Utils/TestServerTransport.cs
@@ -1,7 +1,8 @@
-﻿using System.Threading.Channels;
-using ModelContextProtocol.Protocol.Messages;
+﻿using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Protocol.Types;
+using System.Text.Json;
+using System.Threading.Channels;
 
 namespace ModelContextProtocol.Tests.Utils;
 
@@ -59,10 +60,10 @@ public class TestServerTransport : ITransport
         await WriteMessageAsync(new JsonRpcResponse
         {
             Id = request.Id,
-            Result = new ModelContextProtocol.Protocol.Types.ListRootsResult
+            Result = JsonSerializer.SerializeToNode(new ListRootsResult
             {
                 Roots = []
-            }
+            }),
         }, cancellationToken);
     }
 
@@ -71,7 +72,7 @@ public class TestServerTransport : ITransport
         await WriteMessageAsync(new JsonRpcResponse
         {
             Id = request.Id,
-            Result = new CreateMessageResult { Content = new(), Model = "model", Role = "role" }
+            Result = JsonSerializer.SerializeToNode(new CreateMessageResult { Content = new(), Model = "model", Role = "role" }),
         }, cancellationToken);
     }
 


### PR DESCRIPTION
This PR updates the JSON serialization aspects of the `IMcpClient` and `IMcpServer` abstractions in the following ways:

* Removes serialization concerns from the core `IMcpEndpoint` signature by making its `SendRequestAsync` non generic.
* JSON-RPC parameter and result serialization is now exclusively handled using extension methods over the abstractions.
* Extension methods accepting user-defined objects now accept an optional `JsonSerializerOptions` overload that can be used to override serialization settings.
* Serialization of the built-in implementations now hardcode to the source generator where applicable.