### PR TITLE
Fix race in TransportBase.SetConnected

### DIFF
--- a/src/ModelContextProtocol/Protocol/Transport/TransportBase.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/TransportBase.cs
@@ -48,7 +48,7 @@ public abstract class TransportBase : ITransport
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     protected async Task WriteMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
     {
-        if (IsConnected)
+        if (!IsConnected)
         {
             throw new McpTransportException("Transport is not connected");
         }

--- a/src/ModelContextProtocol/Protocol/Transport/TransportBase.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/TransportBase.cs
@@ -13,7 +13,7 @@ public abstract class TransportBase : ITransport
 {
     private readonly Channel<IJsonRpcMessage> _messageChannel;
     private readonly ILogger _logger;
-    private bool _isConnected;
+    private int _isConnected;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TransportBase"/> class.
@@ -30,7 +30,7 @@ public abstract class TransportBase : ITransport
     }
 
     /// <inheritdoc/>
-    public bool IsConnected => _isConnected;
+    public bool IsConnected => _isConnected == 1;
 
     /// <inheritdoc/>
     public ChannelReader<IJsonRpcMessage> MessageReader => _messageChannel.Reader;
@@ -48,7 +48,7 @@ public abstract class TransportBase : ITransport
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     protected async Task WriteMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
     {
-        if (!_isConnected)
+        if (IsConnected)
         {
             throw new McpTransportException("Transport is not connected");
         }
@@ -64,12 +64,12 @@ public abstract class TransportBase : ITransport
     /// <param name="isConnected">Whether the transport is connected.</param>
     protected void SetConnected(bool isConnected)
     {
-        if (_isConnected == isConnected)
+        var newIsConnected = isConnected ? 1 : 0;
+        if (Interlocked.Exchange(ref _isConnected, newIsConnected) == newIsConnected)
         {
             return;
         }
 
-        _isConnected = isConnected;
         if (!isConnected)
         {
             _messageChannel.Writer.Complete();


### PR DESCRIPTION
- Previously the ChannelWriter could already be completed if multiple threads raced in SetConnected(false)

```
  Failed ModelContextProtocol.Tests.ClientIntegrationTests.CallTool_Stdio_EchoServer(clientId: "test_server") [331 ms]
  Error Message:
   System.Threading.Channels.ChannelClosedException : The channel has been closed.
  Stack Trace:
     at System.Threading.Channels.ChannelWriter`1.Complete(Exception error)
   at ModelContextProtocol.Protocol.Transport.TransportBase.SetConnected(Boolean isConnected) in /_/src/ModelContextProtocol/Protocol/Transport/TransportBase.cs:line 75
   at ModelContextProtocol.Protocol.Transport.StreamClientSessionTransport.CleanupAsync(CancellationToken cancellationToken) in /_/src/ModelContextProtocol/Protocol/Transport/StreamClientSessionTransport.cs:line 192
   at ModelContextProtocol.Client.McpClient.DisposeUnsynchronizedAsync() in /_/src/ModelContextProtocol/Client/McpClient.cs:line 184
   at ModelContextProtocol.Shared.McpEndpoint.DisposeAsync() in /_/src/ModelContextProtocol/Shared/McpEndpoint.cs:line 89
   at ModelContextProtocol.Tests.ClientIntegrationTests.CallTool_Stdio_EchoServer(String clientId) in /_/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs:line 95
--- End of stack trace from previous location ---
  Standard Output Messages:
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClientFactory Information: Creating client for TestServer
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClient Information: Sending request for TestServer with method initialize
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClient Information: Request response received payload for TestServer: {"protocolVersion":"2024-11-05","capabilities":{"logging":{},"prompts":{},"resources":{"subscribe":true},"tools":{},"completions":{}},"serverInfo":{"name":"TestServer","version":"1.0.0.0"},"instructions":"This is a test server with only stub functionality"}
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClient Information: Request response received for TestServer with method initialize
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClient Information: Server TestServer capabilities received: {"logging":{},"prompts":{},"resources":{"subscribe":true},"tools":{},"completions":{}}, server info: {"name":"TestServer","version":"1.0.0.0"}
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClientFactory Information: Client for TestServer created and connected
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClient Information: Sending request for TestServer with method tools/call
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClient Information: Request response received payload for TestServer: {"content":[{"type":"text","text":"Echo: Hello MCP!"}],"isError":false}
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClient Information: Request response received for TestServer with method tools/call
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClient Information: Cleaning up endpoint TestServer
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClient Information: Endpoint message processing cancelled for TestServer
 | [2025-04-09T16:35:33] ModelContextProtocol.Client.McpClient Information: Endpoint cleaned up for TestServer
```

https://github.com/modelcontextprotocol/csharp-sdk/actions/runs/14362374601/job/40266898759?pr=252