### PR TITLE
Remove unessesary $ and fix some typos

### DIFF
--- a/src/ModelContextProtocol/Client/McpClient.cs
+++ b/src/ModelContextProtocol/Client/McpClient.cs
@@ -55,7 +55,7 @@ internal sealed class McpClient : McpEndpoint, IMcpClient
             {
                 if (samplingCapability.SamplingHandler is not { } samplingHandler)
                 {
-                    throw new InvalidOperationException($"Sampling capability was set but it did not provide a handler.");
+                    throw new InvalidOperationException("Sampling capability was set but it did not provide a handler.");
                 }
 
                 RequestHandlers.Set(
@@ -72,7 +72,7 @@ internal sealed class McpClient : McpEndpoint, IMcpClient
             {
                 if (rootsCapability.RootsHandler is not { } rootsHandler)
                 {
-                    throw new InvalidOperationException($"Roots capability was set but it did not provide a handler.");
+                    throw new InvalidOperationException("Roots capability was set but it did not provide a handler.");
                 }
 
                 RequestHandlers.Set(

--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -145,7 +145,7 @@ public static class McpClientExtensions
     /// </para>
     /// <para>
     /// Every iteration through the returned <see cref="IAsyncEnumerable{McpClientTool}"/>
-    /// will result in requerying the server and yielding the sequence of available tools.
+    /// will result in re-querying the server and yielding the sequence of available tools.
     /// </para>
     /// </remarks>
     /// <example>
@@ -248,7 +248,7 @@ public static class McpClientExtensions
     /// </para>
     /// <para>
     /// Every iteration through the returned <see cref="IAsyncEnumerable{McpClientPrompt}"/>
-    /// will result in requerying the server and yielding the sequence of available prompts.
+    /// will result in re-querying the server and yielding the sequence of available prompts.
     /// </para>
     /// </remarks>
     /// <example>
@@ -396,7 +396,7 @@ public static class McpClientExtensions
     /// </para>
     /// <para>
     /// Every iteration through the returned <see cref="IAsyncEnumerable{ResourceTemplate}"/>
-    /// will result in requerying the server and yielding the sequence of available resource templates.
+    /// will result in re-querying the server and yielding the sequence of available resource templates.
     /// </para>
     /// </remarks>
     /// <example>
@@ -510,7 +510,7 @@ public static class McpClientExtensions
     /// </para>
     /// <para>
     /// Every iteration through the returned <see cref="IAsyncEnumerable{Resource}"/>
-    /// will result in requerying the server and yielding the sequence of available resources.
+    /// will result in re-querying the server and yielding the sequence of available resources.
     /// </para>
     /// </remarks>
     /// <example>

--- a/src/ModelContextProtocol/Protocol/Messages/ProgressToken.cs
+++ b/src/ModelContextProtocol/Protocol/Messages/ProgressToken.cs
@@ -37,7 +37,7 @@ public readonly struct ProgressToken : IEquatable<ProgressToken>
 
     /// <inheritdoc />
     public override string? ToString() =>
-        _token is string stringValue ? $"{stringValue}" :
+        _token is string stringValue ? stringValue :
         _token is long longValue ? longValue.ToString(CultureInfo.InvariantCulture) :
         null;
 

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerPrompt.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerPrompt.cs
@@ -263,7 +263,7 @@ internal sealed class AIFunctionMcpServerPrompt : McpServerPrompt
                 Messages = [.. chatMessages.SelectMany(chatMessage => chatMessage.ToPromptMessages())],
             },
 
-            null => throw new InvalidOperationException($"Null result returned from prompt function."),
+            null => throw new InvalidOperationException("Null result returned from prompt function."),
 
             _ => throw new InvalidOperationException($"Unknown result type '{result.GetType()}' returned from prompt function."),
         };


### PR DESCRIPTION
## Motivation and Context
Spotted these while browsing the code.

This pull request includes several changes to improve code readability and consistency in the `ModelContextProtocol` project. The changes primarily involve removing unnecessary string interpolation and correcting spelling in comments.

Error message improvements:

* [`src/ModelContextProtocol/Client/McpClient.cs`](diffhunk://#diff-45abfb7160cbe51f05e2eb07f9950f0abbcb4bbd7b01d11a1bb0ce01719ddc00L58-R58): Removed unnecessary string interpolation from `InvalidOperationException` messages in the `McpClient` constructor. [[1]](diffhunk://#diff-45abfb7160cbe51f05e2eb07f9950f0abbcb4bbd7b01d11a1bb0ce01719ddc00L58-R58) [[2]](diffhunk://#diff-45abfb7160cbe51f05e2eb07f9950f0abbcb4bbd7b01d11a1bb0ce01719ddc00L75-R75)
* [`src/ModelContextProtocol/Server/AIFunctionMcpServerPrompt.cs`](diffhunk://#diff-684eed50d9306f3b6719889e647e948fb109b1be52b8654967c4f3fa84b493d9L266-R266): Removed unnecessary string interpolation from an `InvalidOperationException` message in the `GetAsync` method.

Comment and documentation improvements:

* [`src/ModelContextProtocol/Client/McpClientExtensions.cs`](diffhunk://#diff-4cc55722fca124512d9302f1faf6502cdb0101d63e73a625a792d46002f10c72L148-R148): Corrected the spelling of "requerying" to "re-querying" in multiple comments. [[1]](diffhunk://#diff-4cc55722fca124512d9302f1faf6502cdb0101d63e73a625a792d46002f10c72L148-R148) [[2]](diffhunk://#diff-4cc55722fca124512d9302f1faf6502cdb0101d63e73a625a792d46002f10c72L251-R251) [[3]](diffhunk://#diff-4cc55722fca124512d9302f1faf6502cdb0101d63e73a625a792d46002f10c72L399-R399) [[4]](diffhunk://#diff-4cc55722fca124512d9302f1faf6502cdb0101d63e73a625a792d46002f10c72L513-R513)

Code simplification:

* [`src/ModelContextProtocol/Protocol/Messages/ProgressToken.cs`](diffhunk://#diff-9d266e9b336028bf61c6c971f80ab403bff7865cb96bfd770f60171d36e03b30L40-R40): Simplified the `ToString` method by removing unnecessary string interpolation.