### PR TITLE
Validate and filter inputSchema for McpServerTool so it is spec compliant

### DIFF
--- a/src/ModelContextProtocol/Utils/Json/McpJsonUtilities.cs
+++ b/src/ModelContextProtocol/Utils/Json/McpJsonUtilities.cs
@@ -68,8 +68,12 @@ public static partial class McpJsonUtilities
                 {
                     return false;
                 }
-
-                return true; // No need to check other properties
+            }
+            else if (!(property.NameEquals("properties") || 
+                       property.NameEquals("required")))
+            {
+                // Only "type", "properties", and "required" are allowed.
+                return false;
             }
         }
 

--- a/tests/ModelContextProtocol.Tests/Protocol/ProtocolTypeTests.cs
+++ b/tests/ModelContextProtocol.Tests/Protocol/ProtocolTypeTests.cs
@@ -30,6 +30,7 @@ public static class ProtocolTypeTests
     [InlineData("""{"type":"number"}""")]
     [InlineData("""{"type":"array"}""")]
     [InlineData("""{"type":["object"]}""")]
+    [InlineData("""{"type":"object", "title": "MyAwesomeTool", "description": "It's awesome!", "properties": {}, "required" : ["NotAParam"] }""")]
     public static void ToolInputSchema_RejectsInvalidSchemaDocuments(string invalidSchema)
     {
         using var document = JsonDocument.Parse(invalidSchema);
@@ -41,7 +42,7 @@ public static class ProtocolTypeTests
     [Theory]
     [InlineData("""{"type":"object"}""")]
     [InlineData("""{"type":"object", "properties": {}, "required" : [] }""")]
-    [InlineData("""{"type":"object", "title": "MyAwesomeTool", "description": "It's awesome!", "properties": {}, "required" : ["NotAParam"] }""")]
+    [InlineData("""{"type":"object", "properties": {}, "required" : ["NotAParam"] }""")]
     public static void ToolInputSchema_AcceptsValidSchemaDocuments(string validSchema)
     {
         using var document = JsonDocument.Parse(validSchema);


### PR DESCRIPTION
Fixes #342 

Tools were returned like this when AIFunction jsonSchema was used directly:
```
{
  "name": "Echo",
  "description": "Echoes the message back to the client.",
  "inputSchema": {
    "type": "object",
    "properties": {
      "message": {
        "type": "string"
      },      
      "title": "Echo",
      "description": "Echoes the message back to the client.",
    },
    "required": ["message"]
  }
}
```

But the spec looks like this:
```
  /**
   * A JSON Schema object defining the expected parameters for the tool.
   */
  inputSchema: {
    type: "object";
    properties?: { [key: string]: object };
    required?: string[];
  };
```

Which made some clients fail to list and/or call the tools. 

Changes are validate the json according to the schema, instead of accepting additional properties, and to filter the AIFunction jsonSchema in the Create.

The above tool will now look like this:
```
{
  "name": "Echo",
  "description": "Echoes the message back to the client.",
  "inputSchema": {
    "type": "object",
    "properties": {
      "message": {
        "type": "string"
      }
    },
    "required": ["message"]
  }
}
```

Edit: See my comments below. This is likely not the source of the GitHub Copilot error I encountered. But it's still a valid topic. Even if the MCP schema is open / permissible, it might be confusing to developers that the `title` and `description` properties are duplicated in this manner. In other words, I might not be last not person to end up on a wild goose chase when something else causes an error related to the schema, when seeing this discrepancy from other SDKs. So I still think we should consider an elegant way of cleaning up the AIFunction based JSON. But I'll await the resolution of the open questions, and then rework the PR or close it depending on the outcome.
