### PR TITLE
Improve SSE response handling and URI construction in SseClientSessio…

### DIFF
--- a/src/ModelContextProtocol/Protocol/Transport/SseClientSessionTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseClientSessionTransport.cs
@@ -115,7 +115,7 @@ internal sealed class SseClientSessionTransport : TransportBase
         if (message is JsonRpcRequest request && request.Method == RequestMethods.Initialize)
         {
             // If the response is not a JSON-RPC response, it is an SSE message
-            if (responseContent.Equals("accepted", StringComparison.OrdinalIgnoreCase))
+            if (string.IsNullOrEmpty(responseContent) || responseContent.Equals("accepted", StringComparison.OrdinalIgnoreCase))
             {
                 _logger.SSETransportPostAccepted(_endpointName, messageId);
                 // The response will arrive as an SSE message
@@ -133,7 +133,7 @@ internal sealed class SseClientSessionTransport : TransportBase
         }
 
         // Otherwise, check if the response was accepted (the response will come as an SSE message)
-        if (responseContent.Equals("accepted", StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrEmpty(responseContent) || responseContent.Equals("accepted", StringComparison.OrdinalIgnoreCase))
         {
             _logger.SSETransportPostAccepted(_endpointName, messageId);
         }
@@ -294,13 +294,16 @@ internal sealed class SseClientSessionTransport : TransportBase
             else
             {
                 // If the endpoint is a relative URI, we need to combine it with the relative path of the SSE endpoint
-                var hostUrl = _sseEndpoint.AbsoluteUri;
-                if (hostUrl.EndsWith("/sse", StringComparison.Ordinal))
-                    hostUrl = hostUrl[..^4];
+                var baseUriBuilder = new UriBuilder(_sseEndpoint);
 
-                var endpointUri = $"{hostUrl.TrimEnd('/')}/{data.TrimStart('/')}";
+                // Check that paths end in "/sse" and remove if needed
+                if (baseUriBuilder.Path.EndsWith("/sse", StringComparison.Ordinal))
+                {
+                    baseUriBuilder.Path = baseUriBuilder.Path[..^4];
+                }
 
-                _messageEndpoint = new Uri(endpointUri);
+                // Instead of manually concatenating strings, use the Uri class's composition capabilities
+                _messageEndpoint = new Uri(baseUriBuilder.Uri, data);
             }
 
             // Set connected state


### PR DESCRIPTION
This pull request includes several changes to the `SseClientSessionTransport` class to improve the handling of SSE messages and URI composition. The most important changes include enhancing the conditions for checking response content and refactoring the URI composition logic.

### Enhancements to response content checks:

* Updated the condition to check if `responseContent` is either empty or equals "accepted" in two locations within the `SendMessageAsync` method. [[1]](diffhunk://#diff-b6ca6836231b16d703e38d2259b52c48ddf101876d321885c490c4fced33ed0dL118-R118) [[2]](diffhunk://#diff-b6ca6836231b16d703e38d2259b52c48ddf101876d321885c490c4fced33ed0dL136-R136)

### Refactoring URI composition:

* Refactored the `HandleEndpointEvent` method to use `UriBuilder` for more robust URI composition, including removing the manual string concatenation and handling the "/sse" suffix more effectively.