### PR TITLE
Use TryAddEnumerable for McpServerOptionsSetup

### DIFF
--- a/src/ModelContextProtocol/Configuration/McpServerServiceCollectionExtensions.cs
+++ b/src/ModelContextProtocol/Configuration/McpServerServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using ModelContextProtocol.Server;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -17,7 +18,7 @@ public static class McpServerServiceCollectionExtensions
     public static IMcpServerBuilder AddMcpServer(this IServiceCollection services, Action<McpServerOptions>? configureOptions = null)
     {
         services.AddOptions();
-        services.AddTransient<IConfigureOptions<McpServerOptions>, McpServerOptionsSetup>();
+        services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<McpServerOptions>, McpServerOptionsSetup>());
         if (configureOptions is not null)
         {
             services.Configure(configureOptions);

--- a/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/SseIntegrationTests.cs
@@ -10,6 +10,7 @@ using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Tests.Utils;
 using ModelContextProtocol.Utils.Json;
+using TestServerWithHosting.Tools;
 
 namespace ModelContextProtocol.Tests;
 
@@ -93,6 +94,54 @@ public class SseIntegrationTests(ITestOutputHelper outputHelper) : KestrelInMemo
 
         var message = await receivedNotification.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         Assert.Equal("Hello from server!", message);
+    }
+
+    [Fact]
+    public async Task AddMcpServer_CanBeCalled_MultipleTimes()
+    {
+        var firstOptionsCallbackCalled = false;
+        var secondOptionsCallbackCalled = false;
+
+        Builder.Services.AddMcpServer(options =>
+            {
+                firstOptionsCallbackCalled = true;
+            })
+            .WithTools<EchoTool>();
+
+        Builder.Services.AddMcpServer(options =>
+            {
+                secondOptionsCallbackCalled = true;
+            })
+            .WithTools<SampleLlmTool>();
+
+
+        await using var app = Builder.Build();
+        app.MapMcp();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var httpClient = CreateHttpClient();
+        await using var mcpClient = await ConnectMcpClient(httpClient);
+
+        // Options can be lazily initialized, but they must be instantiated by the time an MCP client can finish connecting.
+        Assert.True(firstOptionsCallbackCalled);
+        Assert.True(secondOptionsCallbackCalled);
+
+        var tools = await mcpClient.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, tools.Count);
+        Assert.Contains(tools, tools => tools.Name == "Echo");
+        Assert.Contains(tools, tools => tools.Name == "sampleLLM");
+
+        var echoResponse = await mcpClient.CallToolAsync(
+            "Echo",
+            new Dictionary<string, object?>
+            {
+                ["message"] = "from client!"
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+        var textContent = Assert.Single(echoResponse.Content, c => c.Type == "text");
+
+        Assert.Equal("hello from client!", textContent.Text);
     }
 
     private static void MapAbsoluteEndpointUriMcp(IEndpointRouteBuilder endpoints)


### PR DESCRIPTION
I considered adding a test for this, but as of right now, I don't think running McpServerOptionsSetup.Configure more than once has an observable impact since the things it does either no-ops (like McpServerPrimitiveCollection.TryAdd when attempting to re-add tools and prompts) or overwrites what was done by the last call with the exact same thing (like McpServerHandlers.OverwriteWithSetHandlers). Still, there's no reason to run McpServerOptionsSetup multiple times if we don't have to, and this is the conventional pattern we use for adding IConfigureOptions ([see AddMvc](https://github.com/dotnet/aspnetcore/blob/b3399b82c5f13e3f4ad164656083d37b5c04ea85/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs#L134-L141)).

I thought about this because of the discussion in https://github.com/modelcontextprotocol/csharp-sdk/issues/240.