### PR TITLE
Delete faulty assert

### DIFF
--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -307,11 +307,6 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
 
         // unsubscribe
         await client.UnsubscribeFromResourceAsync("test://static/resource/1", TestContext.Current.CancellationToken);
-        receivedNotification = new();
-
-        // wait a bit to validate we don't receive another. this is best effort only;
-        // false negatives are possible.
-        await Assert.ThrowsAsync<TimeoutException>(() => receivedNotification.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken));
     }
 
     [Theory]


### PR DESCRIPTION
We need better coverage of Subscribe/Unsubscribe separately, but for now this assert is bad.

Closes https://github.com/modelcontextprotocol/csharp-sdk/issues/228
