### PR TITLE
Add StreamableHttpHandler and WithHttpTransport

### DIFF
--- a/samples/AspNetCoreSseServer/Program.cs
+++ b/samples/AspNetCoreSseServer/Program.cs
@@ -2,6 +2,7 @@ using TestServerWithHosting.Tools;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddMcpServer()
+    .WithHttpTransport()
     .WithTools<EchoTool>()
     .WithTools<SampleLlmTool>();
 

--- a/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.DependencyInjection.Extensions;
+using ModelContextProtocol.AspNetCore;
+using ModelContextProtocol.Server;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Provides methods for configuring HTTP MCP servers via dependency injection.
+/// </summary>
+public static class HttpMcpServerBuilderExtensions
+{
+    /// <summary>
+    /// Adds the services necessary for <see cref="M:McpEndpointRouteBuilderExtensions.MapMcp"/>
+    /// to handle MCP requests and sessions using the MCP HTTP Streaming transport. For more information on configuring the underlying HTTP server
+    /// to control things like port binding custom TLS certificates, see the <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis">Minimal APIs quick reference</see>.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="configureOptions">Configures options for the HTTP Streaming transport. This allows configuring per-session
+    /// <see cref="McpServerOptions"/> and running logic before and after a session.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    public static IMcpServerBuilder WithHttpTransport(this IMcpServerBuilder builder, Action<HttpServerTransportOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.TryAddSingleton<StreamableHttpHandler>();
+
+        if (configureOptions is not null)
+        {
+            builder.Services.Configure(configureOptions);
+        }
+
+        return builder;
+    }
+}

--- a/src/ModelContextProtocol.AspNetCore/HttpMcpSession.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpMcpSession.cs
@@ -12,15 +12,15 @@ internal class HttpMcpSession
     }
 
     public SseResponseStreamTransport Transport { get; }
-    public (string ClaimType, string ClaimValue, string Issuer)? UserIdClaim { get; }
+    public (string Type, string Value, string Issuer)? UserIdClaim { get; }
 
     public bool HasSameUserId(ClaimsPrincipal user)
-        => UserIdClaim?.ClaimValue == GetUserIdClaim(user)?.ClaimValue;
+        => UserIdClaim == GetUserIdClaim(user);
 
     // SignalR only checks for ClaimTypes.NameIdentifier in HttpConnectionDispatcher, but AspNetCore.Antiforgery checks that plus the sub and UPN claims.
     // However, we short-circuit unlike antiforgery since we expect to call this to verify MCP messages a lot more frequently than
     // verifying antiforgery tokens from <form> posts.
-    private static (string ClaimType, string ClaimValue, string Issuer)? GetUserIdClaim(ClaimsPrincipal user)
+    private static (string Type, string Value, string Issuer)? GetUserIdClaim(ClaimsPrincipal user)
     {
         if (user?.Identity?.IsAuthenticated != true)
         {

--- a/src/ModelContextProtocol.AspNetCore/HttpMcpSession.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpMcpSession.cs
@@ -12,7 +12,7 @@ internal class HttpMcpSession
     }
 
     public SseResponseStreamTransport Transport { get; }
-    public (string ClaimType, string ClaimValue)? UserIdClaim { get; }
+    public (string ClaimType, string ClaimValue, string Issuer)? UserIdClaim { get; }
 
     public bool HasSameUserId(ClaimsPrincipal user)
         => UserIdClaim?.ClaimValue == GetUserIdClaim(user)?.ClaimValue;
@@ -20,7 +20,7 @@ internal class HttpMcpSession
     // SignalR only checks for ClaimTypes.NameIdentifier in HttpConnectionDispatcher, but AspNetCore.Antiforgery checks that plus the sub and UPN claims.
     // However, we short-circuit unlike antiforgery since we expect to call this to verify MCP messages a lot more frequently than
     // verifying antiforgery tokens from <form> posts.
-    private static (string ClaimType, string ClaimValue)? GetUserIdClaim(ClaimsPrincipal user)
+    private static (string ClaimType, string ClaimValue, string Issuer)? GetUserIdClaim(ClaimsPrincipal user)
     {
         if (user?.Identity?.IsAuthenticated != true)
         {
@@ -31,7 +31,7 @@ internal class HttpMcpSession
 
         if (claim is { } idClaim)
         {
-            return (idClaim.Type, idClaim.Value);
+            return (idClaim.Type, idClaim.Value, idClaim.Issuer);
         }
 
         return null;

--- a/src/ModelContextProtocol.AspNetCore/HttpMcpSession.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpMcpSession.cs
@@ -1,0 +1,39 @@
+﻿using ModelContextProtocol.Protocol.Transport;
+using System.Security.Claims;
+
+namespace ModelContextProtocol.AspNetCore;
+
+internal class HttpMcpSession
+{
+    public HttpMcpSession(SseResponseStreamTransport transport, ClaimsPrincipal user)
+    {
+        Transport = transport;
+        UserIdClaim = GetUserIdClaim(user);
+    }
+
+    public SseResponseStreamTransport Transport { get; }
+    public (string ClaimType, string ClaimValue)? UserIdClaim { get; }
+
+    public bool HasSameUserId(ClaimsPrincipal user)
+        => UserIdClaim?.ClaimValue == GetUserIdClaim(user)?.ClaimValue;
+
+    // SignalR only checks for ClaimTypes.NameIdentifier in HttpConnectionDispatcher, but AspNetCore.Antiforgery checks that plus the sub and UPN claims.
+    // However, we short-circuit unlike antiforgery since we expect to call this to verify MCP messages a lot more frequently than
+    // verifying antiforgery tokens from <form> posts.
+    private static (string ClaimType, string ClaimValue)? GetUserIdClaim(ClaimsPrincipal user)
+    {
+        if (user?.Identity?.IsAuthenticated != true)
+        {
+            return null;
+        }
+
+        var claim = user.FindFirst(ClaimTypes.NameIdentifier) ?? user.FindFirst("sub") ?? user.FindFirst(ClaimTypes.Upn);
+
+        if (claim is { } idClaim)
+        {
+            return (idClaim.Type, idClaim.Value);
+        }
+
+        return null;
+    }
+}

--- a/src/ModelContextProtocol.AspNetCore/HttpServerTransportOptions.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpServerTransportOptions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Http;
+using ModelContextProtocol.Server;
+
+namespace ModelContextProtocol.AspNetCore;
+
+/// <summary>
+/// Configuration options for <see cref="M:McpEndpointRouteBuilderExtensions.MapMcp"/>.
+/// which implements the Streaming HTTP transport for the Model Context Protocol.
+/// See the protocol specification for details on the Streamable HTTP transport. <see href="https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http"/>
+/// </summary>
+public class HttpServerTransportOptions
+{
+    /// <summary>
+    /// Gets or sets an optional asynchronous callback to configure per-session <see cref="McpServerOptions"/>
+    /// with access to the <see cref="HttpContext"/> of the request that initiated the session.
+    /// </summary>
+    public Func<HttpContext, McpServerOptions, CancellationToken, Task>? ConfigureSessionOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional asynchronous callback for running new MCP sessions manually.
+    /// This is useful for running logic before a sessions starts and after it completes.
+    /// </summary>
+    public Func<HttpContext, IMcpServer, CancellationToken, Task>? RunSessionHandler { get; set; }
+}

--- a/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs
@@ -23,6 +23,7 @@ public static class McpEndpointRouteBuilderExtensions
             throw new InvalidOperationException("You must call WithHttpTransport(). Unable to find required services. Call builder.Services.AddMcpServer().WithHttpTransport() in application startup code.");
 
         var routeGroup = endpoints.MapGroup(pattern);
+        routeGroup.MapGet("", handler.HandleRequestAsync);
         routeGroup.MapGet("/sse", handler.HandleRequestAsync);
         routeGroup.MapPost("/message", handler.HandleRequestAsync);
         return routeGroup;

--- a/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/McpEndpointRouteBuilderExtensions.cs
@@ -1,19 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.AspNetCore.WebUtilities;
+﻿using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using ModelContextProtocol.Protocol.Messages;
-using ModelContextProtocol.Protocol.Transport;
-using ModelContextProtocol.Server;
-using ModelContextProtocol.Utils.Json;
-using System.Collections.Concurrent;
+using ModelContextProtocol.AspNetCore;
 using System.Diagnostics.CodeAnalysis;
-using System.Security.Cryptography;
 
 namespace Microsoft.AspNetCore.Builder;
 
@@ -24,136 +12,19 @@ public static class McpEndpointRouteBuilderExtensions
 {
     /// <summary>
     /// Sets up endpoints for handling MCP HTTP Streaming transport.
+    /// See <see href="https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http">the protocol specification</see> for details about the Streamable HTTP transport.
     /// </summary>
     /// <param name="endpoints">The web application to attach MCP HTTP endpoints.</param>
     /// <param name="pattern">The route pattern prefix to map to.</param>
-    /// <param name="configureOptionsAsync">Configure per-session options.</param>
-    /// <param name="runSessionAsync">Provides an optional asynchronous callback for handling new MCP sessions.</param>
     /// <returns>Returns a builder for configuring additional endpoint conventions like authorization policies.</returns>
-    public static IEndpointConventionBuilder MapMcp(
-        this IEndpointRouteBuilder endpoints,
-        [StringSyntax("Route")] string pattern = "",
-        Func<HttpContext, McpServerOptions, CancellationToken, Task>? configureOptionsAsync = null,
-        Func<HttpContext, IMcpServer, CancellationToken, Task>? runSessionAsync = null)
-        => endpoints.MapMcp(RoutePatternFactory.Parse(pattern), configureOptionsAsync, runSessionAsync);
-
-    /// <summary>
-    /// Sets up endpoints for handling MCP HTTP Streaming transport.
-    /// </summary>
-    /// <param name="endpoints">The web application to attach MCP HTTP endpoints.</param>
-    /// <param name="pattern">The route pattern prefix to map to.</param>
-    /// <param name="configureOptionsAsync">Configure per-session options.</param>
-    /// <param name="runSessionAsync">Provides an optional asynchronous callback for handling new MCP sessions.</param>
-    /// <returns>Returns a builder for configuring additional endpoint conventions like authorization policies.</returns>
-    public static IEndpointConventionBuilder MapMcp(this IEndpointRouteBuilder endpoints,
-        RoutePattern pattern,
-        Func<HttpContext, McpServerOptions, CancellationToken, Task>? configureOptionsAsync = null,
-        Func<HttpContext, IMcpServer, CancellationToken, Task>? runSessionAsync = null)
+    public static IEndpointConventionBuilder MapMcp(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string pattern = "")
     {
-        ConcurrentDictionary<string, SseResponseStreamTransport> _sessions = new(StringComparer.Ordinal);
-
-        var loggerFactory = endpoints.ServiceProvider.GetRequiredService<ILoggerFactory>();
-        var optionsSnapshot = endpoints.ServiceProvider.GetRequiredService<IOptions<McpServerOptions>>();
-        var optionsFactory = endpoints.ServiceProvider.GetRequiredService<IOptionsFactory<McpServerOptions>>();
-        var hostApplicationLifetime = endpoints.ServiceProvider.GetRequiredService<IHostApplicationLifetime>();
+        var handler = endpoints.ServiceProvider.GetService<StreamableHttpHandler>() ??
+            throw new InvalidOperationException("You must call WithHttpTransport(). Unable to find required services. Call builder.Services.AddMcpServer().WithHttpTransport() in application startup code.");
 
         var routeGroup = endpoints.MapGroup(pattern);
-
-        routeGroup.MapGet("/sse", async context =>
-        {
-            // If the server is shutting down, we need to cancel all SSE connections immediately without waiting for HostOptions.ShutdownTimeout
-            // which defaults to 30 seconds.
-            using var sseCts = CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted, hostApplicationLifetime.ApplicationStopping);
-            var cancellationToken = sseCts.Token;
-
-            var response = context.Response;
-            response.Headers.ContentType = "text/event-stream";
-            response.Headers.CacheControl = "no-cache,no-store";
-
-            // Make sure we disable all response buffering for SSE
-            context.Response.Headers.ContentEncoding = "identity";
-            context.Features.GetRequiredFeature<IHttpResponseBodyFeature>().DisableBuffering();
-
-            var sessionId = MakeNewSessionId();
-            await using var transport = new SseResponseStreamTransport(response.Body, $"/message?sessionId={sessionId}");
-            if (!_sessions.TryAdd(sessionId, transport))
-            {
-                throw new Exception($"Unreachable given good entropy! Session with ID '{sessionId}' has already been created.");
-            }
-
-            var options = optionsSnapshot.Value;
-            if (configureOptionsAsync is not null)
-            {
-                options = optionsFactory.Create(Options.DefaultName);
-                await configureOptionsAsync.Invoke(context, options, cancellationToken);
-            }
-
-            try
-            {
-                var transportTask = transport.RunAsync(cancellationToken);
-
-                try
-                {
-                    await using var mcpServer = McpServerFactory.Create(transport, options, loggerFactory, endpoints.ServiceProvider);
-                    context.Features.Set(mcpServer);
-
-                    runSessionAsync ??= RunSession;
-                    await runSessionAsync(context, mcpServer, cancellationToken);
-                }
-                finally
-                {
-                    await transport.DisposeAsync();
-                    await transportTask;
-                }
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                // RequestAborted always triggers when the client disconnects before a complete response body is written,
-                // but this is how SSE connections are typically closed.
-            }
-            finally
-            {
-                _sessions.TryRemove(sessionId, out _);
-            }
-        });
-
-        routeGroup.MapPost("/message", async context =>
-        {
-            if (!context.Request.Query.TryGetValue("sessionId", out var sessionId))
-            {
-                await Results.BadRequest("Missing sessionId query parameter.").ExecuteAsync(context);
-                return;
-            }
-
-            if (!_sessions.TryGetValue(sessionId.ToString(), out var transport))
-            {
-                await Results.BadRequest($"Session ID not found.").ExecuteAsync(context);
-                return;
-            }
-
-            var message = (IJsonRpcMessage?)await context.Request.ReadFromJsonAsync(McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(IJsonRpcMessage)), context.RequestAborted);
-            if (message is null)
-            {
-                await Results.BadRequest("No message in request body.").ExecuteAsync(context);
-                return;
-            }
-
-            await transport.OnMessageReceivedAsync(message, context.RequestAborted);
-            context.Response.StatusCode = StatusCodes.Status202Accepted;
-            await context.Response.WriteAsync("Accepted");
-        });
-
+        routeGroup.MapGet("/sse", handler.HandleRequestAsync);
+        routeGroup.MapPost("/message", handler.HandleRequestAsync);
         return routeGroup;
-    }
-
-    private static Task RunSession(HttpContext httpContext, IMcpServer session, CancellationToken requestAborted)
-        => session.RunAsync(requestAborted);
-
-    private static string MakeNewSessionId()
-    {
-        // 128 bits
-        Span<byte> buffer = stackalloc byte[16];
-        RandomNumberGenerator.Fill(buffer);
-        return WebEncoders.Base64UrlEncode(buffer);
     }
 }

--- a/src/ModelContextProtocol.AspNetCore/README.md
+++ b/src/ModelContextProtocol.AspNetCore/README.md
@@ -30,7 +30,7 @@ dotnet add package ModelContextProtocol.AspNetCore --prerelease
 
 ```csharp
 // Program.cs
-?using ModelContextProtocol.Server;
+using ModelContextProtocol.Server;
 using System.ComponentModel;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/ModelContextProtocol.AspNetCore/README.md
+++ b/src/ModelContextProtocol.AspNetCore/README.md
@@ -34,7 +34,9 @@ dotnet add package ModelContextProtocol.AspNetCore --prerelease
 using System.ComponentModel;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddMcpServer().WithToolsFromAssembly();
+builder.Services.AddMcpServer()
+    .WithHttpTransport()
+    .WithToolsFromAssembly();
 var app = builder.Build();
 
 app.MapMcp();

--- a/src/ModelContextProtocol.AspNetCore/README.md
+++ b/src/ModelContextProtocol.AspNetCore/README.md
@@ -30,20 +30,16 @@ dotnet add package ModelContextProtocol.AspNetCore --prerelease
 
 ```csharp
 // Program.cs
-using ModelContextProtocol.Server;
+?using ModelContextProtocol.Server;
 using System.ComponentModel;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.WebHost.ConfigureKestrel(options =>
-{
-    options.ListenLocalhost(3001);
-});
 builder.Services.AddMcpServer().WithToolsFromAssembly();
 var app = builder.Build();
 
 app.MapMcp();
 
-app.Run();
+app.Run("http://localhost:3001");
 
 [McpServerToolType]
 public static class EchoTool

--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol.Messages;
+using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Utils.Json;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+
+namespace ModelContextProtocol.AspNetCore;
+
+internal sealed class StreamableHttpHandler(
+    IOptions<McpServerOptions> mcpServerOptionsSnapshot,
+    IOptionsFactory<McpServerOptions> mcpServerOptionsFactory,
+    IOptions<HttpServerTransportOptions> httpMcpServerOptions,
+    IHostApplicationLifetime hostApplicationLifetime,
+    ILoggerFactory loggerFactory)
+{
+
+    private readonly ConcurrentDictionary<string, SseResponseStreamTransport> _sessions = new(StringComparer.Ordinal);
+    private readonly ILogger _logger = loggerFactory.CreateLogger<StreamableHttpHandler>();
+
+    public async Task HandleRequestAsync(HttpContext context)
+    {
+        if (context.Request.Method == HttpMethods.Get)
+        {
+            await HandleSseRequestAsync(context);
+        }
+        else if (context.Request.Method == HttpMethods.Post)
+        {
+            await HandleMessageRequestAsync(context);
+        }
+        else
+        {
+            context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+            await context.Response.WriteAsync("Method Not Allowed");
+        }
+    }
+
+    public async Task HandleSseRequestAsync(HttpContext context)
+    {
+        // If the server is shutting down, we need to cancel all SSE connections immediately without waiting for HostOptions.ShutdownTimeout
+        // which defaults to 30 seconds.
+        using var sseCts = CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted, hostApplicationLifetime.ApplicationStopping);
+        var cancellationToken = sseCts.Token;
+
+        var response = context.Response;
+        response.Headers.ContentType = "text/event-stream";
+        response.Headers.CacheControl = "no-cache,no-store";
+
+        // Make sure we disable all response buffering for SSE
+        context.Response.Headers.ContentEncoding = "identity";
+        context.Features.GetRequiredFeature<IHttpResponseBodyFeature>().DisableBuffering();
+
+        var sessionId = MakeNewSessionId();
+        await using var transport = new SseResponseStreamTransport(response.Body, $"/message?sessionId={sessionId}");
+        if (!_sessions.TryAdd(sessionId, transport))
+        {
+            throw new Exception($"Unreachable given good entropy! Session with ID '{sessionId}' has already been created.");
+        }
+
+        var mcpServerOptions = mcpServerOptionsSnapshot.Value;
+        if (httpMcpServerOptions.Value.ConfigureSessionOptions is { } configureSessionOptions)
+        {
+            mcpServerOptions = mcpServerOptionsFactory.Create(Options.DefaultName);
+            await configureSessionOptions(context, mcpServerOptions, cancellationToken);
+        }
+
+        try
+        {
+            var transportTask = transport.RunAsync(cancellationToken);
+
+            try
+            {
+                await using var mcpServer = McpServerFactory.Create(transport, mcpServerOptions, loggerFactory, context.RequestServices);
+                context.Features.Set(mcpServer);
+
+                var runSessionAsync = httpMcpServerOptions.Value.RunSessionHandler ?? RunSessionAsync;
+                await runSessionAsync(context, mcpServer, cancellationToken);
+            }
+            finally
+            {
+                await transport.DisposeAsync();
+                await transportTask;
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // RequestAborted always triggers when the client disconnects before a complete response body is written,
+            // but this is how SSE connections are typically closed.
+        }
+        finally
+        {
+            _sessions.TryRemove(sessionId, out _);
+        }
+    }
+
+    public async Task HandleMessageRequestAsync(HttpContext context)
+    {
+        if (!context.Request.Query.TryGetValue("sessionId", out var sessionId))
+        {
+            await Results.BadRequest("Missing sessionId query parameter.").ExecuteAsync(context);
+            return;
+        }
+
+        if (!_sessions.TryGetValue(sessionId.ToString(), out var transport))
+        {
+            await Results.BadRequest($"Session ID not found.").ExecuteAsync(context);
+            return;
+        }
+
+        var message = (IJsonRpcMessage?)await context.Request.ReadFromJsonAsync(McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(IJsonRpcMessage)), context.RequestAborted);
+        if (message is null)
+        {
+            await Results.BadRequest("No message in request body.").ExecuteAsync(context);
+            return;
+        }
+
+        await transport.OnMessageReceivedAsync(message, context.RequestAborted);
+        context.Response.StatusCode = StatusCodes.Status202Accepted;
+        await context.Response.WriteAsync("Accepted");
+    }
+
+    private static Task RunSessionAsync(HttpContext httpContext, IMcpServer session, CancellationToken requestAborted)
+        => session.RunAsync(requestAborted);
+
+    private static string MakeNewSessionId()
+    {
+        // 128 bits
+        Span<byte> buffer = stackalloc byte[16];
+        RandomNumberGenerator.Fill(buffer);
+        return WebEncoders.Base64UrlEncode(buffer);
+    }
+}

--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -57,7 +57,7 @@ internal sealed class StreamableHttpHandler(
         context.Features.GetRequiredFeature<IHttpResponseBodyFeature>().DisableBuffering();
 
         var sessionId = MakeNewSessionId();
-        await using var transport = new SseResponseStreamTransport(response.Body, $"/message?sessionId={sessionId}");
+        await using var transport = new SseResponseStreamTransport(response.Body, $"message?sessionId={sessionId}");
         if (!_sessions.TryAdd(sessionId, transport))
         {
             throw new Exception($"Unreachable given good entropy! Session with ID '{sessionId}' has already been created.");

--- a/src/ModelContextProtocol/Protocol/Transport/SseClientSessionTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseClientSessionTransport.cs
@@ -285,21 +285,8 @@ internal sealed class SseClientSessionTransport : TransportBase
                 return;
             }
 
-            // Check if data is absolute URI
-            if (data.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || data.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
-            {
-                // Since the endpoint is an absolute URI, we can use it directly
-                _messageEndpoint = new Uri(data);
-            }
-            else
-            {
-                // If the endpoint is a relative URI, we need to combine it with the relative path of the SSE endpoint
-                var baseUriBuilder = new UriBuilder(_sseEndpoint);
-
-
-                // Instead of manually concatenating strings, use the Uri class's composition capabilities
-                _messageEndpoint = new Uri(baseUriBuilder.Uri, data);
-            }
+            // If data is an absolute URL, the Uri will be constructed entirely from it and not the _sseEndpoint.
+            _messageEndpoint = new Uri(_sseEndpoint, data);
 
             // Set connected state
             SetConnected(true);

--- a/src/ModelContextProtocol/Protocol/Transport/SseClientSessionTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseClientSessionTransport.cs
@@ -101,11 +101,12 @@ internal sealed class SseClientSessionTransport : TransportBase
             messageId = messageWithId.Id.ToString();
         }
 
-        var response = await _httpClient.PostAsync(
-            _messageEndpoint,
-            content,
-            cancellationToken
-        ).ConfigureAwait(false);
+        var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, _messageEndpoint)
+        {
+            Content = content,
+        };
+        CopyAdditionalHeaders(httpRequestMessage.Headers);
+        var response = await _httpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
@@ -182,72 +183,52 @@ internal sealed class SseClientSessionTransport : TransportBase
 
     private async Task ReceiveMessagesAsync(CancellationToken cancellationToken)
     {
-        int reconnectAttempts = 0;
-
-        while (!cancellationToken.IsCancellationRequested && !IsConnected)
+        try
         {
-            try
-            {
-                using var request = new HttpRequestMessage(HttpMethod.Get, _sseEndpoint);
-                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+            using var request = new HttpRequestMessage(HttpMethod.Get, _sseEndpoint);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+            CopyAdditionalHeaders(request.Headers);
 
-                if (_options.AdditionalHeaders != null)
+            using var response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken
+            ).ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+
+            using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+            await foreach (SseItem<string> sseEvent in SseParser.Create(stream).EnumerateAsync(cancellationToken).ConfigureAwait(false))
+            {
+                switch (sseEvent.EventType)
                 {
-                    foreach (var header in _options.AdditionalHeaders)
-                    {
-                        request.Headers.Add(header.Key, header.Value);
-                    }
+                    case "endpoint":
+                        HandleEndpointEvent(sseEvent.Data);
+                        break;
+
+                    case "message":
+                        await ProcessSseMessage(sseEvent.Data, cancellationToken).ConfigureAwait(false);
+                        break;
                 }
-
-                using var response = await _httpClient.SendAsync(
-                    request,
-                    HttpCompletionOption.ResponseHeadersRead,
-                    cancellationToken
-                ).ConfigureAwait(false);
-
-                response.EnsureSuccessStatusCode();
-
-                using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-
-                await foreach (SseItem<string> sseEvent in SseParser.Create(stream).EnumerateAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    switch (sseEvent.EventType)
-                    {
-                        case "endpoint":
-                            HandleEndpointEvent(sseEvent.Data);
-                            break;
-
-                        case "message":
-                            await ProcessSseMessage(sseEvent.Data, cancellationToken).ConfigureAwait(false);
-                            break;
-                    }
-                }
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                _logger.TransportReadMessagesCancelled(_endpointName);
-                // Normal shutdown
-            }
-            catch (IOException) when (cancellationToken.IsCancellationRequested)
-            {
-                _logger.TransportReadMessagesCancelled(_endpointName);
-                // Normal shutdown
-            }
-            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-            {
-                _logger.TransportConnectionError(_endpointName, ex);
-
-                reconnectAttempts++;
-                if (reconnectAttempts >= _options.MaxReconnectAttempts)
-                {
-                    throw new McpTransportException("Exceeded reconnect limit", ex);
-                }
-
-                await Task.Delay(_options.ReconnectDelay, cancellationToken).ConfigureAwait(false);
             }
         }
-
-        SetConnected(false);
+        catch when (cancellationToken.IsCancellationRequested)
+        {
+            // Normal shutdown
+            _connectionEstablished.TrySetCanceled(cancellationToken);
+            _logger.TransportReadMessagesCancelled(_endpointName);
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            _connectionEstablished.TrySetException(ex);
+            _logger.TransportConnectionError(_endpointName, ex);
+            throw;
+        }
+        finally
+        {
+            SetConnected(false);
+        }
     }
 
     private async Task ProcessSseMessage(string data, CancellationToken cancellationToken)
@@ -304,6 +285,20 @@ internal sealed class SseClientSessionTransport : TransportBase
         {
             _logger.TransportEndpointEventParseFailed(_endpointName, data, ex);
             throw new McpTransportException("Failed to parse endpoint event", ex);
+        }
+    }
+
+    private void CopyAdditionalHeaders(HttpRequestHeaders headers)
+    {
+        if (_options.AdditionalHeaders is not null)
+        {
+            foreach (var header in _options.AdditionalHeaders)
+            {
+                if (!headers.TryAddWithoutValidation(header.Key, header.Value))
+                {
+                    throw new InvalidOperationException($"Failed to add header '{header.Key}' with value '{header.Value}' from {nameof(SseClientTransportOptions.AdditionalHeaders)}.");
+                }
+            }
         }
     }
 }

--- a/src/ModelContextProtocol/Protocol/Transport/SseClientTransportOptions.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseClientTransportOptions.cs
@@ -49,37 +49,6 @@ public record SseClientTransportOptions
     public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Gets or sets the maximum number of reconnection attempts for the SSE connection before giving up.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This property controls how many times the client will attempt to reconnect to the SSE server
-    /// after a connection failure occurs. If all reconnection attempts fail, a 
-    /// <see cref="McpTransportException"/> with the message "Exceeded reconnect limit" will be thrown.
-    /// </para>
-    /// <para>
-    /// Between each reconnection attempt, the client will wait for the duration specified by <see cref="ReconnectDelay"/>.
-    /// </para>
-    /// </remarks>
-    public int MaxReconnectAttempts { get; init; } = 3;
-
-    /// <summary>
-    /// Gets or sets the delay to employ between reconnection attempts when the SSE connection fails.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// When a connection to the SSE server is lost or fails, the client will wait for this duration
-    /// before attempting to reconnect. This helps prevent excessive reconnection attempts in quick succession
-    /// which could overload the server or network.
-    /// </para>
-    /// <para>
-    /// The reconnection process continues until either a successful connection is established or
-    /// the maximum number of reconnection attempts (<see cref="MaxReconnectAttempts"/>) is reached.
-    /// </para>
-    /// </remarks>
-    public TimeSpan ReconnectDelay { get; init; } = TimeSpan.FromSeconds(5);
-
-    /// <summary>
     /// Gets custom HTTP headers to include in requests to the SSE server.
     /// </summary>
     /// <remarks>

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.AspNetCore.Tests.Utils;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol.Transport;
 
 namespace ModelContextProtocol.AspNetCore.Tests;
 
@@ -11,11 +13,41 @@ public class MapMcpTests(ITestOutputHelper testOutputHelper) : KestrelInMemoryTe
     {
         Builder.Services.AddMcpServer().WithHttpTransport();
         await using var app = Builder.Build();
+
         app.MapMcp("/mcp");
+
         await app.StartAsync(TestContext.Current.CancellationToken);
 
         using var httpClient = CreateHttpClient();
         using var response = await httpClient.GetAsync("http://localhost/mcp/sse", HttpCompletionOption.ResponseHeadersRead, TestContext.Current.CancellationToken);
         response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task CanConnect_WithMcpClient_AfterCustomizingRoute()
+    {
+        Builder.Services.AddMcpServer(options =>
+        {
+            options.ServerInfo = new()
+            {
+                Name = "TestCustomRouteServer",
+                Version = "1.0.0",
+            };
+        }).WithHttpTransport();
+        await using var app = Builder.Build();
+
+        app.MapMcp("/mcp");
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var httpClient = CreateHttpClient();
+        var sseClientTransportOptions = new SseClientTransportOptions()
+        {
+            Endpoint = new Uri("http://localhost/mcp/sse"),
+        };
+        await using var transport = new SseClientTransport(sseClientTransportOptions, httpClient, LoggerFactory);
+        var mcpClient = await McpClientFactory.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("TestCustomRouteServer", mcpClient.ServerInfo.Name);
     }
 }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpTests.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using ModelContextProtocol.Tests.Utils;
+using ModelContextProtocol.AspNetCore.Tests.Utils;
 
-namespace ModelContextProtocol.AspNetCore.Tests.Server;
+namespace ModelContextProtocol.AspNetCore.Tests;
 
 public class MapMcpTests(ITestOutputHelper testOutputHelper) : KestrelInMemoryTest(testOutputHelper)
 {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/Server/MapMcpTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/Server/MapMcpTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Tests.Utils;
 
 namespace ModelContextProtocol.AspNetCore.Tests.Server;
@@ -8,6 +9,7 @@ public class MapMcpTests(ITestOutputHelper testOutputHelper) : KestrelInMemoryTe
     [Fact]
     public async Task Allows_Customizing_Route()
     {
+        Builder.Services.AddMcpServer().WithHttpTransport();
         await using var app = Builder.Build();
         app.MapMcp("/mcp");
         await app.StartAsync(TestContext.Current.CancellationToken);

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
@@ -30,7 +30,6 @@ public partial class SseIntegrationTests(ITestOutputHelper outputHelper) : Kestr
             LoggerFactory,
             TestContext.Current.CancellationToken);
 
-
     [Fact]
     public async Task ConnectAndReceiveMessage_InMemoryServer()
     {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
@@ -4,16 +4,16 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using ModelContextProtocol.AspNetCore.Tests.Utils;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Messages;
 using ModelContextProtocol.Protocol.Transport;
 using ModelContextProtocol.Server;
-using ModelContextProtocol.Tests.Utils;
 using ModelContextProtocol.Utils.Json;
 using System.Text.Json.Serialization;
 using TestServerWithHosting.Tools;
 
-namespace ModelContextProtocol.Tests;
+namespace ModelContextProtocol.AspNetCore.Tests;
 
 public partial class SseIntegrationTests(ITestOutputHelper outputHelper) : KestrelInMemoryTest(outputHelper)
 {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
@@ -38,8 +38,7 @@ public partial class SseIntegrationTests(ITestOutputHelper outputHelper) : Kestr
         app.MapMcp();
         await app.StartAsync(TestContext.Current.CancellationToken);
 
-        using var httpClient = CreateHttpClient();
-        await using var mcpClient = await ConnectMcpClient(httpClient);
+        await using var mcpClient = await ConnectMcpClient(HttpClient);
 
         // Send a test message through POST endpoint
         await mcpClient.SendNotificationAsync("test/message", new Envelope { Message = "Hello, SSE!" }, serializerOptions: JsonContext.Default.Options, cancellationToken: TestContext.Current.CancellationToken);
@@ -54,8 +53,7 @@ public partial class SseIntegrationTests(ITestOutputHelper outputHelper) : Kestr
         MapAbsoluteEndpointUriMcp(app);
         await app.StartAsync(TestContext.Current.CancellationToken);
 
-        using var httpClient = CreateHttpClient();
-        await using var mcpClient = await ConnectMcpClient(httpClient);
+        await using var mcpClient = await ConnectMcpClient(HttpClient);
 
         // Send a test message through POST endpoint
         await mcpClient.SendNotificationAsync("test/message", new Envelope { Message = "Hello, SSE!" }, serializerOptions: JsonContext.Default.Options, cancellationToken: TestContext.Current.CancellationToken);
@@ -87,8 +85,7 @@ public partial class SseIntegrationTests(ITestOutputHelper outputHelper) : Kestr
         app.MapMcp();
         await app.StartAsync(TestContext.Current.CancellationToken);
 
-        using var httpClient = CreateHttpClient();
-        await using var mcpClient = await ConnectMcpClient(httpClient);
+        await using var mcpClient = await ConnectMcpClient(HttpClient);
 
         mcpClient.RegisterNotificationHandler("test/notification", (args, ca) =>
         {
@@ -128,8 +125,7 @@ public partial class SseIntegrationTests(ITestOutputHelper outputHelper) : Kestr
         app.MapMcp();
         await app.StartAsync(TestContext.Current.CancellationToken);
 
-        using var httpClient = CreateHttpClient();
-        await using var mcpClient = await ConnectMcpClient(httpClient);
+        await using var mcpClient = await ConnectMcpClient(HttpClient);
 
         // Options can be lazily initialized, but they must be instantiated by the time an MCP client can finish connecting.
         // Callbacks can be called multiple times if configureOptionsAsync is configured, because that uses the IOptionsFactory,

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseServerIntegrationTestFixture.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseServerIntegrationTestFixture.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.Extensions.Logging;
+using ModelContextProtocol.AspNetCore.Tests.Utils;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol.Transport;
-using ModelContextProtocol.Test.Utils;
 using ModelContextProtocol.Tests.Utils;
 using ModelContextProtocol.TestSseServer;
 
-namespace ModelContextProtocol.Tests;
+namespace ModelContextProtocol.AspNetCore.Tests;
 
 public class SseServerIntegrationTestFixture : IAsyncDisposable
 {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseServerIntegrationTests.cs
@@ -4,7 +4,7 @@ using ModelContextProtocol.Tests.Utils;
 using System.Net;
 using System.Text;
 
-namespace ModelContextProtocol.Tests;
+namespace ModelContextProtocol.AspNetCore.Tests;
 
 public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerIntegrationTestFixture>
 {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryConnection.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryConnection.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Http.Features;
 using System.IO.Pipelines;
 
-namespace ModelContextProtocol.Tests.Utils;
+namespace ModelContextProtocol.AspNetCore.Tests.Utils;
 
 public sealed class KestrelInMemoryConnection : ConnectionContext
 {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryTest.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryTest.cs
@@ -2,8 +2,9 @@
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using ModelContextProtocol.Tests.Utils;
 
-namespace ModelContextProtocol.Tests.Utils;
+namespace ModelContextProtocol.AspNetCore.Tests.Utils;
 
 public class KestrelInMemoryTest : LoggedTest
 {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryTest.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryTest.cs
@@ -19,21 +19,24 @@ public class KestrelInMemoryTest : LoggedTest
         Builder.Services.RemoveAll<IConnectionListenerFactory>();
         Builder.Services.AddSingleton<IConnectionListenerFactory>(_inMemoryTransport);
         Builder.Services.AddSingleton(LoggerProvider);
-    }
 
-    public WebApplicationBuilder Builder { get; }
-
-    public HttpClient CreateHttpClient()
-    {
-        var socketsHttpHandler = new SocketsHttpHandler()
+        HttpClient = new HttpClient(new SocketsHttpHandler()
         {
             ConnectCallback = (context, token) =>
             {
                 var connection = _inMemoryTransport.CreateConnection();
                 return new(connection.ClientStream);
             },
-        };
+        });
+    }
 
-        return new HttpClient(socketsHttpHandler);
+    public WebApplicationBuilder Builder { get; }
+
+    public HttpClient HttpClient { get; }
+
+    public override void Dispose()
+    {
+        HttpClient.Dispose();
+        base.Dispose();
     }
 }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryTransport.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryTransport.cs
@@ -2,7 +2,7 @@
 using System.Net;
 using System.Threading.Channels;
 
-namespace ModelContextProtocol.Tests.Utils;
+namespace ModelContextProtocol.AspNetCore.Tests.Utils;
 
 public sealed class KestrelInMemoryTransport : IConnectionListenerFactory, IConnectionListener
 {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/Utils/LoggedTest.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/Utils/LoggedTest.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using ModelContextProtocol.Test.Utils;
 
 namespace ModelContextProtocol.Tests.Utils;
 

--- a/tests/ModelContextProtocol.AspNetCore.Tests/Utils/XunitLoggerProvider.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/Utils/XunitLoggerProvider.cs
@@ -2,7 +2,7 @@
 using System.Text;
 using Microsoft.Extensions.Logging;
 
-namespace ModelContextProtocol.Test.Utils;
+namespace ModelContextProtocol.Tests.Utils;
 
 public class XunitLoggerProvider(ITestOutputHelper output) : ILoggerProvider
 {

--- a/tests/ModelContextProtocol.TestSseServer/Program.cs
+++ b/tests/ModelContextProtocol.TestSseServer/Program.cs
@@ -408,7 +408,8 @@ public class Program
             builder.Logging.AddProvider(loggerProvider);
         }
 
-        builder.Services.AddMcpServer(ConfigureOptions);
+        builder.Services.AddMcpServer(ConfigureOptions)
+            .WithHttpTransport();
 
         var app = builder.Build();
         app.UseRouting();

--- a/tests/ModelContextProtocol.Tests/EverythingSseServerFixture.cs
+++ b/tests/ModelContextProtocol.Tests/EverythingSseServerFixture.cs
@@ -65,7 +65,8 @@ public class EverythingSseServerFixture : IAsyncDisposable
             ProcessStartInfo processStartInfo = new()
             {
                 FileName = "docker",
-                Arguments = "--version",
+                // "docker info" returns a non-zero exit code if docker engine is not running.
+                Arguments = "info",
                 UseShellExecute = false,
             };
 

--- a/tests/ModelContextProtocol.Tests/Transport/SseClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/SseClientTransportTests.cs
@@ -17,8 +17,6 @@ public class SseClientTransportTests : LoggedTest
         {
             Endpoint = new Uri("http://localhost:8080"),
             ConnectionTimeout = TimeSpan.FromSeconds(2),
-            MaxReconnectAttempts = 3,
-            ReconnectDelay = TimeSpan.FromMilliseconds(50),
             Name = "Test Server",
             AdditionalHeaders = new Dictionary<string, string>
             {
@@ -76,15 +74,12 @@ public class SseClientTransportTests : LoggedTest
         mockHttpHandler.RequestHandler = (request) =>
         {
             retries++;
-            throw new InvalidOperationException("Test exception");
+            throw new Exception("Test exception");
         };
 
-        var action = async () => await transport.ConnectAsync();
-
-        var exception = await Assert.ThrowsAsync<McpTransportException>(action);
-        Assert.Equal("Exceeded reconnect limit", exception.Message);
-
-        Assert.Equal(_transportOptions.MaxReconnectAttempts, retries);
+        var exception = await Assert.ThrowsAsync<Exception>(() => transport.ConnectAsync(TestContext.Current.CancellationToken));
+        Assert.Equal("Test exception", exception.Message);
+        Assert.Equal(1, retries);
     }
 
     [Fact]

--- a/tests/ModelContextProtocol.Tests/Utils/LoggedTest.cs
+++ b/tests/ModelContextProtocol.Tests/Utils/LoggedTest.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using ModelContextProtocol.Test.Utils;
 
 namespace ModelContextProtocol.Tests.Utils;
 

--- a/tests/ModelContextProtocol.Tests/Utils/XunitLoggerProvider.cs
+++ b/tests/ModelContextProtocol.Tests/Utils/XunitLoggerProvider.cs
@@ -2,7 +2,7 @@
 using System.Text;
 using Microsoft.Extensions.Logging;
 
-namespace ModelContextProtocol.Test.Utils;
+namespace ModelContextProtocol.Tests.Utils;
 
 public class XunitLoggerProvider(ITestOutputHelper output) : ILoggerProvider
 {


### PR DESCRIPTION
This is still not an implementation of the "Streamable HTTP" transport, but it gets us a little bit closer.

This is a breaking change that now requires WithHttpTransport() to be called for MapMcp to work. This change also adds testing for IHttpContextAcessor and ensure that requests from different users for the same session are rejected. It also cleans up a few test namespaces like removing ModelContextProtocol.Test.Utils in favor of Test*s*.Utils.

I ~plan to remove~ also removed SseClientTransportOptions.MaxReconnectAttempts and ReconnectDelay. I don't think we want to be in the business of handling retry logic. That's better left to something like Polly.