### PR TITLE
Wrap each request in a service scope

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,9 @@ root = true
 # C# files
 [*.cs]
 
+# Compiler
+dotnet_diagnostic.CS1998.severity = suggestion      # CS1998: Missing awaits
+
 # Code Analysis
 dotnet_diagnostic.CA1002.severity = none            # CA1002: Do not expose generic lists
 dotnet_diagnostic.CA1031.severity = none            # CA1031: Do not catch general exception types

--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -948,7 +948,7 @@ public static class McpClientExtensions
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="chatClient"/> is <see langword="null"/>.</exception>
-    public static Func<CreateMessageRequestParams?, IProgress<ProgressNotificationValue>, CancellationToken, Task<CreateMessageResult>> CreateSamplingHandler(
+    public static Func<CreateMessageRequestParams?, IProgress<ProgressNotificationValue>, CancellationToken, ValueTask<CreateMessageResult>> CreateSamplingHandler(
         this IChatClient chatClient)
     {
         Throw.IfNull(chatClient);

--- a/src/ModelContextProtocol/Configuration/McpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol/Configuration/McpServerBuilderExtensions.cs
@@ -270,7 +270,7 @@ public static partial class McpServerBuilderExtensions
     /// resource system where templates define the URI patterns and the read handler provides the actual content.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithListResourceTemplatesHandler(this IMcpServerBuilder builder, Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>> handler)
+    public static IMcpServerBuilder WithListResourceTemplatesHandler(this IMcpServerBuilder builder, Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>> handler)
     {
         Throw.IfNull(builder);
 
@@ -303,7 +303,7 @@ public static partial class McpServerBuilderExtensions
     /// executes them when invoked by clients.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithListToolsHandler(this IMcpServerBuilder builder, Func<RequestContext<ListToolsRequestParams>, CancellationToken, Task<ListToolsResult>> handler)
+    public static IMcpServerBuilder WithListToolsHandler(this IMcpServerBuilder builder, Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>> handler)
     {
         Throw.IfNull(builder);
 
@@ -323,7 +323,7 @@ public static partial class McpServerBuilderExtensions
     /// This method is typically paired with <see cref="WithListToolsHandler"/> to provide a complete tools implementation,
     /// where <see cref="WithListToolsHandler"/> advertises available tools and this handler executes them.
     /// </remarks>
-    public static IMcpServerBuilder WithCallToolHandler(this IMcpServerBuilder builder, Func<RequestContext<CallToolRequestParams>, CancellationToken, Task<CallToolResponse>> handler)
+    public static IMcpServerBuilder WithCallToolHandler(this IMcpServerBuilder builder, Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResponse>> handler)
     {
         Throw.IfNull(builder);
 
@@ -356,7 +356,7 @@ public static partial class McpServerBuilderExtensions
     /// produces them when invoked by clients.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithListPromptsHandler(this IMcpServerBuilder builder, Func<RequestContext<ListPromptsRequestParams>, CancellationToken, Task<ListPromptsResult>> handler)
+    public static IMcpServerBuilder WithListPromptsHandler(this IMcpServerBuilder builder, Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>> handler)
     {
         Throw.IfNull(builder);
 
@@ -371,7 +371,7 @@ public static partial class McpServerBuilderExtensions
     /// <param name="handler">The handler function that processes prompt requests.</param>
     /// <returns>The builder provided in <paramref name="builder"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
-    public static IMcpServerBuilder WithGetPromptHandler(this IMcpServerBuilder builder, Func<RequestContext<GetPromptRequestParams>, CancellationToken, Task<GetPromptResult>> handler)
+    public static IMcpServerBuilder WithGetPromptHandler(this IMcpServerBuilder builder, Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>> handler)
     {
         Throw.IfNull(builder);
 
@@ -392,7 +392,7 @@ public static partial class McpServerBuilderExtensions
     /// where this handler advertises available resources and the read handler provides their content when requested.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithListResourcesHandler(this IMcpServerBuilder builder, Func<RequestContext<ListResourcesRequestParams>, CancellationToken, Task<ListResourcesResult>> handler)
+    public static IMcpServerBuilder WithListResourcesHandler(this IMcpServerBuilder builder, Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>> handler)
     {
         Throw.IfNull(builder);
 
@@ -411,7 +411,7 @@ public static partial class McpServerBuilderExtensions
     /// This handler is typically paired with <see cref="WithListResourcesHandler"/> to provide a complete resources implementation,
     /// where the list handler advertises available resources and the read handler provides their content when requested.
     /// </remarks>
-    public static IMcpServerBuilder WithReadResourceHandler(this IMcpServerBuilder builder, Func<RequestContext<ReadResourceRequestParams>, CancellationToken, Task<ReadResourceResult>> handler)
+    public static IMcpServerBuilder WithReadResourceHandler(this IMcpServerBuilder builder, Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>> handler)
     {
         Throw.IfNull(builder);
 
@@ -430,7 +430,7 @@ public static partial class McpServerBuilderExtensions
     /// The completion handler is invoked when clients request suggestions for argument values. 
     /// This enables auto-complete functionality for both prompt arguments and resource references.
     /// </remarks>
-    public static IMcpServerBuilder WithCompleteHandler(this IMcpServerBuilder builder, Func<RequestContext<CompleteRequestParams>, CancellationToken, Task<CompleteResult>> handler)
+    public static IMcpServerBuilder WithCompleteHandler(this IMcpServerBuilder builder, Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>> handler)
     {
         Throw.IfNull(builder);
 
@@ -460,7 +460,7 @@ public static partial class McpServerBuilderExtensions
     /// resources and to send appropriate notifications through the connection when resources change.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithSubscribeToResourcesHandler(this IMcpServerBuilder builder, Func<RequestContext<SubscribeRequestParams>, CancellationToken, Task<EmptyResult>> handler)
+    public static IMcpServerBuilder WithSubscribeToResourcesHandler(this IMcpServerBuilder builder, Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>> handler)
     {
         Throw.IfNull(builder);
 
@@ -490,7 +490,7 @@ public static partial class McpServerBuilderExtensions
     /// to the specified resource.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithUnsubscribeFromResourcesHandler(this IMcpServerBuilder builder, Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, Task<EmptyResult>> handler)
+    public static IMcpServerBuilder WithUnsubscribeFromResourcesHandler(this IMcpServerBuilder builder, Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>> handler)
     {
         Throw.IfNull(builder);
 
@@ -517,7 +517,7 @@ public static partial class McpServerBuilderExtensions
     /// most recently set level.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithSetLoggingLevelHandler(this IMcpServerBuilder builder, Func<RequestContext<SetLevelRequestParams>, CancellationToken, Task<EmptyResult>> handler)
+    public static IMcpServerBuilder WithSetLoggingLevelHandler(this IMcpServerBuilder builder, Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>> handler)
     {
         Throw.IfNull(builder);
 

--- a/src/ModelContextProtocol/IMcpEndpoint.cs
+++ b/src/ModelContextProtocol/IMcpEndpoint.cs
@@ -69,5 +69,5 @@ public interface IMcpEndpoint : IAsyncDisposable
     /// <param name="method">The notification method.</param>
     /// <param name="handler">The handler to be invoked.</param>
     /// <returns>An <see cref="IDisposable"/> that will remove the registered handler when disposed.</returns>
-    IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, Task> handler);
+    IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler);
 }

--- a/src/ModelContextProtocol/Protocol/Types/ClientCapabilities.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ClientCapabilities.cs
@@ -77,5 +77,5 @@ public class ClientCapabilities
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public IEnumerable<KeyValuePair<string, Func<JsonRpcNotification, CancellationToken, Task>>>? NotificationHandlers { get; set; }
+    public IEnumerable<KeyValuePair<string, Func<JsonRpcNotification, CancellationToken, ValueTask>>>? NotificationHandlers { get; set; }
 }

--- a/src/ModelContextProtocol/Protocol/Types/CompletionsCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/CompletionsCapability.cs
@@ -33,5 +33,5 @@ public class CompletionsCapability
     /// and should return appropriate completion suggestions.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<CompleteRequestParams>, CancellationToken, Task<CompleteResult>>? CompleteHandler { get; set; }
+    public Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>? CompleteHandler { get; set; }
 }

--- a/src/ModelContextProtocol/Protocol/Types/EmptyResult.cs
+++ b/src/ModelContextProtocol/Protocol/Types/EmptyResult.cs
@@ -9,5 +9,5 @@ namespace ModelContextProtocol.Protocol.Types;
 public class EmptyResult
 {
     [JsonIgnore]
-    internal static Task<EmptyResult> CompletedTask { get; } = Task.FromResult(new EmptyResult());
+    internal static EmptyResult Instance { get; } = new();
 }

--- a/src/ModelContextProtocol/Protocol/Types/LoggingCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/LoggingCapability.cs
@@ -19,5 +19,5 @@ public class LoggingCapability
     /// Gets or sets the handler for set logging level requests from clients.
     /// </summary>
     [JsonIgnore]
-    public Func<RequestContext<SetLevelRequestParams>, CancellationToken, Task<EmptyResult>>? SetLoggingLevelHandler { get; set; }
+    public Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>? SetLoggingLevelHandler { get; set; }
 }

--- a/src/ModelContextProtocol/Protocol/Types/PromptsCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/PromptsCapability.cs
@@ -41,7 +41,7 @@ public class PromptsCapability
     /// along with any prompts defined in <see cref="PromptCollection"/>.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<ListPromptsRequestParams>, CancellationToken, Task<ListPromptsResult>>? ListPromptsHandler { get; set; }
+    public Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>? ListPromptsHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.PromptsGet"/> requests.
@@ -58,7 +58,7 @@ public class PromptsCapability
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<GetPromptRequestParams>, CancellationToken, Task<GetPromptResult>>? GetPromptHandler { get; set; }
+    public Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>? GetPromptHandler { get; set; }
 
     /// <summary>
     /// Gets or sets a collection of prompts that will be served by the server.

--- a/src/ModelContextProtocol/Protocol/Types/ResourcesCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ResourcesCapability.cs
@@ -40,7 +40,7 @@ public class ResourcesCapability
     /// allowing clients to discover available resource types and their access patterns.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>>? ListResourceTemplatesHandler { get; set; }
+    public Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>? ListResourceTemplatesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesList"/> requests.
@@ -50,7 +50,7 @@ public class ResourcesCapability
     /// The implementation should return a <see cref="ListResourcesResult"/> with the matching resources.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<ListResourcesRequestParams>, CancellationToken, Task<ListResourcesResult>>? ListResourcesHandler { get; set; }
+    public Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>? ListResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesRead"/> requests.
@@ -62,7 +62,7 @@ public class ResourcesCapability
     /// its contents in a ReadResourceResult object.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<ReadResourceRequestParams>, CancellationToken, Task<ReadResourceResult>>? ReadResourceHandler { get; set; }
+    public Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>? ReadResourceHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesSubscribe"/> requests.
@@ -75,7 +75,7 @@ public class ResourcesCapability
     /// requiring polling.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<SubscribeRequestParams>, CancellationToken, Task<EmptyResult>>? SubscribeToResourcesHandler { get; set; }
+    public Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>? SubscribeToResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesUnsubscribe"/> requests.
@@ -86,5 +86,5 @@ public class ResourcesCapability
     /// about the specified resource.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, Task<EmptyResult>>? UnsubscribeFromResourcesHandler { get; set; }
+    public Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>? UnsubscribeFromResourcesHandler { get; set; }
 }

--- a/src/ModelContextProtocol/Protocol/Types/RootsCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/RootsCapability.cs
@@ -41,5 +41,5 @@ public class RootsCapability
     /// The handler receives request parameters and should return a <see cref="ListRootsResult"/> containing the collection of available roots.
     /// </remarks>
     [JsonIgnore]
-    public Func<ListRootsRequestParams?, CancellationToken, Task<ListRootsResult>>? RootsHandler { get; set; }
+    public Func<ListRootsRequestParams?, CancellationToken, ValueTask<ListRootsResult>>? RootsHandler { get; set; }
 }

--- a/src/ModelContextProtocol/Protocol/Types/SamplingCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/SamplingCapability.cs
@@ -40,5 +40,5 @@ public class SamplingCapability
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public Func<CreateMessageRequestParams?, IProgress<ProgressNotificationValue>, CancellationToken, Task<CreateMessageResult>>? SamplingHandler { get; set; }
+    public Func<CreateMessageRequestParams?, IProgress<ProgressNotificationValue>, CancellationToken, ValueTask<CreateMessageResult>>? SamplingHandler { get; set; }
 }

--- a/src/ModelContextProtocol/Protocol/Types/ServerCapabilities.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ServerCapabilities.cs
@@ -83,5 +83,5 @@ public class ServerCapabilities
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public IEnumerable<KeyValuePair<string, Func<JsonRpcNotification, CancellationToken, Task>>>? NotificationHandlers { get; set; }
+    public IEnumerable<KeyValuePair<string, Func<JsonRpcNotification, CancellationToken, ValueTask>>>? NotificationHandlers { get; set; }
 }

--- a/src/ModelContextProtocol/Protocol/Types/ToolsCapability.cs
+++ b/src/ModelContextProtocol/Protocol/Types/ToolsCapability.cs
@@ -34,7 +34,7 @@ public class ToolsCapability
     /// and the tools from the collection will be combined to form the complete list of available tools.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<ListToolsRequestParams>, CancellationToken, Task<ListToolsResult>>? ListToolsHandler { get; set; }
+    public Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>? ListToolsHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ToolsCall"/> requests.
@@ -46,7 +46,7 @@ public class ToolsCapability
     /// being called and its arguments, and should return a <see cref="CallToolResponse"/> with the execution results.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<CallToolRequestParams>, CancellationToken, Task<CallToolResponse>>? CallToolHandler { get; set; }
+    public Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResponse>>? CallToolHandler { get; set; }
 
     /// <summary>
     /// Gets or sets a collection of tools served by the server.

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerPrompt.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerPrompt.cs
@@ -97,7 +97,7 @@ internal sealed class AIFunctionMcpServerPrompt : McpServerPrompt
                     {
                         ExcludeFromSchema = true,
                         BindParameter = (pi, args) =>
-                            GetRequestContext(args)?.Server?.Services?.GetService(pi.ParameterType) ??
+                            GetRequestContext(args)?.Services?.GetService(pi.ParameterType) ??
                             (pi.HasDefaultValue ? null :
                              throw new ArgumentException("No service of the requested type was found.")),
                     };
@@ -109,7 +109,7 @@ internal sealed class AIFunctionMcpServerPrompt : McpServerPrompt
                     {
                         ExcludeFromSchema = true,
                         BindParameter = (pi, args) =>
-                            (GetRequestContext(args)?.Server?.Services as IKeyedServiceProvider)?.GetKeyedService(pi.ParameterType, keyedAttr.Key) ??
+                            (GetRequestContext(args)?.Services as IKeyedServiceProvider)?.GetKeyedService(pi.ParameterType, keyedAttr.Key) ??
                             (pi.HasDefaultValue ? null :
                              throw new ArgumentException("No service of the requested type was found.")),
                     };
@@ -208,7 +208,7 @@ internal sealed class AIFunctionMcpServerPrompt : McpServerPrompt
 
         AIFunctionArguments arguments = new()
         {
-            Services = request.Server?.Services,
+            Services = request.Services,
             Context = new Dictionary<object, object?>() { [typeof(RequestContext<GetPromptRequestParams>)] = request }
         };
 

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerPrompt.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerPrompt.cs
@@ -200,7 +200,7 @@ internal sealed class AIFunctionMcpServerPrompt : McpServerPrompt
     ///   <item><description><see cref="ChatMessage"/> objects are converted to prompt messages</description></item>
     /// </list>
     /// </remarks>
-    public override async Task<GetPromptResult> GetAsync(
+    public override async ValueTask<GetPromptResult> GetAsync(
         RequestContext<GetPromptRequestParams> request, CancellationToken cancellationToken = default)
     {
         Throw.IfNull(request);

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -120,7 +120,7 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
                     {
                         ExcludeFromSchema = true,
                         BindParameter = (pi, args) =>
-                            GetRequestContext(args)?.Server?.Services?.GetService(pi.ParameterType) ??
+                            GetRequestContext(args)?.Services?.GetService(pi.ParameterType) ??
                             (pi.HasDefaultValue ? null :
                              throw new ArgumentException("No service of the requested type was found.")),
                     };
@@ -132,7 +132,7 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
                     {
                         ExcludeFromSchema = true,
                         BindParameter = (pi, args) =>
-                            (GetRequestContext(args)?.Server?.Services as IKeyedServiceProvider)?.GetKeyedService(pi.ParameterType, keyedAttr.Key) ??
+                            (GetRequestContext(args)?.Services as IKeyedServiceProvider)?.GetKeyedService(pi.ParameterType, keyedAttr.Key) ??
                             (pi.HasDefaultValue ? null :
                              throw new ArgumentException("No service of the requested type was found.")),
                     };
@@ -245,7 +245,7 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
 
         AIFunctionArguments arguments = new()
         {
-            Services = request.Server?.Services,
+            Services = request.Services,
             Context = new Dictionary<object, object?>() { [typeof(RequestContext<CallToolRequestParams>)] = request }
         };
 

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -237,7 +237,7 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
     public override Tool ProtocolTool { get; }
 
     /// <inheritdoc />
-    public override async Task<CallToolResponse> InvokeAsync(
+    public override async ValueTask<CallToolResponse> InvokeAsync(
         RequestContext<CallToolRequestParams> request, CancellationToken cancellationToken = default)
     {
         Throw.IfNull(request);

--- a/src/ModelContextProtocol/Server/DelegatingMcpServerPrompt.cs
+++ b/src/ModelContextProtocol/Server/DelegatingMcpServerPrompt.cs
@@ -24,7 +24,7 @@ public abstract class DelegatingMcpServerPrompt : McpServerPrompt
     public override Prompt ProtocolPrompt => _innerPrompt.ProtocolPrompt;
 
     /// <inheritdoc />
-    public override Task<GetPromptResult> GetAsync(
+    public override ValueTask<GetPromptResult> GetAsync(
         RequestContext<GetPromptRequestParams> request, 
         CancellationToken cancellationToken = default) =>
         _innerPrompt.GetAsync(request, cancellationToken);

--- a/src/ModelContextProtocol/Server/DelegatingMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/DelegatingMcpServerTool.cs
@@ -24,7 +24,7 @@ public abstract class DelegatingMcpServerTool : McpServerTool
     public override Tool ProtocolTool => _innerTool.ProtocolTool;
 
     /// <inheritdoc />
-    public override Task<CallToolResponse> InvokeAsync(
+    public override ValueTask<CallToolResponse> InvokeAsync(
         RequestContext<CallToolRequestParams> request, 
         CancellationToken cancellationToken = default) =>
         _innerTool.InvokeAsync(request, cancellationToken);

--- a/src/ModelContextProtocol/Server/McpServerHandlers.cs
+++ b/src/ModelContextProtocol/Server/McpServerHandlers.cs
@@ -41,7 +41,7 @@ public sealed class McpServerHandlers
     /// Tools from both sources will be combined when returning results to clients.
     /// </para>
     /// </remarks>
-    public Func<RequestContext<ListToolsRequestParams>, CancellationToken, Task<ListToolsResult>>? ListToolsHandler { get; set; }
+    public Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>? ListToolsHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ToolsCall"/> requests.
@@ -50,7 +50,7 @@ public sealed class McpServerHandlers
     /// This handler is invoked when a client makes a call to a tool that isn't found in the <see cref="McpServerTool"/> collection.
     /// The handler should implement logic to execute the requested tool and return appropriate results.
     /// </remarks>
-    public Func<RequestContext<CallToolRequestParams>, CancellationToken, Task<CallToolResponse>>? CallToolHandler { get; set; }
+    public Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResponse>>? CallToolHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.PromptsList"/> requests.
@@ -66,7 +66,7 @@ public sealed class McpServerHandlers
     /// Prompts from both sources will be combined when returning results to clients.
     /// </para>
     /// </remarks>
-    public Func<RequestContext<ListPromptsRequestParams>, CancellationToken, Task<ListPromptsResult>>? ListPromptsHandler { get; set; }
+    public Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>? ListPromptsHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.PromptsGet"/> requests.
@@ -75,7 +75,7 @@ public sealed class McpServerHandlers
     /// This handler is invoked when a client requests details for a specific prompt that isn't found in the <see cref="McpServerPrompt"/> collection.
     /// The handler should implement logic to fetch or generate the requested prompt and return appropriate results.
     /// </remarks>
-    public Func<RequestContext<GetPromptRequestParams>, CancellationToken, Task<GetPromptResult>>? GetPromptHandler { get; set; }
+    public Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>? GetPromptHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesTemplatesList"/> requests.
@@ -85,7 +85,7 @@ public sealed class McpServerHandlers
     /// It supports pagination through the cursor mechanism, where the client can make
     /// repeated calls with the cursor returned by the previous call to retrieve more resource templates.
     /// </remarks>
-    public Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>>? ListResourceTemplatesHandler { get; set; }
+    public Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>? ListResourceTemplatesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesList"/> requests.
@@ -95,7 +95,7 @@ public sealed class McpServerHandlers
     /// It supports pagination through the cursor mechanism, where the client can make
     /// repeated calls with the cursor returned by the previous call to retrieve more resources.
     /// </remarks>
-    public Func<RequestContext<ListResourcesRequestParams>, CancellationToken, Task<ListResourcesResult>>? ListResourcesHandler { get; set; }
+    public Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>? ListResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesRead"/> requests.
@@ -104,7 +104,7 @@ public sealed class McpServerHandlers
     /// This handler is invoked when a client requests the content of a specific resource identified by its URI.
     /// The handler should implement logic to locate and retrieve the requested resource.
     /// </remarks>
-    public Func<RequestContext<ReadResourceRequestParams>, CancellationToken, Task<ReadResourceResult>>? ReadResourceHandler { get; set; }
+    public Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>? ReadResourceHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.CompletionComplete"/> requests.
@@ -114,7 +114,7 @@ public sealed class McpServerHandlers
     /// The handler processes auto-completion requests, returning a list of suggestions based on the 
     /// reference type and current argument value.
     /// </remarks>
-    public Func<RequestContext<CompleteRequestParams>, CancellationToken, Task<CompleteResult>>? CompleteHandler { get; set; }
+    public Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>? CompleteHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesSubscribe"/> requests.
@@ -130,7 +130,7 @@ public sealed class McpServerHandlers
     /// whenever a relevant resource is created, updated, or deleted.
     /// </para>
     /// </remarks>
-    public Func<RequestContext<SubscribeRequestParams>, CancellationToken, Task<EmptyResult>>? SubscribeToResourcesHandler { get; set; }
+    public Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>? SubscribeToResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesUnsubscribe"/> requests.
@@ -146,7 +146,7 @@ public sealed class McpServerHandlers
     /// to the client for the specified resources.
     /// </para>
     /// </remarks>
-    public Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, Task<EmptyResult>>? UnsubscribeFromResourcesHandler { get; set; }
+    public Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>? UnsubscribeFromResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.LoggingSetLevel"/> requests.
@@ -161,7 +161,7 @@ public sealed class McpServerHandlers
     /// at or above the specified level to the client as notifications/message notifications.
     /// </para>
     /// </remarks>
-    public Func<RequestContext<SetLevelRequestParams>, CancellationToken, Task<EmptyResult>>? SetLoggingLevelHandler { get; set; }
+    public Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>? SetLoggingLevelHandler { get; set; }
 
     /// <summary>
     /// Overwrite any handlers in McpServerOptions with non-null handlers from this instance.

--- a/src/ModelContextProtocol/Server/McpServerOptions.cs
+++ b/src/ModelContextProtocol/Server/McpServerOptions.cs
@@ -56,4 +56,13 @@ public class McpServerOptions
     /// to provide context about available functionality.
     /// </remarks>
     public string? ServerInstructions { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to create a new service provider scope for each handled request.
+    /// </summary>
+    /// <remarks>
+    /// The default is <see langword="true"/>. When <see langword="true"/>, each invocation of a request
+    /// handler will be invoked within a new service scope.
+    /// </remarks>
+    public bool ScopeRequests { get; set; } = true;
 }

--- a/src/ModelContextProtocol/Server/McpServerPrompt.cs
+++ b/src/ModelContextProtocol/Server/McpServerPrompt.cs
@@ -37,7 +37,7 @@ public abstract class McpServerPrompt : IMcpServerPrimitive
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">The prompt implementation returns <see langword="null"/> or an unsupported result type.</exception>
-    public abstract Task<GetPromptResult> GetAsync(
+    public abstract ValueTask<GetPromptResult> GetAsync(
         RequestContext<GetPromptRequestParams> request,
         CancellationToken cancellationToken = default);
 

--- a/src/ModelContextProtocol/Server/McpServerTool.cs
+++ b/src/ModelContextProtocol/Server/McpServerTool.cs
@@ -23,7 +23,7 @@ public abstract class McpServerTool : IMcpServerPrimitive
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The call response from invoking the tool.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
-    public abstract Task<CallToolResponse> InvokeAsync(
+    public abstract ValueTask<CallToolResponse> InvokeAsync(
         RequestContext<CallToolRequestParams> request,
         CancellationToken cancellationToken = default);
 

--- a/src/ModelContextProtocol/Server/RequestContext.cs
+++ b/src/ModelContextProtocol/Server/RequestContext.cs
@@ -1,9 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Utils;
 
 namespace ModelContextProtocol.Server;
 
 /// <summary>
-/// Provides a context container that provides access to both the server instance and the client request parameters.
+/// Provides a context container that provides access to the client request parameters and resources for the request.
 /// </summary>
 /// <typeparam name="TParams">Type of the request parameters specific to each MCP operation.</typeparam>
 /// <remarks>
@@ -11,4 +12,43 @@ namespace ModelContextProtocol.Server;
 /// This type is typically received as a parameter in handler delegates registered with <see cref="IMcpServerBuilder"/>,
 /// and may be injected as parameters into <see cref="McpServerTool"/>s.
 /// </remarks>
-public record RequestContext<TParams>(IMcpServer Server, TParams? Params);
+public sealed class RequestContext<TParams>
+{
+    /// <summary>The server with which this instance is associated.</summary>
+    private IMcpServer _server;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequestContext{TParams}"/> class with the specified server.
+    /// </summary>
+    /// <param name="server">The server with which this instance is associated.</param>
+    public RequestContext(IMcpServer server)
+    {
+        Throw.IfNull(server);
+
+        _server = server;
+        Services = server.Services;
+    }
+
+    /// <summary>Gets or sets the server with which this instance is associated.</summary>
+    public IMcpServer Server 
+    {
+        get => _server;
+        set
+        {
+            Throw.IfNull(value);
+            _server = value;
+        }
+    }
+
+    /// <summary>Gets or sets the services associated with this request.</summary>
+    /// <remarks>
+    /// This may not be the same instance stored in <see cref="IMcpServer.Services"/>
+    /// if <see cref="McpServerOptions.ScopeRequests"/> was true, in which case this
+    /// might be a scoped <see cref="IServiceProvider"/> derived from the server's
+    /// <see cref="IMcpServer.Services"/>.
+    /// </remarks>
+    public IServiceProvider? Services { get; set; }
+
+    /// <summary>Gets or sets the parameters associated with this request.</summary>
+    public TParams? Params { get; set; }
+}

--- a/src/ModelContextProtocol/Shared/McpEndpoint.cs
+++ b/src/ModelContextProtocol/Shared/McpEndpoint.cs
@@ -49,7 +49,7 @@ internal abstract class McpEndpoint : IAsyncDisposable
     public Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default)
         => GetSessionOrThrow().SendMessageAsync(message, cancellationToken);
 
-    public IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, Task> handler) =>
+    public IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler) =>
         GetSessionOrThrow().RegisterNotificationHandler(method, handler);
 
     /// <summary>

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -314,7 +314,7 @@ internal sealed class McpSession : IDisposable
         }, Tuple.Create(this, requestId));
     }
 
-    public IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, Task> handler)
+    public IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler)
     {
         Throw.IfNullOrWhiteSpace(method);
         Throw.IfNull(handler);

--- a/src/ModelContextProtocol/Shared/RequestHandlers.cs
+++ b/src/ModelContextProtocol/Shared/RequestHandlers.cs
@@ -30,7 +30,7 @@ internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, 
     /// </remarks>
     public void Set<TRequest, TResponse>(
         string method,
-        Func<TRequest?, CancellationToken, Task<TResponse>> handler,
+        Func<TRequest?, CancellationToken, ValueTask<TResponse>> handler,
         JsonTypeInfo<TRequest> requestTypeInfo,
         JsonTypeInfo<TResponse> responseTypeInfo)
     {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
@@ -87,7 +87,7 @@ public partial class SseIntegrationTests(ITestOutputHelper outputHelper) : Kestr
         {
             var msg = args.Params?["message"]?.GetValue<string>();
             receivedNotification.SetResult(msg);
-            return Task.CompletedTask;
+            return default;
         });
 
         // Send a test message through POST endpoint

--- a/tests/ModelContextProtocol.TestSseServer/Program.cs
+++ b/tests/ModelContextProtocol.TestSseServer/Program.cs
@@ -6,6 +6,8 @@ using Serilog;
 using System.Text;
 using System.Text.Json;
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
 namespace ModelContextProtocol.TestSseServer;
 
 public class Program
@@ -104,9 +106,9 @@ public class Program
         {
             Tools = new()
             {
-                ListToolsHandler = (request, cancellationToken) =>
+                ListToolsHandler = async (request, cancellationToken) =>
                 {
-                    return Task.FromResult(new ListToolsResult()
+                    return new ListToolsResult()
                     {
                         Tools = 
                         [
@@ -149,7 +151,7 @@ public class Program
                                     """, McpJsonUtilities.DefaultOptions),
                             }
                         ]
-                    });
+                    };
                 },
                 CallToolHandler = async (request, cancellationToken) =>
                 {
@@ -192,10 +194,10 @@ public class Program
             },
             Resources = new()
             {
-                ListResourceTemplatesHandler = (request, cancellationToken) =>
+                ListResourceTemplatesHandler = async (request, cancellationToken) =>
                 {
 
-                    return Task.FromResult(new ListResourceTemplatesResult()
+                    return new ListResourceTemplatesResult()
                     {
                         ResourceTemplates = [
                             new ResourceTemplate()
@@ -204,10 +206,10 @@ public class Program
                                 Name = "Dynamic Resource",
                             }
                         ]
-                    });
+                    };
                 },
 
-                ListResourcesHandler = (request, cancellationToken) =>
+                ListResourcesHandler = async (request, cancellationToken) =>
                 {
                     int startIndex = 0;
                     var requestParams = request.Params ?? new();
@@ -231,13 +233,14 @@ public class Program
                     {
                         nextCursor = Convert.ToBase64String(Encoding.UTF8.GetBytes(endIndex.ToString()));
                     }
-                    return Task.FromResult(new ListResourcesResult()
+
+                    return new ListResourcesResult()
                     {
                         NextCursor = nextCursor,
                         Resources = resources.GetRange(startIndex, endIndex - startIndex)
-                    });
+                    };
                 },
-                ReadResourceHandler =(request, cancellationToken) =>
+                ReadResourceHandler = async (request, cancellationToken) =>
                 {
                     if (request.Params?.Uri is null)
                     {
@@ -251,7 +254,8 @@ public class Program
                         {
                             throw new McpException("Invalid resource URI");
                         }
-                        return Task.FromResult(new ReadResourceResult()
+
+                        return new ReadResourceResult()
                         {
                             Contents = [
                                 new TextResourceContents()
@@ -261,23 +265,23 @@ public class Program
                                     Text = $"Dynamic resource {id}: This is a plaintext resource"
                                 }
                             ]
-                        });
+                        };
                     }
 
                     ResourceContents? contents = resourceContents.FirstOrDefault(r => r.Uri == request.Params.Uri) ?? 
                         throw new McpException("Resource not found");
                     
-                    return Task.FromResult(new ReadResourceResult()
+                    return new ReadResourceResult()
                     {
                         Contents = [contents]
-                    });
+                    };
                 }
             },
             Prompts = new()
             {
-                ListPromptsHandler = (request, cancellationToken) =>
+                ListPromptsHandler = async (request, cancellationToken) =>
                 {
-                    return Task.FromResult(new ListPromptsResult()
+                    return new ListPromptsResult()
                     {
                         Prompts = [
                             new Prompt()
@@ -306,9 +310,9 @@ public class Program
                                 }
                             }
                         ]
-                    });
+                    };
                 },
-                GetPromptHandler = (request, cancellationToken) =>
+                GetPromptHandler = async (request, cancellationToken) =>
                 {
                     if (request.Params is null)
                     {
@@ -365,10 +369,10 @@ public class Program
                         throw new McpException($"Unknown prompt: {request.Params.Name}");
                     }
 
-                    return Task.FromResult(new GetPromptResult()
+                    return new GetPromptResult()
                     {
                         Messages = messages
-                    });
+                    };
                 }
             },
         };

--- a/tests/ModelContextProtocol.Tests/Client/McpClientExtensionsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientExtensionsTests.cs
@@ -381,7 +381,7 @@ public class McpClientExtensionsTests : ClientServerTestBase
             (notification, cancellationToken) =>
             {
                 Assert.True(channel.Writer.TryWrite(JsonSerializer.Deserialize<LoggingMessageNotificationParams>(notification.Params, McpJsonUtilities.DefaultOptions)));
-                return Task.CompletedTask;
+                return default;
             }))
         {
             logger.LogTrace("Trace {Message}", "message");

--- a/tests/ModelContextProtocol.Tests/Client/McpClientFactoryTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientFactoryTests.cs
@@ -41,18 +41,19 @@ public class McpClientFactoryTests
             {
                 Sampling = new SamplingCapability
                 {
-                    SamplingHandler = (c, p, t) => Task.FromResult(
-                        new CreateMessageResult { 
+                    SamplingHandler = async (c, p, t) =>
+                        new CreateMessageResult 
+                        { 
                             Content = new Content { Text = "result" }, 
                             Model = "test-model", 
                             Role = Role.User, 
                             StopReason = "endTurn" 
-                    }),
+                        },
                 },
                 Roots = new RootsCapability
                 {
                     ListChanged = true,
-                    RootsHandler = (t, r) => Task.FromResult(new ListRootsResult { Roots = [] }),
+                    RootsHandler = async (t, r) => new ListRootsResult { Roots = [] },
                 }
             }
         };

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -265,7 +265,7 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
                     {
                         var notificationParams = JsonSerializer.Deserialize<ResourceUpdatedNotificationParams>(notification.Params, McpJsonUtilities.DefaultOptions);
                         tcs.TrySetResult(true);
-                        return Task.CompletedTask;
+                        return default;
                     })
                 ]
             }
@@ -295,7 +295,7 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
                     {
                         var notificationParams = JsonSerializer.Deserialize<ResourceUpdatedNotificationParams>(notification.Params, McpJsonUtilities.DefaultOptions);
                         receivedNotification.TrySetResult(true);
-                        return Task.CompletedTask;
+                        return default;
                     })
                 ]
             }
@@ -370,10 +370,10 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
             {
                 Sampling = new()
                 {
-                    SamplingHandler = (_, _, _) =>
+                    SamplingHandler = async (_, _, _) =>
                     {
                         samplingHandlerCalls++;
-                        return Task.FromResult(new CreateMessageResult
+                        return new CreateMessageResult
                         {
                             Model = "test-model",
                             Role = Role.Assistant,
@@ -382,7 +382,7 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
                                 Type = "text",
                                 Text = "Test response"
                             }
-                        });
+                        };
                     },
                 },
             },
@@ -569,7 +569,7 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
                         {
                             receivedNotification.TrySetResult(true);
                         }
-                        return Task.CompletedTask;
+                        return default;
                     })
                 ]
             }

--- a/tests/ModelContextProtocol.Tests/ClientServerTestBase.cs
+++ b/tests/ModelContextProtocol.Tests/ClientServerTestBase.cs
@@ -25,7 +25,7 @@ public abstract class ClientServerTestBase : LoggedTest, IAsyncDisposable
             .AddMcpServer()
             .WithStreamServerTransport(_clientToServerPipe.Reader.AsStream(), _serverToClientPipe.Writer.AsStream());
         ConfigureServices(sc, _builder);
-        ServiceProvider = sc.BuildServiceProvider();
+        ServiceProvider = sc.BuildServiceProvider(validateScopes: true);
 
         _cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         Server = ServiceProvider.GetRequiredService<IMcpServer>();

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsHandlerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsHandlerTests.cs
@@ -21,7 +21,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithListToolsHandler_Sets_Handler()
     {
-        Func<RequestContext<ListToolsRequestParams>, CancellationToken, Task<ListToolsResult>> handler = (context, token) => Task.FromResult(new ListToolsResult());
+        Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>> handler = async (context, token) => new ListToolsResult();
 
         _builder.Object.WithListToolsHandler(handler);
 
@@ -34,7 +34,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithCallToolHandler_Sets_Handler()
     {
-        Func<RequestContext<CallToolRequestParams>, CancellationToken, Task<CallToolResponse>> handler = (context, token) => Task.FromResult(new CallToolResponse());
+        Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResponse>> handler = async (context, token) => new CallToolResponse();
 
         _builder.Object.WithCallToolHandler(handler);
 
@@ -47,7 +47,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithListPromptsHandler_Sets_Handler()
     {
-        Func<RequestContext<ListPromptsRequestParams>, CancellationToken, Task<ListPromptsResult>> handler = (context, token) => Task.FromResult(new ListPromptsResult());
+        Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>> handler = async (context, token) => new ListPromptsResult();
 
         _builder.Object.WithListPromptsHandler(handler);
 
@@ -60,7 +60,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithGetPromptHandler_Sets_Handler()
     {
-        Func<RequestContext<GetPromptRequestParams>, CancellationToken, Task<GetPromptResult>> handler = (context, token) => Task.FromResult(new GetPromptResult());
+        Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>> handler = async (context, token) => new GetPromptResult();
 
         _builder.Object.WithGetPromptHandler(handler);
 
@@ -73,7 +73,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithListResourceTemplatesHandler_Sets_Handler()
     {
-        Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, Task<ListResourceTemplatesResult>> handler = (context, token) => Task.FromResult(new ListResourceTemplatesResult());
+        Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>> handler = async (context, token) => new ListResourceTemplatesResult();
 
         _builder.Object.WithListResourceTemplatesHandler(handler);
 
@@ -86,7 +86,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithListResourcesHandler_Sets_Handler()
     {
-        Func<RequestContext<ListResourcesRequestParams>, CancellationToken, Task<ListResourcesResult>> handler = (context, token) => Task.FromResult(new ListResourcesResult());
+        Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>> handler = async (context, token) => new ListResourcesResult();
 
         _builder.Object.WithListResourcesHandler(handler);
 
@@ -99,7 +99,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithReadResourceHandler_Sets_Handler()
     {
-        Func<RequestContext<ReadResourceRequestParams>, CancellationToken, Task<ReadResourceResult>> handler = (context, token) => Task.FromResult(new ReadResourceResult());
+        Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>> handler = async (context, token) => new ReadResourceResult();
 
         _builder.Object.WithReadResourceHandler(handler);
 
@@ -112,7 +112,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithCompleteHandler_Sets_Handler()
     {
-        Func<RequestContext<CompleteRequestParams>, CancellationToken, Task<CompleteResult>> handler = (context, token) => Task.FromResult(new CompleteResult());
+        Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>> handler = async (context, token) => new CompleteResult();
 
         _builder.Object.WithCompleteHandler(handler);
 
@@ -125,7 +125,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithSubscribeToResourcesHandler_Sets_Handler()
     {
-        Func<RequestContext<SubscribeRequestParams>, CancellationToken, Task<EmptyResult>> handler = (context, token) => Task.FromResult(new EmptyResult());
+        Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>> handler = async (context, token) => new EmptyResult();
 
         _builder.Object.WithSubscribeToResourcesHandler(handler);
 
@@ -138,7 +138,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithUnsubscribeFromResourcesHandler_Sets_Handler()
     {
-        Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, Task<EmptyResult>> handler = (context, token) => Task.FromResult(new EmptyResult());
+        Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>> handler = async (context, token) => new EmptyResult();
 
         _builder.Object.WithUnsubscribeFromResourcesHandler(handler);
 

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsPromptsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsPromptsTests.cs
@@ -8,8 +8,6 @@ using ModelContextProtocol.Server;
 using System.ComponentModel;
 using System.Threading.Channels;
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-
 namespace ModelContextProtocol.Tests.Configuration;
 
 public class McpServerBuilderExtensionsPromptsTests : ClientServerTestBase
@@ -143,7 +141,7 @@ public class McpServerBuilderExtensionsPromptsTests : ClientServerTestBase
         await using (client.RegisterNotificationHandler("notifications/prompts/list_changed", (notification, cancellationToken) =>
             {
                 listChanged.Writer.TryWrite(notification);
-                return Task.CompletedTask;
+                return default;
             }))
         {
             serverPrompts.Add(newPrompt);

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
@@ -16,8 +16,6 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading.Channels;
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-
 namespace ModelContextProtocol.Tests.Configuration;
 
 public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
@@ -209,7 +207,7 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         await using (client.RegisterNotificationHandler(NotificationMethods.ToolListChangedNotification, (notification, cancellationToken) =>
             {
                 listChanged.Writer.TryWrite(notification);
-                return Task.CompletedTask;
+                return default;
             }))
         {
             serverTools.Add(newTool);
@@ -588,7 +586,7 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         {
             ProgressNotification pn = JsonSerializer.Deserialize<ProgressNotification>(notification.Params, McpJsonUtilities.DefaultOptions)!;
             notifications.Enqueue(pn);
-            return Task.CompletedTask;
+            return default;
         }))
         {
             var result = await client.SendRequestAsync<CallToolRequestParams, CallToolResponse>(

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
@@ -757,26 +757,8 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         public static string MethodD(string d) => d.ToString();
     }
 
-    public class ComplexObject
-    {
-        public string? Name { get; set; }
-        public int Age { get; set; }
-    }
-
     public class ObjectWithId
     {
         public string Id { get; set; } = Guid.NewGuid().ToString("N");
     }
-
-    [JsonSerializable(typeof(bool))]
-    [JsonSerializable(typeof(int))]
-    [JsonSerializable(typeof(long))]
-    [JsonSerializable(typeof(double))]
-    [JsonSerializable(typeof(string))]
-    [JsonSerializable(typeof(DateTime))]
-    [JsonSerializable(typeof(DateTimeOffset))]
-    [JsonSerializable(typeof(ComplexObject))]
-    [JsonSerializable(typeof(string[]))]
-    [JsonSerializable(typeof(JsonElement))]
-    partial class JsonContext : JsonSerializerContext;
 }

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerScopedTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerScopedTests.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Server;
+using System.Text.Json;
+
+namespace ModelContextProtocol.Tests.Configuration;
+
+public partial class McpServerScopedTests : ClientServerTestBase
+{
+    public McpServerScopedTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
+    {
+        mcpServerBuilder.WithTools<EchoTool>(serializerOptions: JsonContext.Default.Options);
+        services.AddScoped(_ => new ComplexObject() { Name = "Scoped" });
+    }
+
+    [Fact]
+    public async Task InjectScopedServiceAsArgument()
+    {
+        IMcpClient client = await CreateMcpClientForServer();
+
+        var tools = await client.ListToolsAsync(JsonContext.Default.Options, TestContext.Current.CancellationToken);
+        var tool = tools.First(t => t.Name == nameof(EchoTool.EchoComplex));
+        Assert.DoesNotContain("\"complex\"", JsonSerializer.Serialize(tool.JsonSchema, AIJsonUtilities.DefaultOptions));
+
+        Assert.Contains("\"Scoped\"", JsonSerializer.Serialize(await tool.InvokeAsync(cancellationToken: TestContext.Current.CancellationToken), AIJsonUtilities.DefaultOptions));
+    }
+
+    [McpServerToolType]
+    public sealed class EchoTool()
+    {
+        [McpServerTool]
+        public static string EchoComplex(ComplexObject complex) => complex.Name!;
+    }
+}

--- a/tests/ModelContextProtocol.Tests/DockerEverythingServerTests.cs
+++ b/tests/ModelContextProtocol.Tests/DockerEverythingServerTests.cs
@@ -77,10 +77,10 @@ public class DockerEverythingServerTests(ITestOutputHelper testOutputHelper) : L
             {
                 Sampling = new()
                 {
-                    SamplingHandler = (_, _, _) =>
+                    SamplingHandler = async (_, _, _) =>
                     {
                         samplingHandlerCalls++;
-                        return Task.FromResult(new CreateMessageResult
+                        return new CreateMessageResult
                         {
                             Model = "test-model",
                             Role = Role.Assistant,
@@ -89,7 +89,7 @@ public class DockerEverythingServerTests(ITestOutputHelper testOutputHelper) : L
                                 Type = "text",
                                 Text = "Test response"
                             }
-                        });
+                        };
                     },
                 },
             },

--- a/tests/ModelContextProtocol.Tests/JsonContext.cs
+++ b/tests/ModelContextProtocol.Tests/JsonContext.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public class ComplexObject
+{
+    public string? Name { get; set; }
+    public int Age { get; set; }
+}
+
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(DateTimeOffset))]
+[JsonSerializable(typeof(ComplexObject))]
+[JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(JsonElement))]
+partial class JsonContext : JsonSerializerContext;

--- a/tests/ModelContextProtocol.Tests/Protocol/CancellationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Protocol/CancellationTests.cs
@@ -39,7 +39,7 @@ public class CancellationTests : ClientServerTestBase
         await using (Server.RegisterNotificationHandler(NotificationMethods.CancelledNotification, (notification, cancellationToken) =>
         {
             gotCancellation = true;
-            return Task.CompletedTask;
+            return default;
         }))
         {
             await Assert.ThrowsAsync<OperationCanceledException>(() => client.ListToolsAsync(cancellationToken: new CancellationToken(true)));

--- a/tests/ModelContextProtocol.Tests/Protocol/NotificationHandlerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Protocol/NotificationHandlerTests.cs
@@ -25,7 +25,7 @@ public class NotificationHandlerTests : ClientServerTestBase
                 {
                     Interlocked.Increment(ref counter);
                     tcs.SetResult(true);
-                    return Task.CompletedTask;
+                    return default;
                 }))
             {
                 await Server.SendNotificationAsync(NotificationName, TestContext.Current.CancellationToken);
@@ -58,7 +58,7 @@ public class NotificationHandlerTests : ClientServerTestBase
                     tcs.TrySetResult(true);
                 }
 
-                return Task.CompletedTask;
+                return default;
             });
         }
 

--- a/tests/ModelContextProtocol.Tests/Server/McpServerDelegatesTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerDelegatesTests.cs
@@ -21,16 +21,16 @@ public class McpServerHandlerTests
         Assert.Null(handlers.SubscribeToResourcesHandler);
         Assert.Null(handlers.UnsubscribeFromResourcesHandler);
 
-        handlers.ListToolsHandler = (p, c) => Task.FromResult(new ListToolsResult());
-        handlers.CallToolHandler = (p, c) => Task.FromResult(new CallToolResponse());
-        handlers.ListPromptsHandler = (p, c) => Task.FromResult(new ListPromptsResult());
-        handlers.GetPromptHandler = (p, c) => Task.FromResult(new GetPromptResult());
-        handlers.ListResourceTemplatesHandler = (p, c) => Task.FromResult(new ListResourceTemplatesResult());
-        handlers.ListResourcesHandler = (p, c) => Task.FromResult(new ListResourcesResult());
-        handlers.ReadResourceHandler = (p, c) => Task.FromResult(new ReadResourceResult());
-        handlers.CompleteHandler = (p, c) => Task.FromResult(new CompleteResult());
-        handlers.SubscribeToResourcesHandler = (s, c) => Task.FromResult(new EmptyResult());
-        handlers.UnsubscribeFromResourcesHandler = (s, c) => Task.FromResult(new EmptyResult());
+        handlers.ListToolsHandler = async (p, c) => new ListToolsResult();
+        handlers.CallToolHandler = async (p, c) => new CallToolResponse();
+        handlers.ListPromptsHandler = async (p, c) => new ListPromptsResult();
+        handlers.GetPromptHandler = async (p, c) => new GetPromptResult();
+        handlers.ListResourceTemplatesHandler = async (p, c) => new ListResourceTemplatesResult();
+        handlers.ListResourcesHandler = async (p, c) => new ListResourcesResult();
+        handlers.ReadResourceHandler = async (p, c) => new ReadResourceResult();
+        handlers.CompleteHandler = async (p, c) => new CompleteResult();
+        handlers.SubscribeToResourcesHandler = async (s, c) => new EmptyResult();
+        handlers.UnsubscribeFromResourcesHandler = async (s, c) => new EmptyResult();
 
         Assert.NotNull(handlers.ListToolsHandler);
         Assert.NotNull(handlers.CallToolHandler);

--- a/tests/ModelContextProtocol.Tests/Server/McpServerLoggingLevelTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerLoggingLevelTests.cs
@@ -12,10 +12,7 @@ public class McpServerLoggingLevelTests
 
         services.AddMcpServer()
             .WithStdioServerTransport()
-            .WithSetLoggingLevelHandler((ctx, ct) =>
-            {
-                return Task.FromResult(new EmptyResult());
-            });
+            .WithSetLoggingLevelHandler(async (ctx, ct) => new EmptyResult());
 
         var provider = services.BuildServiceProvider();
 
@@ -29,10 +26,7 @@ public class McpServerLoggingLevelTests
 
         services.AddMcpServer()
             .WithStdioServerTransport()
-            .WithSetLoggingLevelHandler((ctx, ct) =>
-            {
-                return Task.FromResult(new EmptyResult());
-            });
+            .WithSetLoggingLevelHandler(async (ctx, ct) => new EmptyResult());
 
         var provider = services.BuildServiceProvider();
 

--- a/tests/ModelContextProtocol.Tests/Server/McpServerPromptTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerPromptTests.cs
@@ -33,7 +33,7 @@ public class McpServerPromptTests
         Assert.DoesNotContain("server", prompt.ProtocolPrompt.Arguments?.Select(a => a.Name) ?? []);
 
         var result = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(mockServer.Object, null),
+            new RequestContext<GetPromptRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.NotNull(result.Messages);
@@ -59,16 +59,12 @@ public class McpServerPromptTests
         Assert.Contains("something", prompt.ProtocolPrompt.Arguments?.Select(a => a.Name) ?? []);
         Assert.DoesNotContain("actualMyService", prompt.ProtocolPrompt.Arguments?.Select(a => a.Name) ?? []);
 
-        Mock<IMcpServer> mockServer = new();
-
         await Assert.ThrowsAsync<ArgumentException>(async () => await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(mockServer.Object, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken));
 
-        mockServer.SetupGet(x => x.Services).Returns(services);
-
         var result = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(mockServer.Object, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object) { Services = services },
             TestContext.Current.CancellationToken);
         Assert.Equal("Hello", result.Messages[0].Content.Text);
     }
@@ -89,7 +85,7 @@ public class McpServerPromptTests
         }, new() { Services = services });
 
         var result = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
         Assert.Equal("Hello", result.Messages[0].Content.Text);
     }
@@ -102,7 +98,7 @@ public class McpServerPromptTests
             typeof(DisposablePromptType));
 
         var result = await prompt1.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
         Assert.Equal("disposals:1", result.Messages[0].Content.Text);
     }
@@ -115,7 +111,7 @@ public class McpServerPromptTests
             typeof(AsyncDisposablePromptType));
 
         var result = await prompt1.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
         Assert.Equal("asyncDisposals:1", result.Messages[0].Content.Text);
     }
@@ -128,7 +124,7 @@ public class McpServerPromptTests
             typeof(AsyncDisposableAndDisposablePromptType));
 
         var result = await prompt1.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
         Assert.Equal("disposals:0, asyncDisposals:1", result.Messages[0].Content.Text);
     }
@@ -144,7 +140,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
 
         Assert.Same(expected, actual);
@@ -161,7 +157,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(actual);
@@ -187,7 +183,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(actual);
@@ -218,7 +214,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(actual);
@@ -247,7 +243,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(actual);
@@ -280,7 +276,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(actual);
@@ -303,7 +299,7 @@ public class McpServerPromptTests
         });
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken));
     }
 
@@ -316,7 +312,7 @@ public class McpServerPromptTests
         });
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(null!, null),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken));
     }
 

--- a/tests/ModelContextProtocol.Tests/Server/McpServerResourceTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerResourceTests.cs
@@ -13,19 +13,19 @@ public class McpServerResourceTests
 
         services.AddMcpServer()
             .WithStdioServerTransport()
-            .WithListResourceTemplatesHandler((ctx, ct) =>
+            .WithListResourceTemplatesHandler(async (ctx, ct) =>
             {
-                return Task.FromResult(new ListResourceTemplatesResult
+                return new ListResourceTemplatesResult
                 {
                     ResourceTemplates =
                     [
                         new ResourceTemplate { Name = "Static Resource", Description = "A static resource with a numeric ID", UriTemplate = "test://static/resource/{id}" }
                     ]
-                });
+                };
             })
-            .WithReadResourceHandler((ctx, ct) =>
+            .WithReadResourceHandler(async (ctx, ct) =>
             {
-                return Task.FromResult(new ReadResourceResult
+                return new ReadResourceResult
                 {
                     Contents = [new TextResourceContents
                     {
@@ -33,7 +33,7 @@ public class McpServerResourceTests
                         Text = "Static Resource",
                         MimeType = "text/plain",
                     }]
-                });
+                };
             });
 
         var provider = services.BuildServiceProvider();
@@ -48,19 +48,19 @@ public class McpServerResourceTests
 
         services.AddMcpServer()
             .WithStdioServerTransport()
-            .WithListResourcesHandler((ctx, ct) =>
+            .WithListResourcesHandler(async (ctx, ct) =>
             {
-                return Task.FromResult(new ListResourcesResult
+                return new ListResourcesResult
                 {
                     Resources =
                     [
                         new Resource { Name = "Static Resource", Description = "A static resource with a numeric ID", Uri = "test://static/resource/foo.txt" }
                     ]
-                });
+                };
             })
-            .WithReadResourceHandler((ctx, ct) =>
+            .WithReadResourceHandler(async (ctx, ct) =>
             {
-                return Task.FromResult(new ReadResourceResult
+                return new ReadResourceResult
                 {
                     Contents = [new TextResourceContents
                     {
@@ -68,7 +68,7 @@ public class McpServerResourceTests
                         Text = "Static Resource",
                         MimeType = "text/plain",
                     }]
-                });
+                };
             });
 
         var provider = services.BuildServiceProvider();
@@ -82,9 +82,9 @@ public class McpServerResourceTests
         var services = new ServiceCollection();
         services.AddMcpServer()
             .WithStdioServerTransport()
-            .WithReadResourceHandler((ctx, ct) =>
+            .WithReadResourceHandler(async (ctx, ct) =>
             {
-                return Task.FromResult(new ReadResourceResult
+                return new ReadResourceResult
                 {
                     Contents = [new TextResourceContents
                     {
@@ -92,7 +92,7 @@ public class McpServerResourceTests
                         Text = "Static Resource",
                         MimeType = "text/plain",
                     }]
-                });
+                };
             });
         var sp = services.BuildServiceProvider();
         Assert.Throws<McpException>(() => sp.GetRequiredService<IMcpServer>());

--- a/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
@@ -202,8 +202,8 @@ public class McpServerTests : LoggedTest
             {
                 Completions = new()
                 {
-                    CompleteHandler = (request, ct) =>
-                        Task.FromResult(new CompleteResult
+                    CompleteHandler = async (request, ct) =>
+                        new CompleteResult
                         {
                             Completion = new()
                             {
@@ -211,7 +211,7 @@ public class McpServerTests : LoggedTest
                                 Total = 2,
                                 HasMore = true
                             }
-                        })
+                        }
                 }
             },
             method: RequestMethods.CompletionComplete,
@@ -234,19 +234,19 @@ public class McpServerTests : LoggedTest
             {
                 Resources = new()
                 {
-                    ListResourceTemplatesHandler = (request, ct) =>
+                    ListResourceTemplatesHandler = async (request, ct) =>
                     {
-                        return Task.FromResult(new ListResourceTemplatesResult
+                        return new ListResourceTemplatesResult
                         {
                             ResourceTemplates = [new() { UriTemplate = "test", Name = "Test Resource" }]
-                        });
+                        };
                     },
-                    ListResourcesHandler = (request, ct) =>
+                    ListResourcesHandler = async (request, ct) =>
                     {
-                        return Task.FromResult(new ListResourcesResult
+                        return new ListResourcesResult
                         {
                             Resources = [new() { Uri = "test", Name = "Test Resource" }]
-                        });
+                        };
                     },
                     ReadResourceHandler = (request, ct) => throw new NotImplementedException(),
                 }
@@ -270,12 +270,12 @@ public class McpServerTests : LoggedTest
             {
                 Resources = new()
                 {
-                    ListResourcesHandler = (request, ct) =>
+                    ListResourcesHandler = async (request, ct) =>
                     {
-                        return Task.FromResult(new ListResourcesResult
+                        return new ListResourcesResult
                         {
                             Resources = [new() { Uri = "test", Name = "Test Resource" }]
-                        });
+                        };
                     },
                     ReadResourceHandler = (request, ct) => throw new NotImplementedException(),
                 }
@@ -305,12 +305,12 @@ public class McpServerTests : LoggedTest
             {
                 Resources = new()
                 {
-                    ReadResourceHandler = (request, ct) =>
+                    ReadResourceHandler = async (request, ct) =>
                     {
-                        return Task.FromResult(new ReadResourceResult
+                        return new ReadResourceResult
                         {
                             Contents = [new TextResourceContents { Text = "test" }]
-                        });
+                        };
                     },
                     ListResourcesHandler = (request, ct) => throw new NotImplementedException(),
                 }
@@ -342,12 +342,12 @@ public class McpServerTests : LoggedTest
             {
                 Prompts = new()
                 {
-                    ListPromptsHandler = (request, ct) =>
+                    ListPromptsHandler = async (request, ct) =>
                     {
-                        return Task.FromResult(new ListPromptsResult
+                        return new ListPromptsResult
                         {
                             Prompts = [new() { Name = "test" }]
-                        });
+                        };
                     },
                     GetPromptHandler = (request, ct) => throw new NotImplementedException(),
                 },
@@ -377,7 +377,7 @@ public class McpServerTests : LoggedTest
             {
                 Prompts = new()
                 {
-                    GetPromptHandler = (request, ct) => Task.FromResult(new GetPromptResult { Description = "test" }),
+                    GetPromptHandler = async (request, ct) => new GetPromptResult { Description = "test" },
                     ListPromptsHandler = (request, ct) => throw new NotImplementedException(),
                 }
             },
@@ -405,12 +405,12 @@ public class McpServerTests : LoggedTest
             {
                 Tools = new()
                 {
-                    ListToolsHandler = (request, ct) =>
+                    ListToolsHandler = async (request, ct) =>
                     {
-                        return Task.FromResult(new ListToolsResult
+                        return new ListToolsResult
                         {
                             Tools = [new() { Name = "test" }]
-                        });
+                        };
                     },
                     CallToolHandler = (request, ct) => throw new NotImplementedException(),
                 }
@@ -440,12 +440,12 @@ public class McpServerTests : LoggedTest
             {
                 Tools = new()
                 {
-                    CallToolHandler = (request, ct) =>
+                    CallToolHandler = async (request, ct) =>
                     {
-                        return Task.FromResult(new CallToolResponse
+                        return new CallToolResponse
                         {
                             Content = [new Content { Text = "test" }]
-                        });
+                        };
                     },
                     ListToolsHandler = (request, ct) => throw new NotImplementedException(),
                 }
@@ -623,7 +623,7 @@ public class McpServerTests : LoggedTest
             throw new NotImplementedException();
         public Task RunAsync(CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
-        public IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, Task> handler) =>
+        public IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler) =>
             throw new NotImplementedException();
     }
 
@@ -639,7 +639,7 @@ public class McpServerTests : LoggedTest
             NotificationHandlers = [new(NotificationMethods.ProgressNotification, (notification, cancellationToken) =>
             {
                 notificationReceived.TrySetResult(notification);
-                return Task.CompletedTask;
+                return default;
             })],
         };
 

--- a/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
@@ -40,7 +40,7 @@ public partial class McpServerToolTests
         Assert.DoesNotContain("server", JsonSerializer.Serialize(tool.ProtocolTool.InputSchema, McpJsonUtilities.DefaultOptions));
 
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
         Assert.Equal("42", result.Content[0].Text);
     }
@@ -92,14 +92,12 @@ public partial class McpServerToolTests
         Mock<IMcpServer> mockServer = new();
 
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
         Assert.True(result.IsError);
 
-        mockServer.SetupGet(x => x.Services).Returns(services);
-
         result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object) { Services = services },
             TestContext.Current.CancellationToken);
         Assert.Equal("42", result.Content[0].Text);
     }
@@ -120,7 +118,7 @@ public partial class McpServerToolTests
         }, new() { Services = services });
 
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(null!, null),
+            new RequestContext<CallToolRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
         Assert.Equal("42", result.Content[0].Text);
     }
@@ -135,7 +133,7 @@ public partial class McpServerToolTests
             options);
 
         var result = await tool1.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(null!, null),
+            new RequestContext<CallToolRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
         Assert.Equal("""{"disposals":1}""", result.Content[0].Text);
     }
@@ -150,7 +148,7 @@ public partial class McpServerToolTests
             options);
 
         var result = await tool1.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(null!, null),
+            new RequestContext<CallToolRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
         Assert.Equal("""{"asyncDisposals":1}""", result.Content[0].Text);
     }
@@ -165,7 +163,7 @@ public partial class McpServerToolTests
             options);
 
         var result = await tool1.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(null!, null),
+            new RequestContext<CallToolRequestParams>(new Mock<IMcpServer>().Object),
             TestContext.Current.CancellationToken);
         Assert.Equal("""{"asyncDisposals":1,"disposals":0}""", result.Content[0].Text);
     }
@@ -186,7 +184,7 @@ public partial class McpServerToolTests
         });
 
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
 
         Assert.Equal(3, result.Content.Count);
@@ -223,7 +221,7 @@ public partial class McpServerToolTests
         });
 
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
 
         Assert.Single(result.Content);
@@ -251,7 +249,7 @@ public partial class McpServerToolTests
             return (string?)null;
         });
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
         Assert.Empty(result.Content);
     }
@@ -266,7 +264,7 @@ public partial class McpServerToolTests
             return "42";
         });
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
         Assert.Single(result.Content);
         Assert.Equal("42", result.Content[0].Text);
@@ -283,7 +281,7 @@ public partial class McpServerToolTests
             return new List<string>() { "42", "43" };
         });
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
         Assert.Equal(2, result.Content.Count);
         Assert.Equal("42", result.Content[0].Text);
@@ -302,7 +300,7 @@ public partial class McpServerToolTests
             return new Content { Text = "42", Type = "text" };
         });
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
         Assert.Single(result.Content);
         Assert.Equal("42", result.Content[0].Text);
@@ -319,7 +317,7 @@ public partial class McpServerToolTests
             return new List<Content>() { new() { Text = "42", Type = "text" }, new() { Data = "1234", Type = "image", MimeType = "image/png" } };
         });
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
         Assert.Equal(2, result.Content.Count);
         Assert.Equal("42", result.Content[0].Text);
@@ -345,7 +343,7 @@ public partial class McpServerToolTests
             return response;
         });
         var result = await tool.InvokeAsync(
-            new RequestContext<CallToolRequestParams>(mockServer.Object, null),
+            new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
 
         Assert.Same(response, result);


### PR DESCRIPTION
As long as I was touching the request handlers, I also made a change I've been meaning to make, which is to have all of these delegate callbacks return ValueTask instead of Task.

Fixes https://github.com/modelcontextprotocol/csharp-sdk/issues/234
Fixes https://github.com/modelcontextprotocol/csharp-sdk/issues/198