### PR TITLE
Write "event: message" to SSE response

### DIFF
--- a/src/ModelContextProtocol/Client/McpClient.cs
+++ b/src/ModelContextProtocol/Client/McpClient.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 namespace ModelContextProtocol.Client;
 
 /// <inheritdoc/>
-internal sealed class McpClient : McpJsonRpcEndpoint, IMcpClient
+internal sealed class McpClient : McpEndpoint, IMcpClient
 {
     private readonly IClientTransport _clientTransport;
     private readonly McpClientOptions _options;

--- a/src/ModelContextProtocol/Configuration/McpServerConfig.cs
+++ b/src/ModelContextProtocol/Configuration/McpServerConfig.cs
@@ -28,11 +28,6 @@ public record McpServerConfig
     public string? Location { get; set; }
 
     /// <summary>
-    /// Arguments (if any) to pass to the executable.
-    /// </summary>
-    public string[]? Arguments { get; init; }
-
-    /// <summary>
     /// Additional transport-specific configuration.
     /// </summary>
     public Dictionary<string, string>? TransportOptions { get; init; }

--- a/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
@@ -76,7 +76,8 @@ public sealed class SseResponseStreamTransport(Stream sseResponseStream, string 
             throw new InvalidOperationException($"Transport is not connected. Make sure to call {nameof(RunAsync)} first.");
         }
 
-        await _outgoingSseChannel.Writer.WriteAsync(new SseItem<IJsonRpcMessage?>(message), cancellationToken);
+        // Emit redundant "event: message" lines for better compatibility with other SDKs.
+        await _outgoingSseChannel.Writer.WriteAsync(new SseItem<IJsonRpcMessage?>(message, "message"), cancellationToken);
     }
 
     /// <summary>

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -9,7 +9,7 @@ using System.Text.Json.Nodes;
 namespace ModelContextProtocol.Server;
 
 /// <inheritdoc />
-internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
+internal sealed class McpServer : McpEndpoint, IMcpServer
 {
     private readonly EventHandler? _toolsChangedDelegate;
     private readonly EventHandler? _promptsChangedDelegate;

--- a/src/ModelContextProtocol/Shared/McpEndpoint.cs
+++ b/src/ModelContextProtocol/Shared/McpEndpoint.cs
@@ -15,7 +15,7 @@ namespace ModelContextProtocol.Shared;
 /// This is especially true as a client represents a connection to one and only one server, and vice versa.
 /// Any multi-client or multi-server functionality should be implemented at a higher level of abstraction.
 /// </summary>
-internal abstract class McpJsonRpcEndpoint : IAsyncDisposable
+internal abstract class McpEndpoint : IAsyncDisposable
 {
     private readonly RequestHandlers _requestHandlers = [];
     private readonly NotificationHandlers _notificationHandlers = [];
@@ -29,10 +29,10 @@ internal abstract class McpJsonRpcEndpoint : IAsyncDisposable
     protected readonly ILogger _logger;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="McpJsonRpcEndpoint"/> class.
+    /// Initializes a new instance of the <see cref="McpEndpoint"/> class.
     /// </summary>
     /// <param name="loggerFactory">The logger factory.</param>
-    protected McpJsonRpcEndpoint(ILoggerFactory? loggerFactory = null)
+    protected McpEndpoint(ILoggerFactory? loggerFactory = null)
     {
         _logger = loggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance;
     }
@@ -57,7 +57,7 @@ internal abstract class McpJsonRpcEndpoint : IAsyncDisposable
     /// <summary>
     /// Task that processes incoming messages from the transport.
     /// </summary>
-    protected Task? MessageProcessingTask { get; set; }
+    protected Task? MessageProcessingTask { get; private set; }
 
     [MemberNotNull(nameof(MessageProcessingTask))]
     protected void StartSession(ITransport sessionTransport)

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -29,7 +29,7 @@ internal sealed class McpSession : IDisposable
     private readonly ConcurrentDictionary<RequestId, CancellationTokenSource> _handlingRequests = new();
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly ILogger _logger;
-    
+
     private readonly string _id = Guid.NewGuid().ToString("N");
     private long _nextRequestId;
 
@@ -371,7 +371,7 @@ internal sealed class McpSession : IDisposable
                 default:
                     return JsonSerializer.Deserialize(
                         JsonSerializer.Serialize(notificationParams, McpJsonUtilities.DefaultOptions.GetTypeInfo<object?>()),
-                        McpJsonUtilities.DefaultOptions.GetTypeInfo<CancelledNotification>());
+                            McpJsonUtilities.DefaultOptions.GetTypeInfo<CancelledNotification>());
             }
         }
         catch

--- a/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
@@ -1,6 +1,8 @@
 ﻿using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Tests.Utils;
+using System.Net;
+using System.Text;
 
 namespace ModelContextProtocol.Tests;
 
@@ -29,6 +31,12 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
             loggerFactory: LoggerFactory,
             cancellationToken: TestContext.Current.CancellationToken);
     }
+
+    private HttpClient GetHttpClient() =>
+        new()
+        {
+            BaseAddress = new(_fixture.DefaultConfig.Location!),
+        };
 
     [Fact]
     public async Task ConnectAndPing_Sse_TestServer()
@@ -270,5 +278,47 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
             var textContent = Assert.Single(result.Content, c => c.Type == "text");
             Assert.Equal($"Echo: Hello MCP! {i}", textContent.Text);
         }
+    }
+
+    [Fact]
+    public async Task EventSourceStream_Includes_MessageEventType()
+    {
+        // Simulate our own MCP client handshake using a plain HttpClient so we can look for "event: message"
+        // in the raw SSE response stream which is not exposed by the real MCP client.
+        using var httpClient = GetHttpClient();
+        await using var sseResponse = await httpClient.GetStreamAsync("", TestContext.Current.CancellationToken);
+        using var streamReader = new StreamReader(sseResponse);
+
+        // read event stream from the server
+        var endpointEvent = await streamReader.ReadLineAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("event: endpoint", endpointEvent);
+
+        var endpointData = await streamReader.ReadLineAsync(TestContext.Current.CancellationToken);
+        Assert.NotNull(endpointData);
+        Assert.StartsWith("data: ", endpointData);
+        var messageEndpoint = endpointData["data: ".Length..];
+
+        const string initializeRequest = """
+            {"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"IntegrationTestClient","version":"1.0.0"}}}
+            """;
+        using (var initializeRequestBody = new StringContent(initializeRequest, Encoding.UTF8, "application/json"))
+        {
+            var response = await httpClient.PostAsync(messageEndpoint, initializeRequestBody, TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        }
+
+        const string initializeNotification = """
+            {"jsonrpc":"2.0","method":"notifications/initialized"}
+            """;
+        using (var initializeNotificationBody = new StringContent(initializeNotification, Encoding.UTF8, "application/json"))
+        {
+            var response = await httpClient.PostAsync(messageEndpoint, initializeNotificationBody, TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        }
+
+        // read event stream from the server
+        Assert.Equal("", await streamReader.ReadLineAsync(TestContext.Current.CancellationToken));
+        var messageEvent = await streamReader.ReadLineAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("event: message", messageEvent);
     }
 }


### PR DESCRIPTION
Even though this wastes a few more bytes per message in the SSE response stream, this appears to be the way to send SSE message events that's most compatible with existing MCP clients.

I also took the opportunity to rename McpJsonRpcEndpoint to just McpEndpoint. I wanted to do that in my earlier refactoring PR that split a lot of it out into McpSession, but I was trying to keep that change as small as I could. I don't think it's worth a whole PR just to rename it now though.

Lastly, I removed the unused McpServerConfig.Arguments property. Arguments are now passed in via McpServerConfig.TransportOptions["arguments"] instead.