### PR TITLE
Changed the name of the ActivitySource and Metric to clarify that the semantic conventions have not been ratified yet.

### DIFF
--- a/src/ModelContextProtocol/Diagnostics.cs
+++ b/src/ModelContextProtocol/Diagnostics.cs
@@ -5,7 +5,7 @@ namespace ModelContextProtocol;
 
 internal static class Diagnostics
 {
-    internal static ActivitySource ActivitySource { get; } = new("Exprimental.ModelContextProtocol");
+    internal static ActivitySource ActivitySource { get; } = new("Experimental.ModelContextProtocol");
 
     /// <summary>
     /// Follows boundaries from http.server.request.duration/http.client.request.duration

--- a/src/ModelContextProtocol/Diagnostics.cs
+++ b/src/ModelContextProtocol/Diagnostics.cs
@@ -5,7 +5,7 @@ namespace ModelContextProtocol;
 
 internal static class Diagnostics
 {
-    internal static ActivitySource ActivitySource { get; } = new("ModelContextProtocol");
+    internal static ActivitySource ActivitySource { get; } = new("Exprimental.ModelContextProtocol");
 
     /// <summary>
     /// Follows boundaries from http.server.request.duration/http.client.request.duration
@@ -24,6 +24,6 @@ internal static class Diagnostics
         HistogramBucketBoundaries = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300],
     };
 
-    internal static Meter Meter { get; } = new("ModelContextProtocol");
+    internal static Meter Meter { get; } = new("Experimental.ModelContextProtocol");
 
 }

--- a/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
+++ b/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
@@ -17,7 +17,7 @@ public class DiagnosticTests
         var activities = new List<Activity>();
 
         using (var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
-            .AddSource("ModelContextProtocol")
+            .AddSource("Experimental.ModelContextProtocol")
             .AddInMemoryExporter(activities)
             .Build())
         {


### PR DESCRIPTION
## Summary

Prepended the name of the ActivitySource and Metric with Experimental.



## Motivation and Context
We have a pattern in the .NET SDK to prepend the namespaces for telemetry with "Experimental" when the semantic conventions are not yet finalized, and so what the source emits are subject to change when the standard is finalized.

## How Has This Been Tested?
Run the tests from VS test explorer

## Breaking Changes
Yes, if they have consumed telemetry in the hours since #183 was merged.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
