### PR TITLE
Added `TcpServerTransport`

### DIFF
--- a/src/ModelContextProtocol/Configuration/McpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol/Configuration/McpServerBuilderExtensions.cs
@@ -354,18 +354,15 @@ public static partial class McpServerBuilderExtensions
     /// Adds a server transport that uses TCP connection for communication.
     /// </summary>
     /// <param name="builder">The builder instance.</param>
-    /// <param name="options">The options to configure the transport.</param>
-    public static IMcpServerBuilder WithTcpServerTransport(this IMcpServerBuilder builder, McpServerTcpTransportOptions? options = null)
+    /// <param name="configureOptions">The options to configure the transport.</param>
+    public static IMcpServerBuilder WithTcpServerTransport(this IMcpServerBuilder builder, Action<McpServerTcpTransportOptions>? configureOptions = null)
     {
         Throw.IfNull(builder);
 
-        options ??= McpServerTcpTransportOptions.Default;
-
-        builder.Services.Configure<McpServerTcpTransportOptions>(opts =>
+        if (configureOptions != null)
         {
-            opts.IpAddress = options.IpAddress;
-            opts.Port = options.Port;
-        });
+            builder.Services.Configure(configureOptions);
+        }
 
         builder.Services.AddSingleton<ITransport, TcpServerTransport>(services =>
         {

--- a/src/ModelContextProtocol/Configuration/McpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol/Configuration/McpServerBuilderExtensions.cs
@@ -350,5 +350,27 @@ public static partial class McpServerBuilderExtensions
 
         return builder;
     }
+    /// <summary>
+    /// Adds a server transport that uses stdin/stdout for communication.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    public static IMcpServerBuilder WithTcpServerTransport(this IMcpServerBuilder builder)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.AddSingleton<ITransport, TcpServerTransport>();
+        builder.Services.AddHostedService<TcpMcpServerHostedService>();
+
+        builder.Services.AddSingleton(services =>
+        {
+            ITransport serverTransport = services.GetRequiredService<ITransport>();
+            IOptions<McpServerOptions> options = services.GetRequiredService<IOptions<McpServerOptions>>();
+            ILoggerFactory? loggerFactory = services.GetService<ILoggerFactory>();
+
+            return McpServerFactory.Create(serverTransport, options.Value, loggerFactory, services);
+        });
+
+        return builder;
+    }
     #endregion
 }

--- a/src/ModelContextProtocol/Hosting/TcpMcpServerHostedService.cs
+++ b/src/ModelContextProtocol/Hosting/TcpMcpServerHostedService.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Hosting;
+using ModelContextProtocol.Server;
+
+namespace ModelContextProtocol.Hosting;
+
+/// <summary>
+/// Hosted service for a single-session (i.e stdio) MCP server.
+/// </summary>
+internal sealed class TcpMcpServerHostedService(IMcpServer session) : BackgroundService
+{
+    /// <inheritdoc />
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) => session.RunAsync(stoppingToken);
+}

--- a/src/ModelContextProtocol/Hosting/TcpMcpServerHostedService.cs
+++ b/src/ModelContextProtocol/Hosting/TcpMcpServerHostedService.cs
@@ -4,7 +4,7 @@ using ModelContextProtocol.Server;
 namespace ModelContextProtocol.Hosting;
 
 /// <summary>
-/// Hosted service for a single-session (i.e stdio) MCP server.
+/// Hosted service for a single-session (i.e TCP) MCP server.
 /// </summary>
 internal sealed class TcpMcpServerHostedService(IMcpServer session) : BackgroundService
 {

--- a/src/ModelContextProtocol/Protocol/Transport/TcpServerTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/TcpServerTransport.cs
@@ -1,0 +1,217 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Logging;
+using ModelContextProtocol.Protocol.Messages;
+using ModelContextProtocol.Utils;
+using ModelContextProtocol.Utils.Json;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+
+namespace ModelContextProtocol.Protocol.Transport;
+
+/// <summary>
+/// Provides a server MCP transport implemented around a TCP connection.
+/// </summary>
+public class TcpServerTransport : TransportBase, ITransport
+{
+    private static readonly byte[] s_newlineBytes = "\n"u8.ToArray();
+
+    private readonly ILogger _logger;
+    private readonly TcpListener _tcpListener;
+    private readonly string _endpointName;
+
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private readonly CancellationTokenSource _shutdownCts = new();
+
+    private readonly Task _readLoopCompleted;
+    private NetworkStream? _networkStream;
+    private StreamReader? _inputReader;
+    private Stream? _outputStream;
+    private int _disposed = 0;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TcpServerTransport"/> class.
+    /// </summary>
+    /// <param name="port">The port to listen on.</param>
+    /// <param name="serverName">Optional name of the server, used for diagnostic purposes, like logging.</param>
+    /// <param name="loggerFactory">Optional logger factory used for logging employed by the transport.</param>
+    public TcpServerTransport(int port, string? serverName = null, ILoggerFactory? loggerFactory = null)
+        : base(loggerFactory)
+    {
+        _logger = loggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance;
+
+        _tcpListener = new TcpListener(IPAddress.Any, port);
+        _tcpListener.Start();
+
+        _endpointName = serverName is not null ? $"Server (TCP) ({serverName})" : "Server (TCP)";
+        _readLoopCompleted = Task.Run(AcceptAndReadMessagesAsync, _shutdownCts.Token);
+    }
+
+    /// <inheritdoc/>
+    public override async Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
+    {
+        if (!IsConnected)
+        {
+            _logger.TransportNotConnected(_endpointName);
+            throw new McpTransportException("Transport is not connected");
+        }
+
+        using var _ = await _sendLock.LockAsync(cancellationToken).ConfigureAwait(false);
+
+        string id = "(no id)";
+        if (message is IJsonRpcMessageWithId messageWithId)
+        {
+            id = messageWithId.Id.ToString();
+        }
+
+        try
+        {
+            _logger.TransportSendingMessage(_endpointName, id);
+
+            await JsonSerializer.SerializeAsync(_outputStream!, message, McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(IJsonRpcMessage)), cancellationToken).ConfigureAwait(false);
+            await _outputStream!.WriteAsync(s_newlineBytes, cancellationToken).ConfigureAwait(false);
+            await _outputStream!.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.TransportSentMessage(_endpointName, id);
+        }
+        catch (Exception ex)
+        {
+            _logger.TransportSendFailed(_endpointName, id, ex);
+            throw new McpTransportException("Failed to send message", ex);
+        }
+    }
+
+    private async Task AcceptAndReadMessagesAsync()
+    {
+        CancellationToken shutdownToken = _shutdownCts.Token;
+        try
+        {
+            _logger.TransportEnteringReadMessagesLoop(_endpointName);
+
+            while (!shutdownToken.IsCancellationRequested)
+            {
+                _logger.TransportReadingMessages(_endpointName);
+
+                var client = await _tcpListener.AcceptTcpClientAsync().ConfigureAwait(false);
+                _networkStream = client.GetStream();
+                _inputReader = new StreamReader(_networkStream, Encoding.UTF8);
+                _outputStream = _networkStream;
+
+                SetConnected(true);
+                _logger.TransportAlreadyConnected(_endpointName);
+
+                while (!shutdownToken.IsCancellationRequested)
+                {
+                    var line = await _inputReader.ReadLineAsync(shutdownToken).ConfigureAwait(false);
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        if (line is null)
+                        {
+                            _logger.TransportEndOfStream(_endpointName);
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    _logger.TransportReceivedMessage(_endpointName, line);
+
+                    try
+                    {
+                        if (JsonSerializer.Deserialize(line, McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(IJsonRpcMessage))) is IJsonRpcMessage message)
+                        {
+                            string messageId = "(no id)";
+                            if (message is IJsonRpcMessageWithId messageWithId)
+                            {
+                                messageId = messageWithId.Id.ToString();
+                            }
+                            _logger.TransportReceivedMessageParsed(_endpointName, messageId);
+
+                            await WriteMessageAsync(message, shutdownToken).ConfigureAwait(false);
+                            _logger.TransportMessageWritten(_endpointName, messageId);
+                        }
+                        else
+                        {
+                            _logger.TransportMessageParseUnexpectedType(_endpointName, line);
+                        }
+                    }
+                    catch (JsonException ex)
+                    {
+                        _logger.TransportMessageParseFailed(_endpointName, line, ex);
+                        // Continue reading even if we fail to parse a message
+                    }
+                }
+
+                client.Close();
+                SetConnected(false);
+            }
+
+            _logger.TransportExitingReadMessagesLoop(_endpointName);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.TransportReadMessagesCancelled(_endpointName);
+        }
+        catch (Exception ex)
+        {
+            _logger.TransportReadMessagesFailed(_endpointName, ex);
+        }
+        finally
+        {
+            SetConnected(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            _logger.TransportCleaningUp(_endpointName);
+
+            // Signal to the read loop to stop.
+            await _shutdownCts.CancelAsync().ConfigureAwait(false);
+            _shutdownCts.Dispose();
+
+            // Dispose of network resources.
+            _inputReader?.Dispose();
+            _outputStream?.Dispose();
+            _networkStream?.Dispose();
+            _tcpListener.Stop();
+
+            // Make sure the work has quiesced.
+            try
+            {
+                _logger.TransportWaitingForReadTask(_endpointName);
+                await _readLoopCompleted.ConfigureAwait(false);
+                _logger.TransportReadTaskCleanedUp(_endpointName);
+            }
+            catch (TimeoutException)
+            {
+                _logger.TransportCleanupReadTaskTimeout(_endpointName);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.TransportCleanupReadTaskCancelled(_endpointName);
+            }
+            catch (Exception ex)
+            {
+                _logger.TransportCleanupReadTaskFailed(_endpointName, ex);
+            }
+        }
+        finally
+        {
+            SetConnected(false);
+            _logger.TransportCleanedUp(_endpointName);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/ModelContextProtocol/Protocol/Transport/TcpServerTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/TcpServerTransport.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Logging;
 using ModelContextProtocol.Protocol.Messages;
+using ModelContextProtocol.Server;
 using ModelContextProtocol.Utils;
 using ModelContextProtocol.Utils.Json;
 using System.Net;
@@ -34,18 +35,17 @@ public class TcpServerTransport : TransportBase, ITransport
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpServerTransport"/> class.
     /// </summary>
-    /// <param name="port">The port to listen on.</param>
-    /// <param name="serverName">Optional name of the server, used for diagnostic purposes, like logging.</param>
+    /// <param name="options">Configuration options for the transport.</param>
     /// <param name="loggerFactory">Optional logger factory used for logging employed by the transport.</param>
-    public TcpServerTransport(int port, string? serverName = null, ILoggerFactory? loggerFactory = null)
+    public TcpServerTransport(McpServerTcpTransportOptions options, ILoggerFactory? loggerFactory = null)
         : base(loggerFactory)
     {
         _logger = loggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance;
 
-        _tcpListener = new TcpListener(IPAddress.Any, port);
+        _tcpListener = new TcpListener(options.IpAddress, options.Port);
         _tcpListener.Start();
 
-        _endpointName = serverName is not null ? $"Server (TCP) ({serverName})" : "Server (TCP)";
+        _endpointName = $"Server (TCP) ({options.IpAddress})";
         _readLoopCompleted = Task.Run(AcceptAndReadMessagesAsync, _shutdownCts.Token);
     }
 

--- a/src/ModelContextProtocol/Server/McpServerTcpTransportOptions.cs
+++ b/src/ModelContextProtocol/Server/McpServerTcpTransportOptions.cs
@@ -10,19 +10,10 @@ public class McpServerTcpTransportOptions
     /// <summary>
     /// The TCP port to listen on.
     /// </summary>
-    public required int Port { get; set; }
+    public required int Port { get; set; } = 60606;
 
     /// <summary>
     /// The TCP host to listen on. This is typically the IP address of the server. If not specified, the server will listen on all available network interfaces.
     /// </summary>
-    public required IPAddress IpAddress { get; set; }
-
-    /// <summary>
-    /// Default options for the TCP server transport.
-    /// </summary>
-    public static McpServerTcpTransportOptions Default => new McpServerTcpTransportOptions
-    {
-        Port = 60606,
-        IpAddress = IPAddress.Any
-    };
+    public required IPAddress IpAddress { get; set; } = IPAddress.Any;
 }

--- a/src/ModelContextProtocol/Server/McpServerTcpTransportOptions.cs
+++ b/src/ModelContextProtocol/Server/McpServerTcpTransportOptions.cs
@@ -1,0 +1,28 @@
+﻿using System.Net;
+
+namespace ModelContextProtocol.Server;
+
+/// <summary>
+/// Configuration options for the TcpServerTransport.
+/// </summary>
+public class McpServerTcpTransportOptions
+{
+    /// <summary>
+    /// The TCP port to listen on.
+    /// </summary>
+    public required int Port { get; set; }
+
+    /// <summary>
+    /// The TCP host to listen on. This is typically the IP address of the server. If not specified, the server will listen on all available network interfaces.
+    /// </summary>
+    public required IPAddress IpAddress { get; set; }
+
+    /// <summary>
+    /// Default options for the TCP server transport.
+    /// </summary>
+    public static McpServerTcpTransportOptions Default => new McpServerTcpTransportOptions
+    {
+        Port = 60606,
+        IpAddress = IPAddress.Any
+    };
+}

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsTransportsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsTransportsTests.cs
@@ -19,4 +19,17 @@ public class McpServerBuilderExtensionsTransportsTests
         Assert.NotNull(transportType);
         Assert.Equal(typeof(StdioServerTransport), transportType.ImplementationType);
     }
+    [Fact]
+    public void WithTcpServerTransport_Sets_Transport()
+    {
+        var services = new ServiceCollection();
+        var builder = new Mock<IMcpServerBuilder>();
+        builder.SetupGet(b => b.Services).Returns(services);
+
+        builder.Object.WithTcpServerTransport();
+
+        var transportType = services.FirstOrDefault(s => s.ServiceType == typeof(ITransport));
+        Assert.NotNull(transportType);
+        Assert.Equal(typeof(TcpServerTransport), transportType.ImplementationType);
+    }
 }

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsTransportsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsTransportsTests.cs
@@ -1,6 +1,7 @@
 ﻿using ModelContextProtocol.Protocol.Transport;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using System.Net;
 
 namespace ModelContextProtocol.Tests.Configuration;
 
@@ -27,6 +28,23 @@ public class McpServerBuilderExtensionsTransportsTests
         builder.SetupGet(b => b.Services).Returns(services);
 
         builder.Object.WithTcpServerTransport();
+
+        var transportType = services.FirstOrDefault(s => s.ServiceType == typeof(ITransport));
+        Assert.NotNull(transportType);
+        Assert.Equal(typeof(TcpServerTransport), transportType.ImplementationType);
+    }
+    [Fact]
+    public void WithTcpServerTransport_Sets_Transport_Options()
+    {
+        var services = new ServiceCollection();
+        var builder = new Mock<IMcpServerBuilder>();
+        builder.SetupGet(b => b.Services).Returns(services);
+
+        builder.Object.WithTcpServerTransport(options =>
+        {
+            options.Port = 12345;
+            options.IpAddress = IPAddress.Parse("127.0.0.1");
+        });
 
         var transportType = services.FirstOrDefault(s => s.ServiceType == typeof(ITransport));
         Assert.NotNull(transportType);


### PR DESCRIPTION
- Added `TcpServerTransport`
- Added `.WithTcpServerTransport()` for building MCP Server with TCP support
- Added test that is testing `WithTcpServerTransport` function

## Motivation and Context
1. My primary goal is to build [Unity-MCP](https://github.com/IvanMurzak/Unity-MCP) that may be connected with Claude Desktop. Unity Editor environment has a .NET sandbox that doesn't allow to use STDIO stream. 
2. To make Unity-MCP-Runtime package for Unity Engine that would allow to implement MCP server into a player's build.
3. TCP connection works fine in the same time. Also TCP connection could be more flexible for connecting to a wider range of apps. This PR covers this [issue](https://github.com/modelcontextprotocol/csharp-sdk/issues/196).


## How Has This Been Tested?
I added tests to cover TCP Protocol. All of them passed.

## Breaking Changes
- none

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
