### PR TITLE
Bump version to 0.1.0-preview.10

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
     <RepositoryUrl>https://github.com/modelcontextprotocol/csharp-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>preview.9</VersionSuffix>
+    <VersionSuffix>preview.10</VersionSuffix>
     <Authors>ModelContextProtocolOfficial</Authors>
     <Copyright>© Anthropic and Contributors.</Copyright>
     <PackageTags>ModelContextProtocol;mcp;ai;llm</PackageTags>


### PR DESCRIPTION
https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v0.1.0-preview.9 was published. Bump the version forward.