### PR TITLE
Update markdown-link-check to ignore external links causing 403 in CI

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -17,4 +17,4 @@ jobs:
         uses: becheran/mlc@v0.21.0
         with:
           # Ignore external links that result in 403 errors during CI
-          args: --ignore-links "http*://www.anthropic.com/*,http*://hackerone.com/anthropic-vdp/*" ./
+          args: --ignore-links "https://www.anthropic.com/*,https://hackerone.com/anthropic-vdp/*" --do-not-warn-for-redirect-to "https://modelcontextprotocol.io/*,https://github.com/login?*" ./

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -17,4 +17,4 @@ jobs:
         uses: becheran/mlc@v0.15.4
         with:
           # Ignore external links that result in 403 errors during CI
-          args: --ignore-links "https://www.anthropic.com/,https://hackerone.com/anthropic-vdp" ./
+          args: --ignore-links "http*://www.anthropic.com/*,http*://hackerone.com/anthropic-vdp/*" ./

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Markup Link Checker (mlc)
         uses: becheran/mlc@v0.21.0
         with:
-          # Ignore external links that result in 403 errors during CI
+          # Ignore external links that result in 403 errors during CI. Do not warn for redirects where we want to keep the vanity URL in the markdown or for GitHub links that redirect to the login.
           args: --ignore-links "https://www.anthropic.com/*,https://hackerone.com/anthropic-vdp/*" --do-not-warn-for-redirect-to "https://modelcontextprotocol.io/*,https://github.com/login?*" ./

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,5 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
+
       - name: Markup Link Checker (mlc)
         uses: becheran/mlc@v0.15.4
+        with:
+          # Ignore external links that result in 403 errors during CI
+          args: --ignore-links "https://www.anthropic.com/,https://hackerone.com/anthropic-vdp" ./

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@main
 
       - name: Markup Link Checker (mlc)
-        uses: becheran/mlc@v0.15.4
+        uses: becheran/mlc@v0.21.0
         with:
           # Ignore external links that result in 403 errors during CI
           args: --ignore-links "http*://www.anthropic.com/*,http*://hackerone.com/anthropic-vdp/*" ./

--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -31,7 +31,7 @@ The following process is used when publishing new releases to NuGet.org:
 3. **Monitor the Release workflow**
     - After publishing the release, a workflow will begin for producing the release's build artifacts and publishing the NuGet package to NuGet.org
     - If the job fails, troubleshoot and re-run the workflow as needed
-    - Verify the package version becomes listed on at [https://nuget.org/packages/ModelContextProtocol](https://nuget.org/packages/ModelContextProtocol)
+    - Verify the package version becomes listed on at [https://nuget.org/packages/ModelContextProtocol](https://www.nuget.org/packages/ModelContextProtocol)
 
 4. **Update the source to increment the version number**
     - Immediately after publishing a new release, the [`/src/Directory.Build.Props`](../../src/Directory.Build.props) file needs to be updated to bump the version to the next expected release version


### PR DESCRIPTION
The `markdown-link-check` action is failing on `SECURITY.md` with 403 errors for external links that cannot be reached from CI. This sets those URLs to be ignored in the action.