### PR TITLE
Fix race in KestrelInMemoryConnection 

### DIFF
--- a/samples/AspNetCoreSseServer/Properties/launchSettings.json
+++ b/samples/AspNetCoreSseServer/Properties/launchSettings.json
@@ -4,7 +4,6 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "http://localhost:3001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -13,7 +12,6 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "https://localhost:7133;http://localhost:3001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/tests/ModelContextProtocol.Tests/Transport/SseClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/SseClientTransportTests.cs
@@ -148,7 +148,7 @@ public class SseClientTransportTests : LoggedTest
 
         var eventSourcePipe = new Pipe();
         var eventSourceData = "event: endpoint\r\ndata: /sseendpoint\r\n\r\n"u8;
-        Assert.True(eventSourceData.TryCopyTo(eventSourcePipe.Writer.GetSpan()));
+        eventSourceData.CopyTo(eventSourcePipe.Writer.GetSpan(eventSourceData.Length));
         eventSourcePipe.Writer.Advance(eventSourceData.Length);
         await eventSourcePipe.Writer.FlushAsync(TestContext.Current.CancellationToken);
 

--- a/tests/ModelContextProtocol.Tests/Utils/KestrelInMemoryConnection.cs
+++ b/tests/ModelContextProtocol.Tests/Utils/KestrelInMemoryConnection.cs
@@ -43,9 +43,10 @@ public sealed class KestrelInMemoryConnection : ConnectionContext
         // completes the other half of these pipes.
         _serverToClientPipe.Writer.Complete();
         _serverToClientPipe.Reader.Complete();
-        // Disposing the CTS without waiting for the client would be problematic
-        // except we always dispose the HttpClient before Kestrel in our tests.
-        _connectionClosedCts.Dispose();
+
+        // Don't bother disposing the _connectionClosedCts, since this is just for testing,
+        // and it's annoying to synchronize with DuplexStream.
+
         return base.DisposeAsync();
     }
 


### PR DESCRIPTION
This should avoid the following race. I went the easy route, and just stop disposing KestrelInMemoryConnection._connectionClosedCts, because IIRC, you only *really* need to dispose it if a caller is using something like CancellationToken.WaitHandle, which I don't expect in our tests at least. I could try synchronizing with the SocketsHttpHandler disposing the stream on a background thread, but it was a lot more code and risked deadlocks if done incorrectly.

```
[xUnit.net 00:00:06.33]       System.AggregateException : One or more errors occurred. (The CancellationTokenSource has been disposed.)
[xUnit.net 00:00:06.33]     [FATAL ERROR] System.AggregateException
[xUnit.net 00:00:06.33]       ---- System.ObjectDisposedException : The CancellationTokenSource has been disposed.
[xUnit.net 00:00:06.33]       Stack Trace:
[xUnit.net 00:00:06.33]            at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean throwOnFirstException)
[xUnit.net 00:00:06.33]            at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
[xUnit.net 00:00:06.33]            at System.Threading.TimerQueue.FireNextTimers()
[xUnit.net 00:00:06.33]            at System.Threading.ThreadPoolWorkQueue.Dispatch()
[xUnit.net 00:00:06.33] Catastrophic failure: System.AggregateException : One or more errors occurred. (The CancellationTokenSource has been disposed.)
[xUnit.net 00:00:06.33]            at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
---- System.ObjectDisposedException : The CancellationTokenSource has been disposed.
[xUnit.net 00:00:06.33]         ----- Inner Stack Trace -----
[xUnit.net 00:00:06.33]            at System.Threading.CancellationTokenSource.Cancel()
[xUnit.net 00:00:06.33]         /_/tests/ModelContextProtocol.Tests/Utils/KestrelInMemoryConnection.cs(83,0): at ModelContextProtocol.Tests.Utils.KestrelInMemoryConnection.DuplexStream.Dispose(Boolean disposing)
[xUnit.net 00:00:06.33]            at System.IO.Stream.Close()
[xUnit.net 00:00:06.33]            at System.Threading.CancellationTokenSource.Invoke(Delegate d, Object state, CancellationTokenSource source)
[xUnit.net 00:00:06.33]            at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
[xUnit.net 00:00:06.33]         --- End of stack trace from previous location ---
[xUnit.net 00:00:06.33]            at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
[xUnit.net 00:00:06.33]            at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean throwOnFirstException)
```

https://github.com/modelcontextprotocol/csharp-sdk/actions/runs/14319353286/job/40132789327

- Also, this removes some duplication from WithStdioServerTransport and WithStreamServerTransport