### PR TITLE
Hardcode the source generator in one remaining location and simplify McpJsonUtilities.

### DIFF
--- a/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseResponseStreamTransport.cs
@@ -53,7 +53,7 @@ public sealed class SseResponseStreamTransport(Stream sseResponseStream, string 
             return;
         }
 
-        JsonSerializer.Serialize(GetUtf8JsonWriter(writer), item.Data, McpJsonUtilities.DefaultOptions.GetTypeInfo<IJsonRpcMessage?>());
+        JsonSerializer.Serialize(GetUtf8JsonWriter(writer), item.Data, McpJsonUtilities.JsonContext.Default.IJsonRpcMessage);
     }
 
     /// <inheritdoc/>

--- a/tests/ModelContextProtocol.Tests/McpJsonUtilitiesTests.cs
+++ b/tests/ModelContextProtocol.Tests/McpJsonUtilitiesTests.cs
@@ -1,0 +1,28 @@
+﻿using ModelContextProtocol.Utils.Json;
+using System.Text.Json;
+
+namespace ModelContextProtocol.Tests;
+
+public static class McpJsonUtilitiesTests
+{
+    [Fact]
+    public static void DefaultOptions_IsSingleton()
+    {
+        var options = McpJsonUtilities.DefaultOptions;
+
+        Assert.NotNull(options);
+        Assert.True(options.IsReadOnly);
+        Assert.Same(options, McpJsonUtilities.DefaultOptions);
+    }
+
+    [Fact]
+    public static void DefaultOptions_UseReflectionWhenEnabled()
+    {
+        var options = McpJsonUtilities.DefaultOptions;
+        bool isReflectionEnabled = JsonSerializer.IsReflectionEnabledByDefault;
+        Type anonType = new { Id = 42 }.GetType();
+
+        Assert.True(isReflectionEnabled); // To be disabled once https://github.com/dotnet/extensions/pull/6241 is incorporated
+        Assert.Equal(isReflectionEnabled, options.TryGetTypeInfo(anonType, out _));
+    }
+}


### PR DESCRIPTION
Following up on https://github.com/modelcontextprotocol/csharp-sdk/pull/182 this PR hardcodes the source generator in one location that got missed due to merge conflicts. It also mirrors a few changes that are being made in https://github.com/dotnet/extensions/pull/6241.