### PR TITLE
Disable response buffering for SSE responses

### DIFF
--- a/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseServerIntegrationTests.cs
@@ -281,6 +281,21 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
     }
 
     [Fact]
+    public async Task EventSourceResponse_Includes_ExpectedHeaders()
+    {
+        using var httpClient = GetHttpClient();
+        using var sseResponse = await httpClient.GetAsync("", HttpCompletionOption.ResponseHeadersRead, TestContext.Current.CancellationToken);
+
+        sseResponse.EnsureSuccessStatusCode();
+
+        Assert.Equal("text/event-stream", sseResponse.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("identity", sseResponse.Content.Headers.ContentEncoding.ToString());
+        Assert.NotNull(sseResponse.Headers.CacheControl);
+        Assert.True(sseResponse.Headers.CacheControl.NoStore);
+        Assert.True(sseResponse.Headers.CacheControl.NoCache);
+    }
+
+    [Fact]
     public async Task EventSourceStream_Includes_MessageEventType()
     {
         // Simulate our own MCP client handshake using a plain HttpClient so we can look for "event: message"


### PR DESCRIPTION
This does the same thing SignalR's ServerSentEventsServerTransport and Blazor's RazorComponentEndpointInvoker does. We didn't catch this before because we test using Kestrel which does not buffer by default.

It's possible to either mock the IHttpResponseBodyFeature or use IIS in integration tests to fully test this fix, but I don't think it's worth the effort right now as I work on other parts of HTTP streaming. I did add test verifying we send the expected headers though.