### PR TITLE
Add structural equality comparers for transport options

### DIFF
--- a/src/ModelContextProtocol/Protocol/Transport/SseClientTransportOptionsEqualityComparer.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseClientTransportOptionsEqualityComparer.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModelContextProtocol.Protocol.Transport;
+
+/// <summary>
+/// Provides structural equality comparison for <see cref="SseClientTransportOptions"/>.
+/// </summary>
+public class SseClientTransportOptionsEqualityComparer : IEqualityComparer<SseClientTransportOptions>
+{
+    /// <summary>
+    /// Gets a default instance of the <see cref="SseClientTransportOptionsEqualityComparer"/>.
+    /// </summary>
+    public static SseClientTransportOptionsEqualityComparer Default { get; } = new();
+
+    /// <summary>
+    /// Determines whether two <see cref="SseClientTransportOptions"/> objects are equal based on their properties.
+    /// </summary>
+    /// <param name="x">The first object to compare.</param>
+    /// <param name="y">The second object to compare.</param>
+    /// <returns><see langword="true"/> if the objects are structurally equal; otherwise, <see langword="false"/>.</returns>
+    public bool Equals(SseClientTransportOptions? x, SseClientTransportOptions? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null || y is null) return false;
+        
+        if (!EqualityComparer<Uri>.Default.Equals(x.Endpoint, y.Endpoint) ||
+            !EqualityComparer<string?>.Default.Equals(x.Name, y.Name) ||
+            !EqualityComparer<TimeSpan>.Default.Equals(x.ConnectionTimeout, y.ConnectionTimeout) ||
+            !EqualityComparer<int>.Default.Equals(x.MaxReconnectAttempts, y.MaxReconnectAttempts) ||
+            !EqualityComparer<TimeSpan>.Default.Equals(x.ReconnectDelay, y.ReconnectDelay))
+        {
+            return false;
+        }
+
+        bool headersEqual = (x.AdditionalHeaders is null && y.AdditionalHeaders is null) ||
+                            (x.AdditionalHeaders is not null && y.AdditionalHeaders is not null &&
+                             x.AdditionalHeaders.Count == y.AdditionalHeaders.Count &&
+                             !x.AdditionalHeaders.Except(y.AdditionalHeaders).Any());
+        if (!headersEqual)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns a hash code for the specified <see cref="SseClientTransportOptions"/> object based on its properties.
+    /// </summary>
+    /// <param name="obj">The object for which a hash code is to be returned.</param>
+    /// <returns>A hash code for the specified object.</returns>
+    /// <exception cref="ArgumentNullException">The type of <paramref name="obj"/> is a reference type and <paramref name="obj"/> is <see langword="null"/>.</exception>
+    public int GetHashCode([DisallowNull] SseClientTransportOptions obj)
+    {
+        if (obj is null) throw new ArgumentNullException(nameof(obj));
+        
+        int hashCode = 17; 
+        hashCode = hashCode * 23 + (obj.Endpoint?.GetHashCode() ?? 0);
+        hashCode = hashCode * 23 + (obj.Name?.GetHashCode() ?? 0);
+        hashCode = hashCode * 23 + obj.ConnectionTimeout.GetHashCode();
+        hashCode = hashCode * 23 + obj.MaxReconnectAttempts.GetHashCode();
+        hashCode = hashCode * 23 + obj.ReconnectDelay.GetHashCode();
+
+        if (obj.AdditionalHeaders is not null)
+        {
+            foreach (var kvp in obj.AdditionalHeaders.OrderBy(kv => kv.Key))
+            {
+                hashCode = hashCode * 23 + kvp.Key.GetHashCode();
+                hashCode = hashCode * 23 + (kvp.Value?.GetHashCode() ?? 0);
+            }
+        }
+        return hashCode;
+    }
+} 

--- a/src/ModelContextProtocol/Protocol/Transport/StdioClientTransportOptionsEqualityComparer.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/StdioClientTransportOptionsEqualityComparer.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModelContextProtocol.Protocol.Transport;
+
+/// <summary>
+/// Provides structural equality comparison for <see cref="StdioClientTransportOptions"/>.
+/// </summary>
+public class StdioClientTransportOptionsEqualityComparer : IEqualityComparer<StdioClientTransportOptions>
+{
+    /// <summary>
+    /// Gets a default instance of the <see cref="StdioClientTransportOptionsEqualityComparer"/>.
+    /// </summary>
+    public static StdioClientTransportOptionsEqualityComparer Default { get; } = new();
+
+    /// <summary>
+    /// Determines whether two <see cref="StdioClientTransportOptions"/> objects are equal based on their properties.
+    /// </summary>
+    /// <param name="x">The first object to compare.</param>
+    /// <param name="y">The second object to compare.</param>
+    /// <returns><see langword="true"/> if the objects are structurally equal; otherwise, <see langword="false"/>.</returns>
+    public bool Equals(StdioClientTransportOptions? x, StdioClientTransportOptions? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null || y is null) return false;
+        
+        if (!EqualityComparer<string>.Default.Equals(x.Command, y.Command) ||
+            !EqualityComparer<string?>.Default.Equals(x.Name, y.Name) ||
+            !EqualityComparer<string?>.Default.Equals(x.WorkingDirectory, y.WorkingDirectory) ||
+            !EqualityComparer<TimeSpan>.Default.Equals(x.ShutdownTimeout, y.ShutdownTimeout))
+        {
+            return false;
+        }
+        
+        bool argumentsEqual = (x.Arguments is null && y.Arguments is null) ||
+                              (x.Arguments is not null && y.Arguments is not null && x.Arguments.SequenceEqual(y.Arguments));
+        if (!argumentsEqual)
+        {
+            return false;
+        }
+        
+        bool envVarsEqual = (x.EnvironmentVariables is null && y.EnvironmentVariables is null) ||
+                            (x.EnvironmentVariables is not null && y.EnvironmentVariables is not null &&
+                             x.EnvironmentVariables.Count == y.EnvironmentVariables.Count &&
+                             !x.EnvironmentVariables.Except(y.EnvironmentVariables).Any());
+        if (!envVarsEqual)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns a hash code for the specified <see cref="StdioClientTransportOptions"/> object based on its properties.
+    /// </summary>
+    /// <param name="obj">The object for which a hash code is to be returned.</param>
+    /// <returns>A hash code for the specified object.</returns>
+    /// <exception cref="ArgumentNullException">The type of <paramref name="obj"/> is a reference type and <paramref name="obj"/> is <see langword="null"/>.</exception>
+    public int GetHashCode([DisallowNull] StdioClientTransportOptions obj)
+    {
+        if (obj is null) throw new ArgumentNullException(nameof(obj));
+        
+        int hashCode = 17; 
+        hashCode = hashCode * 23 + (obj.Command?.GetHashCode() ?? 0);
+        hashCode = hashCode * 23 + (obj.Name?.GetHashCode() ?? 0);
+        hashCode = hashCode * 23 + (obj.WorkingDirectory?.GetHashCode() ?? 0);
+        hashCode = hashCode * 23 + obj.ShutdownTimeout.GetHashCode();
+
+        if (obj.Arguments is not null)
+        {
+            foreach (var arg in obj.Arguments)
+            {
+                hashCode = hashCode * 23 + (arg?.GetHashCode() ?? 0);
+            }
+        }
+
+        if (obj.EnvironmentVariables is not null)
+        {
+            // Order by key for consistency
+            foreach (var kvp in obj.EnvironmentVariables.OrderBy(kv => kv.Key))
+            {
+                hashCode = hashCode * 23 + kvp.Key.GetHashCode();
+                hashCode = hashCode * 23 + (kvp.Value?.GetHashCode() ?? 0);
+            }
+        }
+        return hashCode;
+    }
+} 

--- a/tests/ModelContextProtocol.Tests/Protocol/Transport/TransportOptionsEqualityComparerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Protocol/Transport/TransportOptionsEqualityComparerTests.cs
@@ -1,0 +1,184 @@
+using ModelContextProtocol.Protocol.Transport;
+
+namespace ModelContextProtocol.Tests.Protocol.Transport;
+
+public class TransportOptionsEqualityComparerTests
+{
+    [Fact]
+    public void Stdio_IdenticalObjects_AreEqual()
+    {
+        var options1 = new StdioClientTransportOptions
+        {
+            Command = "cmd",
+            Arguments = new List<string> { "arg1", "arg2" },
+            EnvironmentVariables = new Dictionary<string, string> { { "KEY", "VALUE" } },
+            Name = "Test",
+            WorkingDirectory = "/tmp",
+            ShutdownTimeout = TimeSpan.FromSeconds(10)
+        };
+        var options2 = new StdioClientTransportOptions
+        {
+            Command = "cmd",
+            Arguments = new List<string> { "arg1", "arg2" },
+            EnvironmentVariables = new Dictionary<string, string> { { "KEY", "VALUE" } },
+            Name = "Test",
+            WorkingDirectory = "/tmp",
+            ShutdownTimeout = TimeSpan.FromSeconds(10)
+        };
+
+        Assert.True(StdioClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+        Assert.Equal(StdioClientTransportOptionsEqualityComparer.Default.GetHashCode(options1),
+            StdioClientTransportOptionsEqualityComparer.Default.GetHashCode(options2));
+    }
+
+    [Fact]
+    public void Stdio_DifferentSimpleProperty_AreNotEqual()
+    {
+        var options1 = new StdioClientTransportOptions { Command = "cmd1" };
+        var options2 = new StdioClientTransportOptions { Command = "cmd2" };
+
+        Assert.False(StdioClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+    }
+
+    [Fact]
+    public void Stdio_DifferentArgumentListContent_AreNotEqual()
+    {
+        var options1 = new StdioClientTransportOptions { Command = "cmd", Arguments = new List<string> { "arg1" } };
+        var options2 = new StdioClientTransportOptions { Command = "cmd", Arguments = new List<string> { "arg2" } };
+
+        Assert.False(StdioClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+    }
+
+    [Fact]
+    public void Stdio_DifferentArgumentListOrder_AreNotEqual()
+    {
+        var options1 = new StdioClientTransportOptions
+            { Command = "cmd", Arguments = new List<string> { "arg1", "arg2" } };
+        var options2 = new StdioClientTransportOptions
+            { Command = "cmd", Arguments = new List<string> { "arg2", "arg1" } };
+
+        Assert.False(StdioClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+    }
+
+    [Fact]
+    public void Stdio_DifferentEnvironmentVariables_AreNotEqual()
+    {
+        var options1 = new StdioClientTransportOptions
+            { Command = "cmd", EnvironmentVariables = new Dictionary<string, string> { { "K1", "V1" } } };
+        var options2 = new StdioClientTransportOptions
+            { Command = "cmd", EnvironmentVariables = new Dictionary<string, string> { { "K2", "V2" } } };
+
+        Assert.False(StdioClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+    }
+
+    [Fact]
+    public void Stdio_SameEnvironmentVariablesDifferentOrder_AreEqual()
+    {
+        var options1 = new StdioClientTransportOptions
+        {
+            Command = "cmd", EnvironmentVariables = new Dictionary<string, string> { { "K1", "V1" }, { "K2", "V2" } }
+        };
+        var options2 = new StdioClientTransportOptions
+        {
+            Command = "cmd", EnvironmentVariables = new Dictionary<string, string> { { "K2", "V2" }, { "K1", "V1" } }
+        };
+
+        Assert.True(StdioClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+        Assert.Equal(StdioClientTransportOptionsEqualityComparer.Default.GetHashCode(options1),
+            StdioClientTransportOptionsEqualityComparer.Default.GetHashCode(options2));
+    }
+
+    [Fact]
+    public void Stdio_NullVsEmptyCollections_AreNotEqual()
+    {
+        var options1 = new StdioClientTransportOptions
+            { Command = "cmd", Arguments = null, EnvironmentVariables = null };
+        var options2 = new StdioClientTransportOptions
+        {
+            Command = "cmd", Arguments = new List<string>(), EnvironmentVariables = new Dictionary<string, string>()
+        };
+
+        Assert.False(StdioClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+    }
+
+
+    [Fact]
+    public void Sse_IdenticalObjects_AreEqual()
+    {
+        var options1 = new SseClientTransportOptions
+        {
+            Endpoint = new Uri("https://example.com"),
+            AdditionalHeaders = new Dictionary<string, string> { { "Header", "Value" } },
+            Name = "SseTest",
+            ConnectionTimeout = TimeSpan.FromSeconds(15),
+            MaxReconnectAttempts = 5,
+            ReconnectDelay = TimeSpan.FromSeconds(2)
+        };
+        var options2 = new SseClientTransportOptions
+        {
+            Endpoint = new Uri("https://example.com"),
+            AdditionalHeaders = new Dictionary<string, string> { { "Header", "Value" } },
+            Name = "SseTest",
+            ConnectionTimeout = TimeSpan.FromSeconds(15),
+            MaxReconnectAttempts = 5,
+            ReconnectDelay = TimeSpan.FromSeconds(2)
+        };
+
+        Assert.True(SseClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+        Assert.Equal(SseClientTransportOptionsEqualityComparer.Default.GetHashCode(options1),
+            SseClientTransportOptionsEqualityComparer.Default.GetHashCode(options2));
+    }
+
+    [Fact]
+    public void Sse_DifferentSimpleProperty_AreNotEqual()
+    {
+        var options1 = new SseClientTransportOptions { Endpoint = new Uri("https://one.com") };
+        var options2 = new SseClientTransportOptions { Endpoint = new Uri("https://two.com") };
+
+        Assert.False(SseClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+    }
+
+    [Fact]
+    public void Sse_DifferentAdditionalHeaders_AreNotEqual()
+    {
+        var options1 = new SseClientTransportOptions
+        {
+            Endpoint = new Uri("https://a.com"), AdditionalHeaders = new Dictionary<string, string> { { "H1", "V1" } }
+        };
+        var options2 = new SseClientTransportOptions
+        {
+            Endpoint = new Uri("https://a.com"), AdditionalHeaders = new Dictionary<string, string> { { "H2", "V2" } }
+        };
+
+        Assert.False(SseClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+    }
+
+    [Fact]
+    public void Sse_SameAdditionalHeadersDifferentOrder_AreEqual()
+    {
+        var options1 = new SseClientTransportOptions
+        {
+            Endpoint = new Uri("https://b.com"),
+            AdditionalHeaders = new Dictionary<string, string> { { "H1", "V1" }, { "H2", "V2" } }
+        };
+        var options2 = new SseClientTransportOptions
+        {
+            Endpoint = new Uri("https://b.com"),
+            AdditionalHeaders = new Dictionary<string, string> { { "H2", "V2" }, { "H1", "V1" } }
+        };
+
+        Assert.True(SseClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+        Assert.Equal(SseClientTransportOptionsEqualityComparer.Default.GetHashCode(options1),
+            SseClientTransportOptionsEqualityComparer.Default.GetHashCode(options2));
+    }
+
+    [Fact]
+    public void Sse_NullVsEmptyCollections_AreNotEqual()
+    {
+        var options1 = new SseClientTransportOptions { Endpoint = new Uri("https://c.com"), AdditionalHeaders = null };
+        var options2 = new SseClientTransportOptions
+            { Endpoint = new Uri("https://c.com"), AdditionalHeaders = new Dictionary<string, string>() };
+
+        Assert.False(SseClientTransportOptionsEqualityComparer.Default.Equals(options1, options2));
+    }
+}


### PR DESCRIPTION
This commit introduces IEqualityComparer<T> implementations for StdioClientTransportOptions and SseClientTransportOptions to enable structural comparison, addressing the need identified in #181.

The default record equality performs reference comparison for collection types (Arguments, EnvironmentVariables, AdditionalHeaders). These new comparers allow comparing options based on their values, including the contents of these collections.

- Added StdioClientTransportOptionsEqualityComparer
- Added SseClientTransportOptionsEqualityComparer
- Added corresponding unit tests

Design choices:
- Used IEqualityComparer<T> instead of IEquatable<T> on the options records themselves to avoid potential issues with mutable types and hashing (as discussed in #181).
- Implemented GetHashCode using a manual algorithm compatible with .NET Standard 2.0+ without relying on #if directives.

