### PR TITLE
Add AdditionalHeader handling to ReceiveMessageAsync

### DIFF
--- a/src/ModelContextProtocol/Protocol/Transport/SseClientSessionTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseClientSessionTransport.cs
@@ -191,6 +191,14 @@ internal sealed class SseClientSessionTransport : TransportBase
                 using var request = new HttpRequestMessage(HttpMethod.Get, _sseEndpoint);
                 request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
 
+                if (_options.AdditionalHeaders != null)
+                {
+                    foreach (var header in _options.AdditionalHeaders)
+                    {
+                        request.Headers.Add(header.Key, header.Value);
+                    }
+                }
+
                 using var response = await _httpClient.SendAsync(
                     request,
                     HttpCompletionOption.ResponseHeadersRead,


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
`SseClientTransportOptions.AdditionalHeader` doesn't work.
It makes fail calling MCP that deployed to Azure Functions (or MCP server needed custom header).

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I tested embed my application that have sides MCP client.
Testing server environment is Azure Functions(consumption, deployed East US 2 region)

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
