### PR TITLE
Move notification handler registrations to capabilities

### DIFF
--- a/samples/QuickstartWeatherServer/Tools/WeatherTools.cs
+++ b/samples/QuickstartWeatherServer/Tools/WeatherTools.cs
@@ -1,7 +1,6 @@
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
-using System.Net.Http.Json;
 using System.Text.Json;
 
 namespace QuickstartWeatherServer.Tools;

--- a/src/ModelContextProtocol/Client/McpClientFactory.cs
+++ b/src/ModelContextProtocol/Client/McpClientFactory.cs
@@ -12,23 +12,6 @@ namespace ModelContextProtocol.Client;
 /// <summary>Provides factory methods for creating MCP clients.</summary>
 public static class McpClientFactory
 {
-    /// <summary>Default client options to use when none are supplied.</summary>
-    private static readonly McpClientOptions s_defaultClientOptions = CreateDefaultClientOptions();
-
-    /// <summary>Creates default client options to use when no options are supplied.</summary>
-    private static McpClientOptions CreateDefaultClientOptions()
-    {
-        var asmName = (Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly()).GetName();
-        return new()
-        {
-            ClientInfo = new()
-            {
-                Name = asmName.Name ?? "McpClient",
-                Version = asmName.Version?.ToString() ?? "1.0.0",
-            },
-        };
-    }
-
     /// <summary>Creates an <see cref="IMcpClient"/>, connecting it to the specified server.</summary>
     /// <param name="serverConfig">Configuration for the target server to which the client should connect.</param>
     /// <param name="clientOptions">
@@ -52,7 +35,6 @@ public static class McpClientFactory
     {
         Throw.IfNull(serverConfig);
 
-        clientOptions ??= s_defaultClientOptions;
         createTransportFunc ??= CreateTransport;
         
         string endpointName = $"Client ({serverConfig.Id}: {serverConfig.Name})";

--- a/src/ModelContextProtocol/Client/McpClientFactory.cs
+++ b/src/ModelContextProtocol/Client/McpClientFactory.cs
@@ -5,7 +5,6 @@ using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Utils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.Reflection;
 
 namespace ModelContextProtocol.Client;
 

--- a/src/ModelContextProtocol/Client/McpClientOptions.cs
+++ b/src/ModelContextProtocol/Client/McpClientOptions.cs
@@ -12,7 +12,7 @@ public class McpClientOptions
     /// <summary>
     /// Information about this client implementation.
     /// </summary>
-    public required Implementation ClientInfo { get; set; }
+    public Implementation? ClientInfo { get; set; }
 
     /// <summary>
     /// Client capabilities to advertise to the server.
@@ -28,4 +28,14 @@ public class McpClientOptions
     /// Timeout for initialization sequence.
     /// </summary>
     public TimeSpan InitializationTimeout { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>Creates a shallow clone of the options.</summary>
+    internal McpClientOptions Clone() =>
+        new()
+        {
+            ClientInfo = ClientInfo,
+            Capabilities = Capabilities,
+            ProtocolVersion = ProtocolVersion,
+            InitializationTimeout = InitializationTimeout
+        };
 }

--- a/src/ModelContextProtocol/Client/McpClientOptions.cs
+++ b/src/ModelContextProtocol/Client/McpClientOptions.cs
@@ -28,14 +28,4 @@ public class McpClientOptions
     /// Timeout for initialization sequence.
     /// </summary>
     public TimeSpan InitializationTimeout { get; set; } = TimeSpan.FromSeconds(60);
-
-    /// <summary>Creates a shallow clone of the options.</summary>
-    internal McpClientOptions Clone() =>
-        new()
-        {
-            ClientInfo = ClientInfo,
-            Capabilities = Capabilities,
-            ProtocolVersion = ProtocolVersion,
-            InitializationTimeout = InitializationTimeout
-        };
 }

--- a/src/ModelContextProtocol/Client/McpClientTool.cs
+++ b/src/ModelContextProtocol/Client/McpClientTool.cs
@@ -1,6 +1,5 @@
 ﻿using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Utils.Json;
-using ModelContextProtocol.Utils;
 using Microsoft.Extensions.AI;
 using System.Text.Json;
 

--- a/src/ModelContextProtocol/Configuration/McpServerOptionsSetup.cs
+++ b/src/ModelContextProtocol/Configuration/McpServerOptionsSetup.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using ModelContextProtocol.Server;
+﻿using ModelContextProtocol.Server;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol.Utils;
 
@@ -24,18 +23,6 @@ internal sealed class McpServerOptionsSetup(
     public void Configure(McpServerOptions options)
     {
         Throw.IfNull(options);
-
-        // Configure the option's server information based on the current process,
-        // if it otherwise lacks server information.
-        if (options.ServerInfo is not { } serverInfo)
-        {
-            var assemblyName = Assembly.GetEntryAssembly()?.GetName();
-            options.ServerInfo = new()
-            {
-                Name = assemblyName?.Name ?? "McpServer",
-                Version = assemblyName?.Version?.ToString() ?? "1.0.0",
-            };
-        }
 
         // Collect all of the provided tools into a tools collection. If the options already has
         // a collection, add to it, otherwise create a new one. We want to maintain the identity

--- a/src/ModelContextProtocol/IMcpEndpoint.cs
+++ b/src/ModelContextProtocol/IMcpEndpoint.cs
@@ -15,20 +15,4 @@ public interface IMcpEndpoint : IAsyncDisposable
     /// <param name="message">The message.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Adds a handler for server notifications of a specific method.
-    /// </summary>
-    /// <param name="method">The notification method to handle.</param>
-    /// <param name="handler">The async handler function to process notifications.</param>
-    /// <remarks>
-    /// <para>
-    /// Each method may have multiple handlers. Adding a handler for a method that already has one
-    /// will not replace the existing handler.
-    /// </para>
-    /// <para>
-    /// <see cref="NotificationMethods"> provides constants for common notification methods.</see>
-    /// </para>
-    /// </remarks>
-    void AddNotificationHandler(string method, Func<JsonRpcNotification, Task> handler);
 }

--- a/src/ModelContextProtocol/Protocol/Transport/McpTransportException.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/McpTransportException.cs
@@ -30,7 +30,7 @@ public class McpTransportException : Exception
     /// </summary>
     /// <param name="message">The message that describes the error.</param>
     /// <param name="innerException">The exception that is the cause of the current exception.</param>
-    public McpTransportException(string message, Exception innerException)
+    public McpTransportException(string message, Exception? innerException)
         : base(message, innerException)
     {
     }

--- a/src/ModelContextProtocol/Protocol/Transport/StdioClientTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/StdioClientTransport.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Logging;
 using ModelContextProtocol.Utils;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 
@@ -129,13 +130,25 @@ public sealed class StdioClientTransport : IClientTransport
     }
 
     internal static void DisposeProcess(
-        Process? process, bool processStarted, ILogger logger, TimeSpan shutdownTimeout, string endpointName)
+        Process? process, bool processRunning, ILogger logger, TimeSpan shutdownTimeout, string endpointName)
     {
         if (process is not null)
         {
+            if (processRunning)
+            {
+                try
+                {
+                    processRunning = !process.HasExited;
+                }
+                catch
+                {
+                    processRunning = false;
+                }
+            }
+
             try
             {
-                if (processStarted && !process.HasExited)
+                if (processRunning)
                 {
                     // Wait for the process to exit.
                     // Kill the while process tree because the process may spawn child processes

--- a/src/ModelContextProtocol/Protocol/Transport/StdioClientTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/StdioClientTransport.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Logging;
 using ModelContextProtocol.Utils;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 

--- a/src/ModelContextProtocol/Protocol/Transport/StdioServerTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/StdioServerTransport.cs
@@ -70,9 +70,7 @@ public sealed class StdioServerTransport : StreamServerTransport
     private static string GetServerName(McpServerOptions serverOptions)
     {
         Throw.IfNull(serverOptions);
-        Throw.IfNull(serverOptions.ServerInfo);
-        Throw.IfNull(serverOptions.ServerInfo.Name);
 
-        return serverOptions.ServerInfo.Name;
+        return serverOptions.ServerInfo?.Name ?? McpServer.DefaultImplementation.Name;
     }
 }

--- a/src/ModelContextProtocol/Protocol/Types/Capabilities.cs
+++ b/src/ModelContextProtocol/Protocol/Types/Capabilities.cs
@@ -1,4 +1,5 @@
-﻿using ModelContextProtocol.Server;
+﻿using ModelContextProtocol.Protocol.Messages;
+using ModelContextProtocol.Server;
 using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;
@@ -26,6 +27,14 @@ public class ClientCapabilities
     /// </summary>
     [JsonPropertyName("sampling")]
     public SamplingCapability? Sampling { get; set; }
+
+    /// <summary>Gets or sets notification handlers to register with the client.</summary>
+    /// <remarks>
+    /// When constructed, the client will enumerate these handlers, which may contain multiple handlers per key.
+    /// The client will not re-enumerate the sequence.
+    /// </remarks>
+    [JsonIgnore]
+    public IEnumerable<KeyValuePair<string, Func<JsonRpcNotification, Task>>>? NotificationHandlers { get; set; }
 }
 
 /// <summary>

--- a/src/ModelContextProtocol/Protocol/Types/ListRootsRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ListRootsRequestParams.cs
@@ -1,6 +1,4 @@
-﻿using ModelContextProtocol.Protocol.Messages;
-
-namespace ModelContextProtocol.Protocol.Types;
+﻿namespace ModelContextProtocol.Protocol.Types;
 
 /// <summary>
 /// A request from the server to get a list of root URIs from the client.

--- a/src/ModelContextProtocol/Protocol/Types/ServerCapabilities.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ServerCapabilities.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using ModelContextProtocol.Protocol.Messages;
+using System.Text.Json.Serialization;
 
 namespace ModelContextProtocol.Protocol.Types;
 
@@ -37,4 +38,12 @@ public class ServerCapabilities
     /// </summary>
     [JsonPropertyName("tools")]
     public ToolsCapability? Tools { get; set; }
+
+    /// <summary>Gets or sets notification handlers to register with the server.</summary>
+    /// <remarks>
+    /// When constructed, the server will enumerate these handlers, which may contain multiple handlers per key.
+    /// The server will not re-enumerate the sequence.
+    /// </remarks>
+    [JsonIgnore]
+    public IEnumerable<KeyValuePair<string, Func<JsonRpcNotification, Task>>>? NotificationHandlers { get; set; }
 }

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -11,6 +11,12 @@ namespace ModelContextProtocol.Server;
 /// <inheritdoc />
 internal sealed class McpServer : McpEndpoint, IMcpServer
 {
+    internal static Implementation DefaultImplementation { get; } = new()
+    {
+        Name = DefaultAssemblyName.Name ?? nameof(McpServer),
+        Version = DefaultAssemblyName.Version?.ToString() ?? "1.0.0",
+    };
+
     private readonly EventHandler? _toolsChangedDelegate;
     private readonly EventHandler? _promptsChangedDelegate;
 
@@ -32,9 +38,11 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
         Throw.IfNull(transport);
         Throw.IfNull(options);
 
+        options ??= new();
+
         ServerOptions = options;
         Services = serviceProvider;
-        _endpointName = $"Server ({options.ServerInfo.Name} {options.ServerInfo.Version})";
+        _endpointName = $"Server ({options.ServerInfo?.Name ?? DefaultImplementation.Name} {options.ServerInfo?.Version ?? DefaultImplementation.Version})";
 
         _toolsChangedDelegate = delegate
         {
@@ -158,7 +166,7 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
                 {
                     ProtocolVersion = options.ProtocolVersion,
                     Instructions = options.ServerInstructions,
-                    ServerInfo = options.ServerInfo,
+                    ServerInfo = options.ServerInfo ?? DefaultImplementation,
                     Capabilities = ServerCapabilities ?? new(),
                 });
             },

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -51,7 +51,7 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
             });
         };
 
-        AddNotificationHandler(NotificationMethods.InitializedNotification, _ =>
+        NotificationHandlers.Add(NotificationMethods.InitializedNotification, _ =>
         {
             if (ServerOptions.Capabilities?.Tools?.ToolCollection is { } tools)
             {
@@ -65,6 +65,11 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
 
             return Task.CompletedTask;
         });
+
+        if (options.Capabilities?.NotificationHandlers is { } notificationHandlers)
+        {
+            NotificationHandlers.AddRange(notificationHandlers);
+        }
 
         SetToolsHandler(options);
         SetInitializeHandler(options);
@@ -131,7 +136,7 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
 
     private void SetPingHandler()
     {
-        SetRequestHandler(RequestMethods.Ping,
+        RequestHandlers.Set(RequestMethods.Ping,
             (request, _) => Task.FromResult(new PingResult()),
             McpJsonUtilities.JsonContext.Default.JsonNode,
             McpJsonUtilities.JsonContext.Default.PingResult);
@@ -139,7 +144,7 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
 
     private void SetInitializeHandler(McpServerOptions options)
     {
-        SetRequestHandler(RequestMethods.Initialize,
+        RequestHandlers.Set(RequestMethods.Initialize,
             (request, _) =>
             {
                 ClientCapabilities = request?.Capabilities ?? new();
@@ -164,7 +169,7 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
     private void SetCompletionHandler(McpServerOptions options)
     {
         // This capability is not optional, so return an empty result if there is no handler.
-        SetRequestHandler(RequestMethods.CompletionComplete,
+        RequestHandlers.Set(RequestMethods.CompletionComplete,
             options.GetCompletionHandler is { } handler ?
                 (request, ct) => handler(new(this, request), ct) :
                 (request, ct) => Task.FromResult(new CompleteResult() { Completion = new() { Values = [], Total = 0, HasMore = false } }),
@@ -190,20 +195,20 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
 
         listResourcesHandler ??= (static (_, _) => Task.FromResult(new ListResourcesResult()));
 
-        SetRequestHandler(
+        RequestHandlers.Set(
             RequestMethods.ResourcesList,
             (request, ct) => listResourcesHandler(new(this, request), ct),
             McpJsonUtilities.JsonContext.Default.ListResourcesRequestParams,
             McpJsonUtilities.JsonContext.Default.ListResourcesResult);
 
-        SetRequestHandler(
+        RequestHandlers.Set(
             RequestMethods.ResourcesRead,
             (request, ct) => readResourceHandler(new(this, request), ct),
             McpJsonUtilities.JsonContext.Default.ReadResourceRequestParams,
             McpJsonUtilities.JsonContext.Default.ReadResourceResult);
 
         listResourceTemplatesHandler ??= (static (_, _) => Task.FromResult(new ListResourceTemplatesResult()));
-        SetRequestHandler(
+        RequestHandlers.Set(
             RequestMethods.ResourcesTemplatesList,
             (request, ct) => listResourceTemplatesHandler(new(this, request), ct),
             McpJsonUtilities.JsonContext.Default.ListResourceTemplatesRequestParams,
@@ -221,13 +226,13 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
             throw new McpException("Resources capability was enabled with subscribe support, but SubscribeToResources and/or UnsubscribeFromResources handlers were not specified.");
         }
 
-        SetRequestHandler(
+        RequestHandlers.Set(
             RequestMethods.ResourcesSubscribe,
             (request, ct) => subscribeHandler(new(this, request), ct),
             McpJsonUtilities.JsonContext.Default.SubscribeRequestParams,
             McpJsonUtilities.JsonContext.Default.EmptyResult);
 
-        SetRequestHandler(
+        RequestHandlers.Set(
             RequestMethods.ResourcesUnsubscribe,
             (request, ct) => unsubscribeHandler(new(this, request), ct),
             McpJsonUtilities.JsonContext.Default.UnsubscribeRequestParams,
@@ -314,13 +319,13 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
             }
         }
 
-        SetRequestHandler(
+        RequestHandlers.Set(
             RequestMethods.PromptsList,
             (request, ct) => listPromptsHandler(new(this, request), ct),
             McpJsonUtilities.JsonContext.Default.ListPromptsRequestParams,
             McpJsonUtilities.JsonContext.Default.ListPromptsResult);
 
-        SetRequestHandler(
+        RequestHandlers.Set(
             RequestMethods.PromptsGet,
             (request, ct) => getPromptHandler(new(this, request), ct),
             McpJsonUtilities.JsonContext.Default.GetPromptRequestParams,
@@ -407,13 +412,13 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
             }
         }
 
-        SetRequestHandler(
+        RequestHandlers.Set(
             RequestMethods.ToolsList,
             (request, ct) => listToolsHandler(new(this, request), ct),
             McpJsonUtilities.JsonContext.Default.ListToolsRequestParams,
             McpJsonUtilities.JsonContext.Default.ListToolsResult);
 
-        SetRequestHandler(
+        RequestHandlers.Set(
             RequestMethods.ToolsCall,
             (request, ct) => callToolHandler(new(this, request), ct),
             McpJsonUtilities.JsonContext.Default.CallToolRequestParams,
@@ -432,7 +437,7 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
             throw new McpException("Logging capability was enabled, but SetLoggingLevelHandler was not specified.");
         }
 
-        SetRequestHandler(
+        RequestHandlers.Set(
             RequestMethods.LoggingSetLevel,
             (request, ct) => setLoggingLevelHandler(new(this, request), ct),
             McpJsonUtilities.JsonContext.Default.SetLevelRequestParams,

--- a/src/ModelContextProtocol/Server/McpServerExtensions.cs
+++ b/src/ModelContextProtocol/Server/McpServerExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.AI;
-using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Utils;

--- a/src/ModelContextProtocol/Server/McpServerOptions.cs
+++ b/src/ModelContextProtocol/Server/McpServerOptions.cs
@@ -14,7 +14,7 @@ public class McpServerOptions
     /// <summary>
     /// Information about this server implementation.
     /// </summary>
-    public required Implementation ServerInfo { get; set; }
+    public Implementation? ServerInfo { get; set; }
 
     /// <summary>
     /// Server capabilities to advertise to the server.

--- a/src/ModelContextProtocol/Shared/McpEndpoint.cs
+++ b/src/ModelContextProtocol/Shared/McpEndpoint.cs
@@ -6,7 +6,7 @@ using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Utils;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization.Metadata;
+using System.Reflection;
 
 namespace ModelContextProtocol.Shared;
 
@@ -19,6 +19,9 @@ namespace ModelContextProtocol.Shared;
 /// </summary>
 internal abstract class McpEndpoint : IAsyncDisposable
 {
+    /// <summary>Cached naming information used for name/version when none is specified.</summary>
+    internal static AssemblyName DefaultAssemblyName { get; } = (Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly()).GetName();
+
     private McpSession? _session;
     private CancellationTokenSource? _sessionCts;
 

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Logging;
 using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Transport;
-using ModelContextProtocol.Server;
 using ModelContextProtocol.Utils;
 using ModelContextProtocol.Utils.Json;
 using System.Collections.Concurrent;

--- a/tests/ModelContextProtocol.TestServer/Program.cs
+++ b/tests/ModelContextProtocol.TestServer/Program.cs
@@ -38,7 +38,6 @@ internal static class Program
 
         McpServerOptions options = new()
         {
-            ServerInfo = new Implementation() { Name = "TestServer", Version = "1.0.0" },
             Capabilities = new ServerCapabilities()
             {
                 Tools = ConfigureTools(),

--- a/tests/ModelContextProtocol.TestSseServer/Program.cs
+++ b/tests/ModelContextProtocol.TestSseServer/Program.cs
@@ -25,7 +25,6 @@ public class Program
 
     private static void ConfigureOptions(McpServerOptions options)
     {
-        options.ServerInfo = new Implementation() { Name = "TestServer", Version = "1.0.0" };
         options.Capabilities = new ServerCapabilities()
         {
             Tools = new(),

--- a/tests/ModelContextProtocol.Tests/Client/McpClientFactoryTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientFactoryTests.cs
@@ -11,29 +11,24 @@ namespace ModelContextProtocol.Tests.Client;
 
 public class McpClientFactoryTests
 {
-    private readonly McpClientOptions _defaultOptions = new()
-    {
-        ClientInfo = new() { Name = "TestClient", Version = "1.0.0" }
-    };
-
     [Fact]
     public async Task CreateAsync_WithInvalidArgs_Throws()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>("serverConfig", () => McpClientFactory.CreateAsync((McpServerConfig)null!, _defaultOptions, cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<ArgumentNullException>("serverConfig", () => McpClientFactory.CreateAsync((McpServerConfig)null!, cancellationToken: TestContext.Current.CancellationToken));
 
         await Assert.ThrowsAsync<ArgumentException>("serverConfig", () => McpClientFactory.CreateAsync(new McpServerConfig()
             {
                 Name = "name",
                 Id = "id",
                 TransportType = "somethingunsupported",
-            }, _defaultOptions, cancellationToken: TestContext.Current.CancellationToken));
+            }, cancellationToken: TestContext.Current.CancellationToken));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => McpClientFactory.CreateAsync(new McpServerConfig()
             {
                 Name = "name",
                 Id = "id",
                 TransportType = TransportTypes.StdIo,
-            }, _defaultOptions, (_, __) => null!, cancellationToken: TestContext.Current.CancellationToken));
+            }, createTransportFunc: (_, __) => null!, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -78,8 +73,7 @@ public class McpClientFactoryTests
         // Act
         await using var client = await McpClientFactory.CreateAsync(
             serverConfig,
-            _defaultOptions,
-            (_, __) => new NopTransport(),
+            createTransportFunc: (_, __) => new NopTransport(),
             cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
@@ -102,8 +96,7 @@ public class McpClientFactoryTests
         // Act
         await using var client = await McpClientFactory.CreateAsync(
             serverConfig,
-            _defaultOptions,
-            (_, __) => new NopTransport(),
+            createTransportFunc: (_, __) => new NopTransport(),
             cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
@@ -126,8 +119,7 @@ public class McpClientFactoryTests
         // Act
         await using var client = await McpClientFactory.CreateAsync(
             serverConfig,
-            _defaultOptions,
-            (_, __) => new NopTransport(),
+            createTransportFunc: (_, __) => new NopTransport(),
             cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
@@ -157,8 +149,7 @@ public class McpClientFactoryTests
         // Act
         await using var client = await McpClientFactory.CreateAsync(
             serverConfig,
-            _defaultOptions,
-            (_, __) => new NopTransport(),
+            createTransportFunc: (_, __) => new NopTransport(),
             cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
@@ -186,7 +177,7 @@ public class McpClientFactoryTests
         };
 
         // act & assert
-        await Assert.ThrowsAsync<ArgumentException>(() => McpClientFactory.CreateAsync(config, _defaultOptions, cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<ArgumentException>(() => McpClientFactory.CreateAsync(config, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Theory]
@@ -205,11 +196,6 @@ public class McpClientFactoryTests
 
         var clientOptions = new McpClientOptions
         {
-            ClientInfo = new Implementation 
-            {
-                Name = "TestClient", 
-                Version = "1.0.0.0"
-            },
             Capabilities = new ClientCapabilities
             {
                 Sampling = new SamplingCapability

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTestFixture.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTestFixture.cs
@@ -8,7 +8,6 @@ public class ClientIntegrationTestFixture
 {
     private ILoggerFactory? _loggerFactory;
 
-    public McpClientOptions DefaultOptions { get; }
     public McpServerConfig EverythingServerConfig { get; }
     public McpServerConfig TestServerConfig { get; }
 
@@ -16,11 +15,6 @@ public class ClientIntegrationTestFixture
 
     public ClientIntegrationTestFixture()
     {
-        DefaultOptions = new()
-        {
-            ClientInfo = new() { Name = "IntegrationTestClient", Version = "1.0.0" },
-        };
-
         EverythingServerConfig = new()
         {
             Id = "everything",
@@ -63,5 +57,5 @@ public class ClientIntegrationTestFixture
             "everything" => EverythingServerConfig,
             "test_server" => TestServerConfig,
             _ => throw new ArgumentException($"Unknown client ID: {clientId}")
-        }, clientOptions ?? DefaultOptions, loggerFactory: _loggerFactory);
+        }, clientOptions, loggerFactory: _loggerFactory);
 }

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -256,13 +256,22 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
 
         // act
         TaskCompletionSource<bool> tcs = new();
-        await using var client = await _fixture.CreateClientAsync(clientId);
-        client.AddNotificationHandler(NotificationMethods.ResourceUpdatedNotification, (notification) =>
+        await using var client = await _fixture.CreateClientAsync(clientId, new()
         {
-            var notificationParams = JsonSerializer.Deserialize<ResourceUpdatedNotificationParams>(notification.Params);
-            tcs.TrySetResult(true);
-            return Task.CompletedTask;
+            Capabilities = new()
+            {
+                NotificationHandlers =
+                [
+                    new(NotificationMethods.ResourceUpdatedNotification, notification =>
+                    {
+                        var notificationParams = JsonSerializer.Deserialize<ResourceUpdatedNotificationParams>(notification.Params);
+                        tcs.TrySetResult(true);
+                        return Task.CompletedTask;
+                    })
+                ]
+            }
         });
+
         await client.SubscribeToResourceAsync("test://static/resource/1", TestContext.Current.CancellationToken);
 
         await tcs.Task;
@@ -277,12 +286,20 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
 
         // act
         TaskCompletionSource<bool> receivedNotification = new();
-        await using var client = await _fixture.CreateClientAsync(clientId);
-        client.AddNotificationHandler(NotificationMethods.ResourceUpdatedNotification, (notification) =>
+        await using var client = await _fixture.CreateClientAsync(clientId, new()
         {
-            var notificationParams = JsonSerializer.Deserialize<ResourceUpdatedNotificationParams>(notification.Params);
-            receivedNotification.TrySetResult(true);
-            return Task.CompletedTask;
+            Capabilities = new()
+            {
+                NotificationHandlers =
+                [
+                    new(NotificationMethods.ResourceUpdatedNotification, (notification) =>
+                    {
+                        var notificationParams = JsonSerializer.Deserialize<ResourceUpdatedNotificationParams>(notification.Params);
+                        receivedNotification.TrySetResult(true);
+                        return Task.CompletedTask;
+                    })
+                ]
+            }
         });
         await client.SubscribeToResourceAsync("test://static/resource/1", TestContext.Current.CancellationToken);
 
@@ -483,7 +500,6 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
         // Get the MCP client and tools from it.
         await using var client = await McpClientFactory.CreateAsync(
             _fixture.EverythingServerConfig, 
-            _fixture.DefaultOptions, 
             cancellationToken: TestContext.Current.CancellationToken);
         var mappedTools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
@@ -543,15 +559,23 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
     public async Task SetLoggingLevel_ReceivesLoggingMessages(string clientId)
     {
         TaskCompletionSource<bool> receivedNotification = new();
-        await using var client = await _fixture.CreateClientAsync(clientId);
-        client.AddNotificationHandler(NotificationMethods.LoggingMessageNotification, (notification) =>
+        await using var client = await _fixture.CreateClientAsync(clientId, new()
         {
-            var loggingMessageNotificationParameters = JsonSerializer.Deserialize<LoggingMessageNotificationParams>(notification.Params);
-            if (loggingMessageNotificationParameters is not null)
+            Capabilities = new()
             {
-                receivedNotification.TrySetResult(true);
+                NotificationHandlers =
+                [
+                    new(NotificationMethods.LoggingMessageNotification, (notification) =>
+                    {
+                        var loggingMessageNotificationParameters = JsonSerializer.Deserialize<LoggingMessageNotificationParams>(notification.Params);
+                        if (loggingMessageNotificationParameters is not null)
+                        {
+                            receivedNotification.TrySetResult(true);
+                        }
+                        return Task.CompletedTask;
+                    })
+                ]
             }
-            return Task.CompletedTask;
         });
 
         // act

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -5,10 +5,7 @@ using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Tests.Utils;
 using OpenAI;
-using System.Text.Encodings.Web;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
 
 namespace ModelContextProtocol.Tests;
 
@@ -367,7 +364,6 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
         int samplingHandlerCalls = 0;
         await using var client = await _fixture.CreateClientAsync(clientId, new()
         {
-            ClientInfo = new() { Name = "Sampling_Stdio", Version = "1.0.0" },
             Capabilities = new()
             {
                 Sampling = new()
@@ -532,7 +528,6 @@ public class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIntegratio
             .CreateSamplingHandler();
         await using var client = await McpClientFactory.CreateAsync(_fixture.EverythingServerConfig, new()
         {
-            ClientInfo = new() { Name = nameof(SamplingViaChatClient_RequestResponseProperlyPropagated), Version = "1.0.0" },
             Capabilities = new()
             {
                 Sampling = new()

--- a/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
+++ b/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
@@ -1,6 +1,5 @@
 ﻿using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Transport;
-using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;
 using OpenTelemetry.Trace;
 using System.Diagnostics;
@@ -49,7 +48,6 @@ public class DiagnosticTests
 
         await using (IMcpServer server = McpServerFactory.Create(serverTransport, new()
             {
-                ServerInfo = new Implementation { Name = "TestServer", Version = "1.0.0" },
                 Capabilities = new()
                 {
                     Tools = new()

--- a/tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj
+++ b/tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj
@@ -11,6 +11,13 @@
     <RootNamespace>ModelContextProtocol.Tests</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Without this, tests are currently not showing results until all tests complete
+         https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+    -->
+    <DisableTestingPlatformServerCapability>true</DisableTestingPlatformServerCapability>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/ModelContextProtocol.Tests/Server/McpServerFactoryTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerFactoryTests.cs
@@ -1,5 +1,4 @@
-﻿using ModelContextProtocol.Protocol.Types;
-using ModelContextProtocol.Server;
+﻿using ModelContextProtocol.Server;
 using ModelContextProtocol.Tests.Utils;
 
 namespace ModelContextProtocol.Tests.Server;
@@ -13,7 +12,6 @@ public class McpServerFactoryTests : LoggedTest
     {
         _options = new McpServerOptions
         {
-            ServerInfo = new Implementation { Name = "TestServer", Version = "1.0" },
             ProtocolVersion = "1.0",
             InitializationTimeout = TimeSpan.FromSeconds(30)
         };

--- a/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
@@ -634,8 +634,6 @@ public class McpServerTests : LoggedTest
         public Implementation? ClientInfo => throw new NotImplementedException();
         public McpServerOptions ServerOptions => throw new NotImplementedException();
         public IServiceProvider? Services => throw new NotImplementedException();
-        public void AddNotificationHandler(string method, Func<JsonRpcNotification, Task> handler) => 
-            throw new NotImplementedException();
         public Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
         public Task RunAsync(CancellationToken cancellationToken = default) =>
@@ -649,13 +647,16 @@ public class McpServerTests : LoggedTest
         var options = CreateOptions();
 
         var notificationReceived = new TaskCompletionSource<JsonRpcNotification>();
+        options.Capabilities = new()
+        {
+            NotificationHandlers = [new(NotificationMethods.ProgressNotification, notification =>
+            {
+                notificationReceived.TrySetResult(notification);
+                return Task.CompletedTask;
+            })],
+        };
 
         var server = McpServerFactory.Create(transport, options, LoggerFactory);
-        server.AddNotificationHandler(NotificationMethods.ProgressNotification, notification =>
-        {
-            notificationReceived.SetResult(notification);
-            return Task.CompletedTask;
-        });
 
         Task serverTask = server.RunAsync(TestContext.Current.CancellationToken);
 

--- a/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
@@ -24,7 +24,6 @@ public class McpServerTests : LoggedTest
     {
         return new McpServerOptions
         {
-            ServerInfo = new Implementation { Name = "TestServer", Version = "1.0" },
             ProtocolVersion = "2024",
             InitializationTimeout = TimeSpan.FromSeconds(30),
             Capabilities = capabilities,
@@ -189,8 +188,8 @@ public class McpServerTests : LoggedTest
             {
                 var result = JsonSerializer.Deserialize<InitializeResult>(response);
                 Assert.NotNull(result);
-                Assert.Equal("TestServer", result.ServerInfo.Name);
-                Assert.Equal("1.0", result.ServerInfo.Version);
+                Assert.Equal("ModelContextProtocol.Tests", result.ServerInfo.Name);
+                Assert.Equal("1.0.0.0", result.ServerInfo.Version);
                 Assert.Equal("2024", result.ProtocolVersion);
             });
     }

--- a/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
@@ -213,12 +213,6 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
         await using InMemoryTestSseServer server = new(CreatePortNumber(), LoggerFactory.CreateLogger<InMemoryTestSseServer>());
         await server.StartAsync();
 
-
-        var defaultOptions = new McpClientOptions
-        {
-            ClientInfo = new() { Name = "IntegrationTestClient", Version = "1.0.0" }
-        };
-
         var defaultConfig = new McpServerConfig
         {
             Id = "test_server",
@@ -229,23 +223,27 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
         };
 
         // Act
+        var receivedNotification = new TaskCompletionSource<string?>();
         await using var client = await McpClientFactory.CreateAsync(
             defaultConfig, 
-            defaultOptions, 
+            new()
+            {
+                Capabilities = new()
+                {
+                    NotificationHandlers = [new("test/notification", args =>
+                    {
+                        var msg = args.Params?["message"]?.GetValue<string>();
+                        receivedNotification.SetResult(msg);
+
+                        return Task.CompletedTask;
+                    })],
+                },
+            }, 
             loggerFactory: LoggerFactory,
             cancellationToken: TestContext.Current.CancellationToken);
 
         // Wait for SSE connection to be established
         await server.WaitForConnectionAsync(TimeSpan.FromSeconds(10));
-
-        var receivedNotification = new TaskCompletionSource<string?>();
-        client.AddNotificationHandler("test/notification", (args) =>
-            {
-                var msg = args.Params?["message"]?.GetValue<string>();
-                receivedNotification.SetResult(msg);
-
-                return Task.CompletedTask;
-            });
 
         // Act
         await server.SendTestNotificationAsync("Hello from server!");

--- a/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
@@ -29,11 +29,6 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
         await using InMemoryTestSseServer server = new(CreatePortNumber(), LoggerFactory.CreateLogger<InMemoryTestSseServer>());
         await server.StartAsync();
 
-        var defaultOptions = new McpClientOptions
-        {
-            ClientInfo = new() { Name = "IntegrationTestClient", Version = "1.0.0" }
-        };
-
         var defaultConfig = new McpServerConfig
         {
             Id = "test_server",
@@ -46,7 +41,6 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
         // Act
         await using var client = await McpClientFactory.CreateAsync(
             defaultConfig, 
-            defaultOptions,
             loggerFactory: LoggerFactory,
             cancellationToken: TestContext.Current.CancellationToken);
 
@@ -120,11 +114,6 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
         int samplingHandlerCalls = 0;
         var defaultOptions = new McpClientOptions
         {
-            ClientInfo = new()
-            {
-                Name = "IntegrationTestClient",
-                Version = "1.0.0"
-            },
             Capabilities = new()
             {
                 Sampling = new()
@@ -175,11 +164,6 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
         server.UseFullUrlForEndpointEvent = true;
         await server.StartAsync();
 
-        var defaultOptions = new McpClientOptions
-        {
-            ClientInfo = new() { Name = "IntegrationTestClient", Version = "1.0.0" }
-        };
-
         var defaultConfig = new McpServerConfig
         {
             Id = "test_server",
@@ -192,7 +176,6 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : LoggedTest(ou
         // Act
         await using var client = await McpClientFactory.CreateAsync(
             defaultConfig,
-            defaultOptions,
             loggerFactory: LoggerFactory,
             cancellationToken: TestContext.Current.CancellationToken);
 

--- a/tests/ModelContextProtocol.Tests/SseServerIntegrationTestFixture.cs
+++ b/tests/ModelContextProtocol.Tests/SseServerIntegrationTestFixture.cs
@@ -1,5 +1,4 @@
-﻿using ModelContextProtocol.Client;
-using ModelContextProtocol.Protocol.Transport;
+﻿using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Test.Utils;
 using ModelContextProtocol.Tests.Utils;
 using ModelContextProtocol.TestSseServer;
@@ -31,11 +30,6 @@ public class SseServerIntegrationTestFixture : IAsyncDisposable
 
         _serverTask = Program.MainAsync([port.ToString()], new XunitLoggerProvider(_delegatingTestOutputHelper), _stopCts.Token);
     }
-
-    public static McpClientOptions CreateDefaultClientOptions() => new()
-    {
-        ClientInfo = new() { Name = "IntegrationTestClient", Version = "1.0.0" },
-    };
 
     public void Initialize(ITestOutputHelper output)
     {

--- a/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
@@ -27,7 +27,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
     {
         return McpClientFactory.CreateAsync(
             _fixture.DefaultConfig,
-            options ?? SseServerIntegrationTestFixture.CreateDefaultClientOptions(),
+            options,
             loggerFactory: LoggerFactory,
             cancellationToken: TestContext.Current.CancellationToken);
     }
@@ -220,8 +220,8 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
         // Set up the sampling handler
         int samplingHandlerCalls = 0;
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        var options = SseServerIntegrationTestFixture.CreateDefaultClientOptions();
-        options.Capabilities ??= new();
+        McpClientOptions options = new();
+        options.Capabilities = new();
         options.Capabilities.Sampling ??= new();
         options.Capabilities.Sampling.SamplingHandler = async (_, _, _) =>
         {

--- a/tests/ModelContextProtocol.Tests/Transport/StdioServerTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioServerTransportTests.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.Options;
 using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Transport;
-using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Tests.Utils;
 using ModelContextProtocol.Utils.Json;
@@ -21,11 +20,6 @@ public class StdioServerTransportTests : LoggedTest
     {
         _serverOptions = new McpServerOptions
         {
-            ServerInfo = new Implementation
-            {
-                Name = "Test Server",
-                Version = "1.0"
-            },
             ProtocolVersion = "2.0",
             InitializationTimeout = TimeSpan.FromSeconds(10),
             ServerInstructions = "Test Instructions"
@@ -49,8 +43,6 @@ public class StdioServerTransportTests : LoggedTest
 
         Assert.Throws<ArgumentNullException>("serverOptions", () => new StdioServerTransport((IOptions<McpServerOptions>)null!));
         Assert.Throws<ArgumentNullException>("serverOptions", () => new StdioServerTransport((McpServerOptions)null!));
-        Assert.Throws<ArgumentNullException>("serverOptions.ServerInfo", () => new StdioServerTransport(new McpServerOptions() { ServerInfo = null! }));
-        Assert.Throws<ArgumentNullException>("serverOptions.ServerInfo.Name", () => new StdioServerTransport(new McpServerOptions() { ServerInfo = new() { Name = null!, Version = "" } }));
     }
 
     [Fact]


### PR DESCRIPTION
Currently request handlers are set on the capability objects, but notification handlers are set after construction via an AddNotificationHandler method on the IMcpEndpoint interface. This moves handler specification to be at construction as well. This makes it more consistent with request handlers, simplifies the IMcpEndpoint interface to just be about message sending, and avoids a concurrency bug that could occur if someone tried to add a handler while the endpoint was processing notifications.