### PR TITLE
OpenTelemetry: context propagation and semconv update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,6 +58,10 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="OpenTelemetry" Version="1.11.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.11.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http " Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2"  />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1"  />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
@@ -67,10 +71,5 @@
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http " Version="1.11.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2"  />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1"  />
-
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,5 +67,10 @@
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http " Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2"  />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1"  />
+
   </ItemGroup>
 </Project>

--- a/samples/AspNetCoreSseServer/AspNetCoreSseServer.csproj
+++ b/samples/AspNetCoreSseServer/AspNetCoreSseServer.csproj
@@ -12,4 +12,11 @@
     <ProjectReference Include="..\..\src\ModelContextProtocol.AspNetCore\ModelContextProtocol.AspNetCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+  </ItemGroup>
+
 </Project>

--- a/samples/AspNetCoreSseServer/Program.cs
+++ b/samples/AspNetCoreSseServer/Program.cs
@@ -1,30 +1,22 @@
 using TestServerWithHosting.Tools;
-using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using AspNetCoreSseServer.Tools;
+using OpenTelemetry;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddMcpServer()
     .WithTools<EchoTool>()
-    .WithTools<SampleLlmTool>()
-    .WithTools<LongRunningTool>();
+    .WithTools<SampleLlmTool>();
 
-var resource = ResourceBuilder.CreateEmpty().AddService("mcp.server");
 builder.Services.AddOpenTelemetry()
-    .WithTracing(b => b.SetResourceBuilder(resource)
-        .AddOtlpExporter()
-        .AddSource("*")
+    .WithTracing(b => b.AddSource("*")
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation())
-    .WithMetrics(b => b.SetResourceBuilder(resource)
-        .AddMeter("*")
-        .AddOtlpExporter()
+    .WithMetrics(b => b.AddMeter("*")
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation())
-    .WithLogging(b => b.SetResourceBuilder(resource)
-        .AddOtlpExporter());
+    .WithLogging()
+    .UseOtlpExporter();
 
 var app = builder.Build();
 

--- a/samples/AspNetCoreSseServer/Program.cs
+++ b/samples/AspNetCoreSseServer/Program.cs
@@ -1,9 +1,30 @@
 using TestServerWithHosting.Tools;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using AspNetCoreSseServer.Tools;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddMcpServer()
     .WithTools<EchoTool>()
-    .WithTools<SampleLlmTool>();
+    .WithTools<SampleLlmTool>()
+    .WithTools<LongRunningTool>();
+
+var resource = ResourceBuilder.CreateEmpty().AddService("mcp.server");
+builder.Services.AddOpenTelemetry()
+    .WithTracing(b => b.SetResourceBuilder(resource)
+        .AddOtlpExporter()
+        .AddSource("*")
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation())
+    .WithMetrics(b => b.SetResourceBuilder(resource)
+        .AddMeter("*")
+        .AddOtlpExporter()
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation())
+    .WithLogging(b => b.SetResourceBuilder(resource)
+        .AddOtlpExporter());
 
 var app = builder.Build();
 

--- a/samples/AspNetCoreSseServer/Properties/launchSettings.json
+++ b/samples/AspNetCoreSseServer/Properties/launchSettings.json
@@ -6,7 +6,8 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:3001",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "OTEL_SERVICE_NAME": "sse-server",
       }
     },
     "https": {
@@ -14,7 +15,8 @@
       "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:7133;http://localhost:3001",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "OTEL_SERVICE_NAME": "sse-server",
       }
     }
   }

--- a/samples/ChatWithTools/ChatWithTools.csproj
+++ b/samples/ChatWithTools/ChatWithTools.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Microsoft.Extensions.AI" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
     <PackageReference Include="Anthropic.SDK" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ChatWithTools/Program.cs
+++ b/samples/ChatWithTools/Program.cs
@@ -8,7 +8,6 @@ using OpenTelemetry.Trace;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
-using ModelContextProtocol.Protocol.Types;
 
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddHttpClientInstrumentation()
@@ -42,12 +41,9 @@ var mcpClient = await McpClientFactory.CreateAsync(
         Arguments = ["-y", "--verbose", "@modelcontextprotocol/server-everything"],
         Name = "Everything",
     }),
-    clientOptions: new McpClientOptions()
+    clientOptions: new()
     {
-        Capabilities = new ClientCapabilities()
-        {
-            Sampling = new SamplingCapability() { SamplingHandler = samplingClient.CreateSamplingHandler() }
-        },
+        Capabilities = new() { Sampling = new() { SamplingHandler = samplingClient.CreateSamplingHandler() } },
     },
     loggerFactory: loggerFactory);
 

--- a/samples/ChatWithTools/Program.cs
+++ b/samples/ChatWithTools/Program.cs
@@ -69,11 +69,10 @@ List<ChatMessage> messages = [];
 while (true)
 {
     Console.Write("Q: ");
-
     messages.Add(new(ChatRole.User, Console.ReadLine()));
 
     List<ChatResponseUpdate> updates = [];
-    await foreach (var update in chatClient.GetStreamingResponseAsync(messages, new() { Tools = [.. tools]}))
+    await foreach (var update in chatClient.GetStreamingResponseAsync(messages, new() { Tools = [.. tools] }))
     {
         Console.Write(update);
         updates.Add(update);

--- a/samples/EverythingServer/EverythingServer.csproj
+++ b/samples/EverythingServer/EverythingServer.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
   </ItemGroup>
 

--- a/samples/EverythingServer/EverythingServer.csproj
+++ b/samples/EverythingServer/EverythingServer.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/EverythingServer/Program.cs
+++ b/samples/EverythingServer/Program.cs
@@ -8,6 +8,9 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
@@ -185,6 +188,20 @@ builder.Services
 
         return new EmptyResult();
     });
+
+
+var resource = ResourceBuilder.CreateEmpty().AddService("mcp.server");
+builder.Services.AddOpenTelemetry()
+    .WithTracing(b => b.SetResourceBuilder(resource)
+        .AddOtlpExporter()
+        .AddSource("*")
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation())
+    .WithMetrics(b => b.SetResourceBuilder(resource)
+        .AddMeter("*")
+        .AddOtlpExporter()
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation());
 
 builder.Services.AddSingleton(subscriptions);
 builder.Services.AddHostedService<SubscriptionMessageSender>();

--- a/samples/EverythingServer/Program.cs
+++ b/samples/EverythingServer/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol.Types;
 using ModelContextProtocol.Server;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -201,7 +202,9 @@ builder.Services.AddOpenTelemetry()
         .AddMeter("*")
         .AddOtlpExporter()
         .AddAspNetCoreInstrumentation()
-        .AddHttpClientInstrumentation());
+        .AddHttpClientInstrumentation())
+    .WithLogging(b => b.SetResourceBuilder(resource)
+        .AddOtlpExporter());
 
 builder.Services.AddSingleton(subscriptions);
 builder.Services.AddHostedService<SubscriptionMessageSender>();

--- a/src/ModelContextProtocol/Diagnostics.cs
+++ b/src/ModelContextProtocol/Diagnostics.cs
@@ -40,9 +40,7 @@ internal static class Diagnostics
 
     internal static ActivityContext ExtractActivityContext(this DistributedContextPropagator propagator, IJsonRpcMessage message)
     {
-        string? traceparent = null;
-        string? tracestate = null;
-        propagator?.ExtractTraceIdAndState(message, ExtractContext, out traceparent, out tracestate);
+        propagator.ExtractTraceIdAndState(message, ExtractContext, out var traceparent, out var tracestate);
         ActivityContext.TryParse(traceparent, tracestate, true, out var activityContext);
         return activityContext;
     }
@@ -76,7 +74,7 @@ internal static class Diagnostics
     internal static void InjectActivityContext(this DistributedContextPropagator propagator, Activity? activity, IJsonRpcMessage message)
     {
         // noop if activity is null
-        propagator?.Inject(activity, message, InjectContext);
+        propagator.Inject(activity, message, InjectContext);
     }
 
     private static void InjectContext(object? message, string key, string value)

--- a/src/ModelContextProtocol/Diagnostics.cs
+++ b/src/ModelContextProtocol/Diagnostics.cs
@@ -1,5 +1,8 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using ModelContextProtocol.Protocol.Messages;
 
 namespace ModelContextProtocol;
 
@@ -34,4 +37,79 @@ internal static class Diagnostics
         HistogramBucketBoundaries = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300],
     };
 #endif
+
+    internal static ActivityContext ExtractActivityContext(this DistributedContextPropagator propagator, IJsonRpcMessage message)
+    {
+        string? traceparent = null;
+        string? tracestate = null;
+        propagator?.ExtractTraceIdAndState(message, ExtractContext, out traceparent, out tracestate);
+        ActivityContext.TryParse(traceparent, tracestate, true, out var activityContext);
+        return activityContext;
+    }
+
+    private static void ExtractContext(object? message, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues)
+    {
+        fieldValues = null;
+        fieldValue = null;
+
+        JsonNode? parameters = null;
+        switch (message)
+        {
+            case JsonRpcRequest request:
+                parameters = request.Params;
+                break;
+
+            case JsonRpcNotification notification:
+                parameters = notification.Params;
+                break;
+
+            default:
+                break;
+        }
+
+        if (parameters?[fieldName] is JsonValue value && value.GetValueKind() == JsonValueKind.String)
+        {
+            fieldValue = value.GetValue<string>();
+        }
+    }
+
+    internal static void InjectActivityContext(this DistributedContextPropagator propagator, Activity? activity, IJsonRpcMessage message)
+    {
+        // noop if activity is null
+        propagator?.Inject(activity, message, InjectContext);
+    }
+
+    private static void InjectContext(object? message, string key, string value)
+    {
+        JsonNode? parameters = null;
+        switch (message)
+        {
+            case JsonRpcRequest request:
+                parameters = request.Params;
+                break;
+
+            case JsonRpcNotification notification:
+                parameters = notification.Params;
+                break;
+
+            default:
+                break;
+        }
+
+        if (parameters is JsonObject jsonObject && jsonObject[key] == null)
+        {
+            jsonObject[key] = value;
+        }
+    }
+
+    internal static bool ShouldInstrumentMessage(IJsonRpcMessage message) =>
+        ActivitySource.HasListeners() &&
+        message switch
+        {
+            JsonRpcRequest => true,
+            JsonRpcNotification notification => notification.Method != NotificationMethods.LoggingMessageNotification,
+            _ => false
+        };
+
+    internal static ActivityLink[] ActivityLinkFromCurrent() => Activity.Current is null ? [] : [new ActivityLink(Activity.Current.Context)];
 }

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -516,8 +516,7 @@ internal sealed class McpSession : IDisposable
         tags.Add("mcp.method.name", method);
         tags.Add("network.transport", _transportKind);
 
-        // RPC convention also includes:
-        // server.address, server.port, client.address, client.port, network.peer.address, network.peer.port, network.type
+        // MCP convention also includes: server.address, server.port, client.address, client.port
 
         if (activity is { IsAllDataRequested: true })
         {
@@ -553,6 +552,7 @@ internal sealed class McpSession : IDisposable
                     target = toolName;
                 }
                 break;
+
             case RequestMethods.PromptsGet:
                 string? promptName = GetStringProperty(paramsObj, "name");
                 if (promptName is not null)
@@ -616,6 +616,7 @@ internal sealed class McpSession : IDisposable
                 {
                     content = prop.ToJsonString();
                 }
+
                 activity.SetStatus(ActivityStatusCode.Error, content);
             }
 
@@ -654,7 +655,8 @@ internal sealed class McpSession : IDisposable
         {
             TagList tags = default;
             tags.Add("network.transport", _transportKind);
-            // TODO server.address, server.port, client.address, client.port, network.peer.address, network.peer.port, network.type
+
+            // MCP convention also includes: server.address, server.port, client.address, client.port
             durationMetric.Record(GetElapsed(_sessionStartingTimestamp).TotalSeconds, tags);
         }
 

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -450,7 +450,7 @@ internal sealed class McpSession : IDisposable
         TagList tags = default;
         bool addTags = activity is { IsAllDataRequested: true } || startingTimestamp is not null;
 
-        // propagate trace context, noop if activity is null
+        // propagate trace context
         _propagator?.InjectActivityContext(activity, message);
 
         try
@@ -507,7 +507,6 @@ internal sealed class McpSession : IDisposable
         {
             JsonRpcRequest request => request.Method,
             JsonRpcNotification notification => notification.Method,
-            not null => message.GetType().FullName ?? "unknownMethod",
             _ => "unknownMethod"
         };
 

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -197,7 +197,8 @@ internal sealed class McpSession : IDisposable
             Diagnostics.ActivitySource.StartActivity(
                 CreateActivityName(method),
                 ActivityKind.Server,
-                parentContext: ExtractActivityContext(message)) :
+                parentContext: ExtractActivityContext(message),
+                links: FromCurrent()) :
             null;
 
         TagList tags = default;
@@ -743,4 +744,12 @@ internal sealed class McpSession : IDisposable
             JsonRpcNotification notification => notification.Method != NotificationMethods.LoggingMessageNotification,
             _ => false
         };
+
+    private static ActivityLink[] FromCurrent() {
+        if (Activity.Current is { } activity) {
+            return [new ActivityLink(activity.Context)];
+        }
+
+        return Array.Empty<ActivityLink>();
+    }
 }

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -10,6 +10,9 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+#if !NET
+using System.Threading.Channels;
+#endif
 
 namespace ModelContextProtocol.Shared;
 
@@ -515,7 +518,7 @@ internal sealed class McpSession : IDisposable
         tags.Add("mcp.method.name", method);
         tags.Add("network.transport", _transportKind);
 
-        // TODO (lmolkova), when using SSE transport, add:
+        // TODO: When using SSE transport, add:
         // - server.address and server.port on client spans and metrics
         // - client.address and client.port on server spans (not metrics because of cardinality) when using SSE transport
         if (activity is { IsAllDataRequested: true })
@@ -646,7 +649,7 @@ internal sealed class McpSession : IDisposable
             TagList tags = default;
             tags.Add("network.transport", _transportKind);
 
-            // TODO (lmolkova): add server.address and server.port on client-side when using SSE transport,
+            // TODO: Add server.address and server.port on client-side when using SSE transport,
             // client.* attributes are not added to metrics because of cardinality
             durationMetric.Record(GetElapsed(_sessionStartingTimestamp).TotalSeconds, tags);
         }

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -645,6 +645,9 @@ internal sealed class McpSession : IDisposable
         {
             TagList tags = default;
             tags.Add("network.transport", _transportKind);
+
+            // TODO (lmolkova): add server.address and server.port on client-side when using SSE transport,
+            // client.* attributes are not added to metrics because of cardinality
             durationMetric.Record(GetElapsed(_sessionStartingTimestamp).TotalSeconds, tags);
         }
 

--- a/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
+++ b/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
@@ -4,6 +4,7 @@ using ModelContextProtocol.Server;
 using OpenTelemetry.Trace;
 using System.Diagnostics;
 using System.IO.Pipelines;
+using System.Reflection.Metadata;
 
 namespace ModelContextProtocol.Tests;
 
@@ -33,9 +34,95 @@ public class DiagnosticTests
 
         Assert.NotEmpty(activities);
 
-        Activity toolCallActivity = activities.First(a =>
-            a.Tags.Any(t => t.Key == "rpc.method" && t.Value == "tools/call"));
-        Assert.Equal("DoubleValue", toolCallActivity.Tags.First(t => t.Key == "mcp.request.params.name").Value);
+        var clientToolCall = Assert.Single(activities, a =>
+            a.Tags.Any(t => t.Key == "mcp.tool.name" && t.Value == "DoubleValue") &&
+            a.Tags.Any(t => t.Key == "mcp.method.name" && t.Value == "tools/call") &&
+            a.DisplayName == "tools/call DoubleValue" &&
+            a.Kind == ActivityKind.Client &&
+            a.Status == ActivityStatusCode.Unset);
+
+        var serverToolCall = Assert.Single(activities, a =>
+            a.Tags.Any(t => t.Key == "mcp.tool.name" && t.Value == "DoubleValue") &&
+            a.Tags.Any(t => t.Key == "mcp.method.name" && t.Value == "tools/call") &&
+            a.DisplayName == "tools/call DoubleValue" &&
+            a.Kind == ActivityKind.Server &&
+            a.Status == ActivityStatusCode.Unset);
+
+        Assert.Equal(clientToolCall.SpanId, serverToolCall.ParentSpanId);
+        Assert.Equal(clientToolCall.TraceId, serverToolCall.TraceId);
+
+        var clientListToolsCall = Assert.Single(activities, a =>
+            a.Tags.Any(t => t.Key == "mcp.method.name" && t.Value == "tools/list") &&
+            a.DisplayName == "tools/list" &&
+            a.Kind == ActivityKind.Client &&
+            a.Status == ActivityStatusCode.Unset);
+
+        var serverListToolsCall = Assert.Single(activities, a =>
+            a.Tags.Any(t => t.Key == "mcp.method.name" && t.Value == "tools/list") &&
+            a.DisplayName == "tools/list" &&
+            a.Kind == ActivityKind.Server &&
+            a.Status == ActivityStatusCode.Unset);
+
+        Assert.Equal(clientListToolsCall.SpanId, serverListToolsCall.ParentSpanId);
+        Assert.Equal(clientListToolsCall.TraceId, serverListToolsCall.TraceId);
+    }
+
+    [Fact]
+    public async Task Session_FailedToolCall()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource("Experimental.ModelContextProtocol")
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            await RunConnected(async (client, server) =>
+            {
+                await client.CallToolAsync("Throw", cancellationToken: TestContext.Current.CancellationToken);
+                await Assert.ThrowsAsync<McpException>(() => client.CallToolAsync("does-not-exist", cancellationToken: TestContext.Current.CancellationToken));
+            });
+        }
+
+        Assert.NotEmpty(activities);
+
+        var throwToolClient = Assert.Single(activities, a =>
+            a.Tags.Any(t => t.Key == "mcp.tool.name" && t.Value == "Throw") &&
+            a.Tags.Any(t => t.Key == "mcp.method.name" && t.Value == "tools/call") &&
+            a.DisplayName == "tools/call Throw" &&
+            a.Kind == ActivityKind.Client);
+
+        Assert.Equal(ActivityStatusCode.Error, throwToolClient.Status);
+        Assert.Equal("[{\"type\":\"text\",\"text\":\"boom\"}]", throwToolClient.StatusDescription);
+
+        var throwToolServer = Assert.Single(activities, a =>
+            a.Tags.Any(t => t.Key == "mcp.tool.name" && t.Value == "Throw") &&
+            a.Tags.Any(t => t.Key == "mcp.method.name" && t.Value == "tools/call") &&
+            a.DisplayName == "tools/call Throw" &&
+            a.Kind == ActivityKind.Server);
+
+        Assert.Equal(ActivityStatusCode.Error, throwToolServer.Status);
+        Assert.Equal("[{\"type\":\"text\",\"text\":\"boom\"}]", throwToolServer.StatusDescription);
+
+        var doesNotExistToolClient = Assert.Single(activities, a =>
+            a.Tags.Any(t => t.Key == "mcp.tool.name" && t.Value == "does-not-exist") &&
+            a.Tags.Any(t => t.Key == "mcp.method.name" && t.Value == "tools/call") &&
+            a.DisplayName == "tools/call does-not-exist" &&
+            a.Kind == ActivityKind.Client);
+
+        Assert.Equal(ActivityStatusCode.Error, doesNotExistToolClient.Status);
+        Assert.Equal("Request failed (server side): Unknown tool 'does-not-exist'", doesNotExistToolClient.StatusDescription);
+        Assert.Equal("-32603", doesNotExistToolClient.Tags.Single(t => t.Key == "rpc.jsonrpc.error_code").Value);
+
+        var doesNotExistToolServer = Assert.Single(activities, a =>
+            a.Tags.Any(t => t.Key == "mcp.tool.name" && t.Value == "does-not-exist") &&
+            a.Tags.Any(t => t.Key == "mcp.method.name" && t.Value == "tools/call") &&
+            a.DisplayName == "tools/call does-not-exist" &&
+            a.Kind == ActivityKind.Server);
+
+        Assert.Equal(ActivityStatusCode.Error, doesNotExistToolServer.Status);
+        Assert.Equal("Request failed (server side): Unknown tool 'does-not-exist'", doesNotExistToolClient.StatusDescription);
+        Assert.Equal("-32603", doesNotExistToolClient.Tags.Single(t => t.Key == "rpc.jsonrpc.error_code").Value);
     }
 
     private static async Task RunConnected(Func<IMcpClient, IMcpServer, Task> action)
@@ -52,7 +139,10 @@ public class DiagnosticTests
                 {
                     Tools = new()
                     {
-                        ToolCollection = [McpServerTool.Create((int amount) => amount * 2, new() { Name = "DoubleValue", Description = "Doubles the value." })],
+                        ToolCollection = [
+                            McpServerTool.Create((int amount) => amount * 2, new() { Name = "DoubleValue", Description = "Doubles the value." }),
+                            McpServerTool.Create(() => { throw new Exception("boom"); }, new() { Name = "Throw", Description = "Throws error." }),
+                        ],
                     }
                 }
             }))

--- a/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
+++ b/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
@@ -4,7 +4,6 @@ using ModelContextProtocol.Server;
 using OpenTelemetry.Trace;
 using System.Diagnostics;
 using System.IO.Pipelines;
-using System.Reflection.Metadata;
 
 namespace ModelContextProtocol.Tests;
 
@@ -93,7 +92,6 @@ public class DiagnosticTests
             a.Kind == ActivityKind.Client);
 
         Assert.Equal(ActivityStatusCode.Error, throwToolClient.Status);
-        Assert.Equal("[{\"type\":\"text\",\"text\":\"boom\"}]", throwToolClient.StatusDescription);
 
         var throwToolServer = Assert.Single(activities, a =>
             a.Tags.Any(t => t.Key == "mcp.tool.name" && t.Value == "Throw") &&
@@ -102,7 +100,6 @@ public class DiagnosticTests
             a.Kind == ActivityKind.Server);
 
         Assert.Equal(ActivityStatusCode.Error, throwToolServer.Status);
-        Assert.Equal("[{\"type\":\"text\",\"text\":\"boom\"}]", throwToolServer.StatusDescription);
 
         var doesNotExistToolClient = Assert.Single(activities, a =>
             a.Tags.Any(t => t.Key == "mcp.tool.name" && t.Value == "does-not-exist") &&
@@ -111,7 +108,6 @@ public class DiagnosticTests
             a.Kind == ActivityKind.Client);
 
         Assert.Equal(ActivityStatusCode.Error, doesNotExistToolClient.Status);
-        Assert.Equal("Request failed (server side): Unknown tool 'does-not-exist'", doesNotExistToolClient.StatusDescription);
         Assert.Equal("-32603", doesNotExistToolClient.Tags.Single(t => t.Key == "rpc.jsonrpc.error_code").Value);
 
         var doesNotExistToolServer = Assert.Single(activities, a =>
@@ -121,7 +117,6 @@ public class DiagnosticTests
             a.Kind == ActivityKind.Server);
 
         Assert.Equal(ActivityStatusCode.Error, doesNotExistToolServer.Status);
-        Assert.Equal("Request failed (server side): Unknown tool 'does-not-exist'", doesNotExistToolClient.StatusDescription);
         Assert.Equal("-32603", doesNotExistToolClient.Tags.Single(t => t.Key == "rpc.jsonrpc.error_code").Value);
     }
 


### PR DESCRIPTION
This is a prototype of https://github.com/open-telemetry/semantic-conventions/pull/2083:

- includes client to server context propagation
- more MCP and less JSON RPC context
- disable spans for log notification - they are written as logs

TODO:
- [x] tests
- [ ] docs, especially for server developers on how to enable OTel with less boilerplate
- [x] clean up examples