### PR TITLE
Add request headers to tool handlers

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/SseHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/SseHandler.cs
@@ -112,7 +112,6 @@ internal sealed class SseHandler(
 
         if (contextedMessage.Params != null)
         {
-
             var headersDictionary = context.Request.Headers.ToDictionary(
                 header => header.Key,
                 header => header.Value.ToString()

--- a/src/ModelContextProtocol/Protocol/Types/CallToolRequestParams.cs
+++ b/src/ModelContextProtocol/Protocol/Types/CallToolRequestParams.cs
@@ -26,4 +26,10 @@ public class CallToolRequestParams : RequestParams
     /// </remarks>
     [JsonPropertyName("arguments")]
     public IReadOnlyDictionary<string, JsonElement>? Arguments { get; init; }
+
+    /// <summary>
+    /// Gets or sets the client request headers.
+    /// </summary>
+    [JsonPropertyName("requestHeaders")]
+    public Dictionary<string, string>? RequestHeaders { get; set; }
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This PR adds a new member to `CallToolRequestParams ` to store client request headers when a tool is invoked.
The tool method would be able to read the headers using the `RequestContext` parameter passed from the MCP server.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
