### PR TITLE
Add client-side Streamable HTTP transport support

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -23,9 +23,9 @@ internal sealed class StreamableHttpHandler(
     ILoggerFactory loggerFactory,
     IServiceProvider applicationServices)
 {
-    private static JsonTypeInfo<JsonRpcError> s_errorTypeInfo = GetRequiredJsonTypeInfo<JsonRpcError>();
-    private static MediaTypeHeaderValue ApplicationJsonMediaType = new("application/json");
-    private static MediaTypeHeaderValue TextEventStreamMediaType = new("text/event-stream");
+    private static readonly JsonTypeInfo<JsonRpcError> s_errorTypeInfo = GetRequiredJsonTypeInfo<JsonRpcError>();
+    private static readonly MediaTypeHeaderValue s_applicationJsonMediaType = new("application/json");
+    private static readonly MediaTypeHeaderValue s_textEventStreamMediaType = new("text/event-stream");
 
     public ConcurrentDictionary<string, HttpMcpSession<StreamableHttpServerTransport>> Sessions { get; } = new(StringComparer.Ordinal);
 
@@ -36,7 +36,7 @@ internal sealed class StreamableHttpHandler(
         // so we have to do this manually. The spec doesn't mandate that servers MUST reject these requests,
         // but it's probably good to at least start out trying to be strict.
         var acceptHeaders = context.Request.GetTypedHeaders().Accept;
-        if (!acceptHeaders.Contains(ApplicationJsonMediaType) || !acceptHeaders.Contains(TextEventStreamMediaType))
+        if (!acceptHeaders.Contains(s_applicationJsonMediaType) || !acceptHeaders.Contains(s_textEventStreamMediaType))
         {
             await WriteJsonRpcErrorAsync(context,
                 "Not Acceptable: Client must accept both application/json and text/event-stream",
@@ -64,7 +64,7 @@ internal sealed class StreamableHttpHandler(
     public async Task HandleGetRequestAsync(HttpContext context)
     {
         var acceptHeaders = context.Request.GetTypedHeaders().Accept;
-        if (!acceptHeaders.Contains(TextEventStreamMediaType))
+        if (!acceptHeaders.Contains(s_textEventStreamMediaType))
         {
             await WriteJsonRpcErrorAsync(context,
                 "Not Acceptable: Client must accept text/event-stream",

--- a/src/ModelContextProtocol/Protocol/Transport/SseClientTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseClientTransport.cs
@@ -57,6 +57,11 @@ public sealed class SseClientTransport : IClientTransport, IAsyncDisposable
     /// <inheritdoc />
     public async Task<ITransport> ConnectAsync(CancellationToken cancellationToken = default)
     {
+        if (_options.UseStreamableHttp)
+        {
+            return new StreamableHttpClientSessionTransport(_options, _httpClient, _loggerFactory, Name);
+        }
+
         var sessionTransport = new SseClientSessionTransport(_options, _httpClient, _loggerFactory, Name);
 
         try

--- a/src/ModelContextProtocol/Protocol/Transport/SseClientTransportOptions.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseClientTransportOptions.cs
@@ -1,5 +1,3 @@
-using static System.Net.WebRequestMethods;
-
 namespace ModelContextProtocol.Protocol.Transport;
 
 /// <summary>

--- a/src/ModelContextProtocol/Protocol/Transport/SseClientTransportOptions.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/SseClientTransportOptions.cs
@@ -1,3 +1,5 @@
+using static System.Net.WebRequestMethods;
+
 namespace ModelContextProtocol.Protocol.Transport;
 
 /// <summary>
@@ -31,12 +33,19 @@ public record SseClientTransportOptions
     }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to use "Streamable HTTP" for the transport rather than "HTTP with SSE". Defaults to false.
+    /// <see href="https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http">Streamable HTTP transport specification</see>.
+    /// <see href="https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse">HTTP with SSE transport specification</see>.
+    /// </summary>
+    public bool UseStreamableHttp { get; init; }
+
+    /// <summary>
     /// Gets a transport identifier used for logging purposes.
     /// </summary>
     public string? Name { get; init; }
 
     /// <summary>
-    /// Gets or sets a timeout used to establish the initial connection to the SSE server.
+    /// Gets or sets a timeout used to establish the initial connection to the SSE server. Defaults to 30 seconds.
     /// </summary>
     /// <remarks>
     /// This timeout controls how long the client waits for:

--- a/src/ModelContextProtocol/Protocol/Transport/StreamClientSessionTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/StreamClientSessionTransport.cs
@@ -146,15 +146,7 @@ internal class StreamClientSessionTransport : TransportBase
             var message = (JsonRpcMessage?)JsonSerializer.Deserialize(line.AsSpan().Trim(), McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcMessage)));
             if (message != null)
             {
-                string messageId = "(no id)";
-                if (message is JsonRpcMessageWithId messageWithId)
-                {
-                    messageId = messageWithId.Id.ToString();
-                }
-
-                LogTransportReceivedMessage(Name, messageId);
                 await WriteMessageAsync(message, cancellationToken).ConfigureAwait(false);
-                LogTransportMessageWritten(Name, messageId);
             }
             else
             {

--- a/src/ModelContextProtocol/Protocol/Transport/StreamServerTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/StreamServerTransport.cs
@@ -111,15 +111,7 @@ public class StreamServerTransport : TransportBase
                 {
                     if (JsonSerializer.Deserialize(line, McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcMessage))) is JsonRpcMessage message)
                     {
-                        string messageId = "(no id)";
-                        if (message is JsonRpcMessageWithId messageWithId)
-                        {
-                            messageId = messageWithId.Id.ToString();
-                        }
-
-                        LogTransportReceivedMessage(Name, messageId);
                         await WriteMessageAsync(message, shutdownToken).ConfigureAwait(false);
-                        LogTransportMessageWritten(Name, messageId);
                     }
                     else
                     {

--- a/src/ModelContextProtocol/Protocol/Transport/StreamableHttpClientSessionTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/StreamableHttpClientSessionTransport.cs
@@ -104,8 +104,12 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
 
         if (rpcRequest.Method == RequestMethods.Initialize && rpcResponseCandidate is JsonRpcResponse)
         {
-            // We've successfully initialized! Copy session-id and start GET request.
-            _mcpSessionId = response.Headers.GetValues("mcp-session-id").Single();
+            // We've successfully initialized! Copy session-id and start GET request if any.
+            if (response.Headers.TryGetValues("mcp-session-id", out var sessionIdValues))
+            {
+                _mcpSessionId = sessionIdValues.FirstOrDefault();
+            }
+
             _getReceiveTask = ReceiveUnsolicitedMessagesAsync();
         }
     }

--- a/src/ModelContextProtocol/Protocol/Transport/StreamableHttpClientSessionTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/StreamableHttpClientSessionTransport.cs
@@ -1,0 +1,267 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Protocol.Messages;
+using ModelContextProtocol.Utils;
+using ModelContextProtocol.Utils.Json;
+using System.Net.Http.Headers;
+using System.Net.ServerSentEvents;
+using System.Text;
+using System.Text.Json;
+
+namespace ModelContextProtocol.Protocol.Transport;
+
+/// <summary>
+/// The Streamable HTTP client transport implementation
+/// </summary>
+internal sealed partial class StreamableHttpClientSessionTransport : TransportBase
+{
+    private static MediaTypeWithQualityHeaderValue ApplicationJsonMediaType = new("application/json");
+    private static MediaTypeWithQualityHeaderValue TextEventStreamMediaType = new("text/event-stream");
+
+    private readonly HttpClient _httpClient;
+    private readonly SseClientTransportOptions _options;
+    private readonly CancellationTokenSource _connectionCts;
+    private readonly ILogger _logger;
+
+    private string? _mcpSessionId;
+    private Task? _getReceiveTask;
+
+    public StreamableHttpClientSessionTransport(SseClientTransportOptions transportOptions, HttpClient httpClient, ILoggerFactory? loggerFactory, string endpointName)
+        : base(endpointName, loggerFactory)
+    {
+        Throw.IfNull(transportOptions);
+        Throw.IfNull(httpClient);
+
+        _options = transportOptions;
+        _httpClient = httpClient;
+        _connectionCts = new CancellationTokenSource();
+        _logger = (ILogger?)loggerFactory?.CreateLogger<SseClientTransport>() ?? NullLogger.Instance;
+
+        // We connect with the initialization request with the MCP transport. This means that any errors won't be observed
+        // until the first call to SendMessageAsync. Fortunately, that happens internally in McpClientFactory.ConnectAsync
+        // so we still throw any connection-related Exceptions from there and never expose a pre-connected client to the user.
+        SetConnected(true);
+    }
+
+    /// <inheritdoc/>
+    public override async Task SendMessageAsync(
+        JsonRpcMessage message,
+        CancellationToken cancellationToken = default)
+    {
+        using var sendCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _connectionCts.Token);
+        cancellationToken = sendCts.Token;
+
+        using var content = new StringContent(
+            JsonSerializer.Serialize(message, McpJsonUtilities.JsonContext.Default.JsonRpcMessage),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, _options.Endpoint)
+        {
+            Content = content,
+            Headers =
+            {
+                Accept = { ApplicationJsonMediaType, TextEventStreamMediaType },
+            },
+        };
+
+        CopyAdditionalHeaders(httpRequestMessage.Headers, _options.AdditionalHeaders, _mcpSessionId);
+        var response = await _httpClient.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        var rpcRequest = message as JsonRpcRequest;
+        JsonRpcMessage? rpcResponseCandidate = null;
+
+        if (response.Content.Headers.ContentType?.MediaType == "application/json")
+        {
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (responseContent.StartsWith("["))
+            {
+                rpcResponseCandidate = await ProcessJsonRpcBatch(responseContent, rpcRequest, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                rpcResponseCandidate = await ProcessMessageAsync(responseContent, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        else if (response.Content.Headers.ContentType?.MediaType == "text/event-stream")
+        {
+            var responseBodyStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            rpcResponseCandidate = await ProcessSseResponseAsync(responseBodyStream, rpcRequest, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (rpcRequest is null)
+        {
+            return;
+        }
+
+        if (rpcResponseCandidate is not JsonRpcMessageWithId messageWithId || messageWithId.Id != rpcRequest.Id)
+        {
+            throw new McpException($"Streamable HTTP POST response completed without a reply to request with ID: {rpcRequest.Id}");
+        }
+
+        if (rpcRequest.Method == RequestMethods.Initialize && rpcResponseCandidate is JsonRpcResponse)
+        {
+            // We've successfully initialized! Copy session-id and start GET request.
+            _mcpSessionId = response.Headers.GetValues("mcp-session-id").Single();
+            _getReceiveTask = ReceiveUnsolicitedMessagesAsync();
+        }
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await _connectionCts.CancelAsync().ConfigureAwait(false);
+
+            try
+            {
+                if (_getReceiveTask != null)
+                {
+                    await _getReceiveTask.ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                _connectionCts.Dispose();
+            }
+        }
+        finally
+        {
+            SetConnected(false);
+        }
+    }
+
+    private async Task ReceiveUnsolicitedMessagesAsync()
+    {
+        // Send a GET request to handle any unsolicited messages not sent over a POST response.
+        using var request = new HttpRequestMessage(HttpMethod.Get, _options.Endpoint);
+        request.Headers.Accept.Add(TextEventStreamMediaType);
+        CopyAdditionalHeaders(request.Headers, _options.AdditionalHeaders, _mcpSessionId);
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _connectionCts.Token).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            // Server support for the GET request is optional. If it fails, we don't care. It just means we won't receive unsolicited messages.
+            return;
+        }
+
+        response.EnsureSuccessStatusCode();
+        var responseStream = await response.Content.ReadAsStreamAsync(_connectionCts.Token).ConfigureAwait(false);
+        await ProcessSseResponseAsync(responseStream, relatedRpcRequest: null, _connectionCts.Token).ConfigureAwait(false);
+    }
+
+    private async Task<JsonRpcMessageWithId?> ProcessSseResponseAsync(Stream responseStream, JsonRpcRequest? relatedRpcRequest, CancellationToken cancellationToken)
+    {
+        await foreach (SseItem<string> sseEvent in SseParser.Create(responseStream).EnumerateAsync(cancellationToken).ConfigureAwait(false))
+        {
+            if (sseEvent.EventType != "message")
+            {
+                continue;
+            }
+
+            var message = await ProcessMessageAsync(sseEvent.Data, cancellationToken).ConfigureAwait(false);
+
+            // The server SHOULD end the response here anyway, but we won't leave it to chance. This transport makes
+            // a GET request for any notifications that might need to be sent after the completion of each POST.
+            if (message is JsonRpcMessageWithId messageWithId && relatedRpcRequest?.Id == messageWithId.Id)
+            {
+                return messageWithId;
+            }
+        }
+
+        return null;
+    }
+
+    private async Task<JsonRpcMessageWithId?> ProcessJsonRpcBatch(string arrayData, JsonRpcRequest? relatedRpcRequest, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var batch = JsonSerializer.Deserialize(arrayData, McpJsonUtilities.JsonContext.Default.JsonRpcMessageArray);
+            if (batch is null)
+            {
+                throw new Exception("Unreachable! We already checked arrayData started with '['");
+            }
+
+            JsonRpcMessageWithId? relatedRpcResponse = null;
+
+            foreach (var message in batch!)
+            {
+                await WriteMessageAsync(message, cancellationToken).ConfigureAwait(false);
+                if (message is JsonRpcMessageWithId messageWithId && relatedRpcRequest?.Id == messageWithId.Id)
+                {
+                    relatedRpcResponse = messageWithId;
+                }
+            }
+
+            return relatedRpcResponse;
+        }
+        catch (JsonException ex)
+        {
+            LogJsonException(ex, arrayData);
+        }
+
+        return null;
+    }
+
+    private async Task<JsonRpcMessage?> ProcessMessageAsync(string data, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var message = JsonSerializer.Deserialize(data, McpJsonUtilities.JsonContext.Default.JsonRpcMessage);
+            if (message is null)
+            {
+                LogTransportMessageParseUnexpectedTypeSensitive(Name, data);
+                return null;
+            }
+
+            await WriteMessageAsync(message, cancellationToken).ConfigureAwait(false);
+            return message;
+        }
+        catch (JsonException ex)
+        {
+            LogJsonException(ex, data);
+        }
+
+        return null;
+    }
+
+    private void LogJsonException(JsonException ex, string data)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            LogTransportMessageParseFailedSensitive(Name, data, ex);
+        }
+        else
+        {
+            LogTransportMessageParseFailed(Name, ex);
+        }
+    }
+
+    internal static void CopyAdditionalHeaders(HttpRequestHeaders headers, Dictionary<string, string>? additionalHeaders, string? sessionId = null)
+    {
+        if (sessionId is not null)
+        {
+            headers.Add("mcp-session-id", sessionId);
+        }
+
+        if (additionalHeaders is null)
+        {
+            return;
+        }
+
+        foreach (var header in additionalHeaders)
+        {
+            if (!headers.TryAddWithoutValidation(header.Key, header.Value))
+            {
+                throw new InvalidOperationException($"Failed to add header '{header.Key}' with value '{header.Value}' from {nameof(SseClientTransportOptions.AdditionalHeaders)}.");
+            }
+        }
+    }
+}

--- a/src/ModelContextProtocol/Protocol/Transport/StreamableHttpPostTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/StreamableHttpPostTransport.cs
@@ -61,7 +61,7 @@ internal sealed class StreamableHttpPostTransport(ChannelWriter<JsonRpcMessage>?
         {
             yield return message;
 
-            if (message.Data is JsonRpcResponse response)
+            if (message.Data is JsonRpcMessageWithId response)
             {
                 if (_pendingRequests.Remove(response.Id) && _pendingRequests.Count == 0)
                 {

--- a/src/ModelContextProtocol/Protocol/Transport/TransportBase.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/TransportBase.cs
@@ -76,6 +76,9 @@ public abstract partial class TransportBase : ITransport
             throw new InvalidOperationException("Transport is not connected");
         }
 
+        var messageId = (message as JsonRpcMessageWithId)?.Id.ToString() ?? "(no id)";
+        LogTransportReceivedMessage(Name, messageId);
+
         await _messageChannel.Writer.WriteAsync(message, cancellationToken).ConfigureAwait(false);
     }
 
@@ -114,9 +117,6 @@ public abstract partial class TransportBase : ITransport
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "{EndpointName} transport received message with ID '{MessageId}'.")]
     private protected partial void LogTransportReceivedMessage(string endpointName, string messageId);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "{EndpointName} transport sent message with ID '{MessageId}'.")]
-    private protected partial void LogTransportMessageWritten(string endpointName, string messageId);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "{EndpointName} transport received unexpected message. Message: '{Message}'.")]
     private protected partial void LogTransportMessageParseUnexpectedTypeSensitive(string endpointName, string message);

--- a/src/ModelContextProtocol/Protocol/Transport/TransportBase.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/TransportBase.cs
@@ -37,7 +37,7 @@ public abstract partial class TransportBase : ITransport
         _messageChannel = Channel.CreateUnbounded<JsonRpcMessage>(new UnboundedChannelOptions
         {
             SingleReader = true,
-            SingleWriter = true,
+            SingleWriter = false,
         });
     }
 
@@ -76,8 +76,11 @@ public abstract partial class TransportBase : ITransport
             throw new InvalidOperationException("Transport is not connected");
         }
 
-        var messageId = (message as JsonRpcMessageWithId)?.Id.ToString() ?? "(no id)";
-        LogTransportReceivedMessage(Name, messageId);
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            var messageId = (message as JsonRpcMessageWithId)?.Id.ToString() ?? "(no id)";
+            LogTransportReceivedMessage(Name, messageId);
+        }
 
         await _messageChannel.Writer.WriteAsync(message, cancellationToken).ConfigureAwait(false);
     }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/HttpServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/HttpServerIntegrationTests.cs
@@ -1,0 +1,273 @@
+﻿using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Tests.Utils;
+
+namespace ModelContextProtocol.AspNetCore.Tests;
+
+public abstract class HttpServerIntegrationTests : LoggedTest, IClassFixture<SseServerIntegrationTestFixture>
+{
+    protected readonly SseServerIntegrationTestFixture _fixture;
+
+    public HttpServerIntegrationTests(SseServerIntegrationTestFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+        _fixture = fixture;
+        _fixture.Initialize(testOutputHelper, ClientTransportOptions);
+    }
+
+    public override void Dispose()
+    {
+        _fixture.TestCompleted();
+        base.Dispose();
+    }
+
+    protected abstract SseClientTransportOptions ClientTransportOptions { get; }
+
+    private Task<IMcpClient> GetClientAsync(McpClientOptions? options = null)
+    {
+        return _fixture.ConnectMcpClientAsync(options, LoggerFactory);
+    }
+
+    [Fact]
+    public async Task ConnectAndPing_Sse_TestServer()
+    {
+        // Arrange
+
+        // Act
+        await using var client = await GetClientAsync();
+        await client.PingAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public async Task Connect_TestServer_ShouldProvideServerFields()
+    {
+        // Arrange
+
+        // Act
+        await using var client = await GetClientAsync();
+
+        // Assert
+        Assert.NotNull(client.ServerCapabilities);
+        Assert.NotNull(client.ServerInfo);
+    }
+
+    [Fact]
+    public async Task ListTools_Sse_TestServer()
+    {        
+        // arrange
+
+        // act
+        await using var client = await GetClientAsync();
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.NotNull(tools);
+    }
+
+    [Fact]
+    public async Task CallTool_Sse_EchoServer()
+    {
+        // arrange
+
+        // act
+        await using var client = await GetClientAsync();
+        var result = await client.CallToolAsync(
+            "echo",
+            new Dictionary<string, object?>
+            {
+                ["message"] = "Hello MCP!"
+            },
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        // assert
+        Assert.NotNull(result);
+        Assert.False(result.IsError);
+        var textContent = Assert.Single(result.Content, c => c.Type == "text");
+        Assert.Equal("Echo: Hello MCP!", textContent.Text);
+    }
+
+    [Fact]
+    public async Task ListResources_Sse_TestServer()
+    {
+        // arrange
+
+        // act
+        await using var client = await GetClientAsync();
+
+        IList<Resource> allResources = await client.ListResourcesAsync(TestContext.Current.CancellationToken);
+
+        // The everything server provides 100 test resources
+        Assert.Equal(100, allResources.Count);
+    }
+
+    [Fact]
+    public async Task ReadResource_Sse_TextResource()
+    {
+        // arrange
+
+        // act
+        await using var client = await GetClientAsync();
+        // Odd numbered resources are text in the everything server (despite the docs saying otherwise)
+        // 1 is index 0, which is "even" in the 0-based index
+        // We copied this oddity to the test server
+        var result = await client.ReadResourceAsync("test://static/resource/1", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Single(result.Contents);
+
+        TextResourceContents textContent = Assert.IsType<TextResourceContents>(result.Contents[0]);
+        Assert.NotNull(textContent.Text);
+    }
+
+    [Fact]
+    public async Task ReadResource_Sse_BinaryResource()
+    {
+        // arrange
+
+        // act
+        await using var client = await GetClientAsync();
+        // Even numbered resources are binary in the everything server (despite the docs saying otherwise)
+        // 2 is index 1, which is "odd" in the 0-based index
+        // We copied this oddity to the test server
+        var result = await client.ReadResourceAsync("test://static/resource/2", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Single(result.Contents);
+
+        BlobResourceContents blobContent = Assert.IsType<BlobResourceContents>(result.Contents[0]);
+        Assert.NotNull(blobContent.Blob);
+    }
+
+    [Fact]
+    public async Task ListPrompts_Sse_TestServer()
+    {
+        // arrange
+
+        // act
+        await using var client = await GetClientAsync();
+        var prompts = await client.ListPromptsAsync(TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.NotNull(prompts);
+        Assert.NotEmpty(prompts);
+        // We could add specific assertions for the known prompts
+        Assert.Contains(prompts, p => p.Name == "simple_prompt");
+        Assert.Contains(prompts, p => p.Name == "complex_prompt");
+    }
+
+    [Fact]
+    public async Task GetPrompt_Sse_SimplePrompt()
+    {
+        // arrange
+
+        // act
+        await using var client = await GetClientAsync();
+        var result = await client.GetPromptAsync("simple_prompt", null, cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Messages);
+    }
+
+    [Fact]
+    public async Task GetPrompt_Sse_ComplexPrompt()
+    {
+        // arrange
+
+        // act
+        await using var client = await GetClientAsync();
+        var arguments = new Dictionary<string, object?>
+        {
+            { "temperature", "0.7" },
+            { "style", "formal" }
+        };
+        var result = await client.GetPromptAsync("complex_prompt", arguments, cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Messages);
+    }
+
+    [Fact]
+    public async Task GetPrompt_Sse_NonExistent_ThrowsException()
+    {
+        // arrange
+
+        // act
+        await using var client = await GetClientAsync();
+        await Assert.ThrowsAsync<McpException>(() =>
+            client.GetPromptAsync("non_existent_prompt", null, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Sampling_Sse_TestServer()
+    {
+        // arrange
+        // Set up the sampling handler
+        int samplingHandlerCalls = 0;
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        McpClientOptions options = new();
+        options.Capabilities = new();
+        options.Capabilities.Sampling ??= new();
+        options.Capabilities.Sampling.SamplingHandler = async (_, _, _) =>
+        {
+            samplingHandlerCalls++;
+            return new CreateMessageResult
+            {
+                Model = "test-model",
+                Role = Role.Assistant,
+                Content = new Content
+                {
+                    Type = "text",
+                    Text = "Test response"
+                }
+            };
+        };
+        await using var client = await GetClientAsync(options);
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        // Call the server's sampleLLM tool which should trigger our sampling handler
+        var result = await client.CallToolAsync("sampleLLM", new Dictionary<string, object?>
+            {
+                ["prompt"] = "Test prompt",
+                ["maxTokens"] = 100
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.NotNull(result);
+        var textContent = Assert.Single(result.Content);
+        Assert.Equal("text", textContent.Type);
+        Assert.False(string.IsNullOrEmpty(textContent.Text));
+    }
+
+    [Fact]
+    public async Task CallTool_Sse_EchoServer_Concurrently()
+    {
+        await using var client1 = await GetClientAsync();
+        await using var client2 = await GetClientAsync();
+
+        for (int i = 0; i < 4; i++)
+        {
+            var client = (i % 2 == 0) ? client1 : client2;
+            var result =  await client.CallToolAsync(
+                "echo",
+                new Dictionary<string, object?>
+                {
+                    ["message"] = $"Hello MCP! {i}"
+                },
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+            Assert.NotNull(result);
+            Assert.False(result.IsError);
+            var textContent = Assert.Single(result.Content, c => c.Type == "text");
+            Assert.Equal($"Echo: Hello MCP! {i}", textContent.Text);
+        }
+    }
+}

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpSseTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpSseTests.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Client;
+
+namespace ModelContextProtocol.AspNetCore.Tests;
+
+public class MapMcpSseTests(ITestOutputHelper outputHelper) : MapMcpTests(outputHelper)
+{
+    protected override bool UseStreamableHttp => false;
+
+    [Theory]
+    [InlineData("/a", "/a/sse")]
+    [InlineData("/a/", "/a/sse")]
+    [InlineData("/a/b", "/a/b/sse")]
+    public async Task CanConnect_WithMcpClient_AfterCustomizingRoute(string routePattern, string requestPath)
+    {
+        Builder.Services.AddMcpServer(options =>
+        {
+            options.ServerInfo = new()
+            {
+                Name = "TestCustomRouteServer",
+                Version = "1.0.0",
+            };
+        }).WithHttpTransport();
+        await using var app = Builder.Build();
+
+        app.MapMcp(routePattern);
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        var mcpClient = await ConnectAsync(requestPath);
+
+        Assert.Equal("TestCustomRouteServer", mcpClient.ServerInfo.Name);
+    }
+
+    [Fact]
+    public async Task Can_UseHttpContextAccessor_InTool()
+    {
+        Builder.Services.AddMcpServer().WithHttpTransport().WithTools<EchoHttpContextUserTools>();
+
+        Builder.Services.AddHttpContextAccessor();
+
+        await using var app = Builder.Build();
+
+        app.Use(next =>
+        {
+            return async context =>
+            {
+                context.User = CreateUser("TestUser");
+                await next(context);
+            };
+        });
+
+        app.MapMcp();
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        var mcpClient = await ConnectAsync();
+
+        var response = await mcpClient.CallToolAsync(
+            "EchoWithUserName",
+            new Dictionary<string, object?>() { ["message"] = "Hello world!" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var content = Assert.Single(response.Content);
+        Assert.Equal("TestUser: Hello world!", content.Text);
+    }
+}

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStreamableHttpTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStreamableHttpTests.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ModelContextProtocol.AspNetCore.Tests;
+
+public class MapMcpStreamableHttpTests(ITestOutputHelper outputHelper) : MapMcpTests(outputHelper)
+{
+    protected override bool UseStreamableHttp => true;
+
+    [Theory]
+    [InlineData("/a", "/a")]
+    [InlineData("/a", "/a/")]
+    [InlineData("/a/", "/a/")]
+    [InlineData("/a/", "/a")]
+    [InlineData("/a/b", "/a/b")]
+    public async Task CanConnect_WithMcpClient_AfterCustomizingRoute(string routePattern, string requestPath)
+    {
+        Builder.Services.AddMcpServer(options =>
+        {
+            options.ServerInfo = new()
+            {
+                Name = "TestCustomRouteServer",
+                Version = "1.0.0",
+            };
+        }).WithHttpTransport();
+        await using var app = Builder.Build();
+
+        app.MapMcp(routePattern);
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        var mcpClient = await ConnectAsync(requestPath);
+
+        Assert.Equal("TestCustomRouteServer", mcpClient.ServerInfo.Name);
+    }
+}

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseServerIntegrationTestFixture.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseServerIntegrationTestFixture.cs
@@ -18,10 +18,9 @@ public class SseServerIntegrationTestFixture : IAsyncDisposable
     // multiple tests, so this dispatches the output to the current test.
     private readonly DelegatingTestOutputHelper _delegatingTestOutputHelper = new();
 
-    private SseClientTransportOptions DefaultTransportOptions { get; } = new()
+    private SseClientTransportOptions DefaultTransportOptions { get; set; } = new()
     {
-        Endpoint = new Uri("http://localhost/sse"),
-        Name = "TestServer",
+        Endpoint = new("http://localhost/"),
     };
 
     public SseServerIntegrationTestFixture()
@@ -37,8 +36,9 @@ public class SseServerIntegrationTestFixture : IAsyncDisposable
 
         HttpClient = new HttpClient(socketsHttpHandler)
         {
-            BaseAddress = DefaultTransportOptions.Endpoint,
+            BaseAddress = new("http://localhost/"),
         };
+
         _serverTask = Program.MainAsync([], new XunitLoggerProvider(_delegatingTestOutputHelper), _inMemoryTransport, _stopCts.Token);
     }
 
@@ -53,9 +53,10 @@ public class SseServerIntegrationTestFixture : IAsyncDisposable
             TestContext.Current.CancellationToken);
     }
 
-    public void Initialize(ITestOutputHelper output)
+    public void Initialize(ITestOutputHelper output, SseClientTransportOptions clientTransportOptions)
     {
         _delegatingTestOutputHelper.CurrentTestOutputHelper = output;
+        DefaultTransportOptions = clientTransportOptions;
     }
 
     public void TestCompleted()

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseServerIntegrationTests.cs
@@ -1,279 +1,23 @@
-﻿using ModelContextProtocol.Client;
-using ModelContextProtocol.Protocol.Types;
-using ModelContextProtocol.Tests.Utils;
+﻿using ModelContextProtocol.Protocol.Transport;
 using System.Net;
 using System.Text;
 
 namespace ModelContextProtocol.AspNetCore.Tests;
 
-public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerIntegrationTestFixture>
+public class SseServerIntegrationTests(SseServerIntegrationTestFixture fixture, ITestOutputHelper testOutputHelper)
+    : HttpServerIntegrationTests(fixture, testOutputHelper)
+
 {
-    private readonly SseServerIntegrationTestFixture _fixture;
-
-    public SseServerIntegrationTests(SseServerIntegrationTestFixture fixture, ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper)
+    protected override SseClientTransportOptions ClientTransportOptions => new()
     {
-        _fixture = fixture;
-        _fixture.Initialize(testOutputHelper);
-    }
-
-    public override void Dispose()
-    {
-        _fixture.TestCompleted();
-        base.Dispose();
-    }
-
-    private Task<IMcpClient> GetClientAsync(McpClientOptions? options = null)
-    {
-        return _fixture.ConnectMcpClientAsync(options, LoggerFactory);
-    }
-
-    [Fact]
-    public async Task ConnectAndPing_Sse_TestServer()
-    {
-        // Arrange
-
-        // Act
-        await using var client = await GetClientAsync();
-        await client.PingAsync(TestContext.Current.CancellationToken);
-
-        // Assert
-        Assert.NotNull(client);
-    }
-
-    [Fact]
-    public async Task Connect_TestServer_ShouldProvideServerFields()
-    {
-        // Arrange
-
-        // Act
-        await using var client = await GetClientAsync();
-
-        // Assert
-        Assert.NotNull(client.ServerCapabilities);
-        Assert.NotNull(client.ServerInfo);
-    }
-
-    [Fact]
-    public async Task ListTools_Sse_TestServer()
-    {        
-        // arrange
-
-        // act
-        await using var client = await GetClientAsync();
-        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
-
-        // assert
-        Assert.NotNull(tools);
-    }
-
-    [Fact]
-    public async Task CallTool_Sse_EchoServer()
-    {
-        // arrange
-
-        // act
-        await using var client = await GetClientAsync();
-        var result = await client.CallToolAsync(
-            "echo",
-            new Dictionary<string, object?>
-            {
-                ["message"] = "Hello MCP!"
-            },
-            cancellationToken: TestContext.Current.CancellationToken
-        );
-
-        // assert
-        Assert.NotNull(result);
-        Assert.False(result.IsError);
-        var textContent = Assert.Single(result.Content, c => c.Type == "text");
-        Assert.Equal("Echo: Hello MCP!", textContent.Text);
-    }
-
-    [Fact]
-    public async Task ListResources_Sse_TestServer()
-    {
-        // arrange
-
-        // act
-        await using var client = await GetClientAsync();
-
-        IList<Resource> allResources = await client.ListResourcesAsync(TestContext.Current.CancellationToken);
-
-        // The everything server provides 100 test resources
-        Assert.Equal(100, allResources.Count);
-    }
-
-    [Fact]
-    public async Task ReadResource_Sse_TextResource()
-    {
-        // arrange
-
-        // act
-        await using var client = await GetClientAsync();
-        // Odd numbered resources are text in the everything server (despite the docs saying otherwise)
-        // 1 is index 0, which is "even" in the 0-based index
-        // We copied this oddity to the test server
-        var result = await client.ReadResourceAsync("test://static/resource/1", TestContext.Current.CancellationToken);
-
-        Assert.NotNull(result);
-        Assert.Single(result.Contents);
-
-        TextResourceContents textContent = Assert.IsType<TextResourceContents>(result.Contents[0]);
-        Assert.NotNull(textContent.Text);
-    }
-
-    [Fact]
-    public async Task ReadResource_Sse_BinaryResource()
-    {
-        // arrange
-
-        // act
-        await using var client = await GetClientAsync();
-        // Even numbered resources are binary in the everything server (despite the docs saying otherwise)
-        // 2 is index 1, which is "odd" in the 0-based index
-        // We copied this oddity to the test server
-        var result = await client.ReadResourceAsync("test://static/resource/2", TestContext.Current.CancellationToken);
-
-        Assert.NotNull(result);
-        Assert.Single(result.Contents);
-
-        BlobResourceContents blobContent = Assert.IsType<BlobResourceContents>(result.Contents[0]);
-        Assert.NotNull(blobContent.Blob);
-    }
-
-    [Fact]
-    public async Task ListPrompts_Sse_TestServer()
-    {
-        // arrange
-
-        // act
-        await using var client = await GetClientAsync();
-        var prompts = await client.ListPromptsAsync(TestContext.Current.CancellationToken);
-
-        // assert
-        Assert.NotNull(prompts);
-        Assert.NotEmpty(prompts);
-        // We could add specific assertions for the known prompts
-        Assert.Contains(prompts, p => p.Name == "simple_prompt");
-        Assert.Contains(prompts, p => p.Name == "complex_prompt");
-    }
-
-    [Fact]
-    public async Task GetPrompt_Sse_SimplePrompt()
-    {
-        // arrange
-
-        // act
-        await using var client = await GetClientAsync();
-        var result = await client.GetPromptAsync("simple_prompt", null, cancellationToken: TestContext.Current.CancellationToken);
-
-        // assert
-        Assert.NotNull(result);
-        Assert.NotEmpty(result.Messages);
-    }
-
-    [Fact]
-    public async Task GetPrompt_Sse_ComplexPrompt()
-    {
-        // arrange
-
-        // act
-        await using var client = await GetClientAsync();
-        var arguments = new Dictionary<string, object?>
-        {
-            { "temperature", "0.7" },
-            { "style", "formal" }
-        };
-        var result = await client.GetPromptAsync("complex_prompt", arguments, cancellationToken: TestContext.Current.CancellationToken);
-
-        // assert
-        Assert.NotNull(result);
-        Assert.NotEmpty(result.Messages);
-    }
-
-    [Fact]
-    public async Task GetPrompt_Sse_NonExistent_ThrowsException()
-    {
-        // arrange
-
-        // act
-        await using var client = await GetClientAsync();
-        await Assert.ThrowsAsync<McpException>(() =>
-            client.GetPromptAsync("non_existent_prompt", null, cancellationToken: TestContext.Current.CancellationToken));
-    }
-
-    [Fact]
-    public async Task Sampling_Sse_TestServer()
-    {
-        // arrange
-        // Set up the sampling handler
-        int samplingHandlerCalls = 0;
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        McpClientOptions options = new();
-        options.Capabilities = new();
-        options.Capabilities.Sampling ??= new();
-        options.Capabilities.Sampling.SamplingHandler = async (_, _, _) =>
-        {
-            samplingHandlerCalls++;
-            return new CreateMessageResult
-            {
-                Model = "test-model",
-                Role = Role.Assistant,
-                Content = new Content
-                {
-                    Type = "text",
-                    Text = "Test response"
-                }
-            };
-        };
-        await using var client = await GetClientAsync(options);
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
-
-        // Call the server's sampleLLM tool which should trigger our sampling handler
-        var result = await client.CallToolAsync("sampleLLM", new Dictionary<string, object?>
-            {
-                ["prompt"] = "Test prompt",
-                ["maxTokens"] = 100
-            },
-            cancellationToken: TestContext.Current.CancellationToken);
-
-        // assert
-        Assert.NotNull(result);
-        var textContent = Assert.Single(result.Content);
-        Assert.Equal("text", textContent.Type);
-        Assert.False(string.IsNullOrEmpty(textContent.Text));
-    }
-
-    [Fact]
-    public async Task CallTool_Sse_EchoServer_Concurrently()
-    {
-        await using var client1 = await GetClientAsync();
-        await using var client2 = await GetClientAsync();
-
-        for (int i = 0; i < 4; i++)
-        {
-            var client = (i % 2 == 0) ? client1 : client2;
-            var result =  await client.CallToolAsync(
-                "echo",
-                new Dictionary<string, object?>
-                {
-                    ["message"] = $"Hello MCP! {i}"
-                },
-                cancellationToken: TestContext.Current.CancellationToken
-            );
-
-            Assert.NotNull(result);
-            Assert.False(result.IsError);
-            var textContent = Assert.Single(result.Content, c => c.Type == "text");
-            Assert.Equal($"Echo: Hello MCP! {i}", textContent.Text);
-        }
-    }
+        Endpoint = new Uri("http://localhost/sse"),
+        Name = "TestServer",
+    };
 
     [Fact]
     public async Task EventSourceResponse_Includes_ExpectedHeaders()
     {
-        using var sseResponse = await _fixture.HttpClient.GetAsync("", HttpCompletionOption.ResponseHeadersRead, TestContext.Current.CancellationToken);
+        using var sseResponse = await _fixture.HttpClient.GetAsync("/sse", HttpCompletionOption.ResponseHeadersRead, TestContext.Current.CancellationToken);
 
         sseResponse.EnsureSuccessStatusCode();
 
@@ -289,7 +33,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
     {
         // Simulate our own MCP client handshake using a plain HttpClient so we can look for "event: message"
         // in the raw SSE response stream which is not exposed by the real MCP client.
-        await using var sseResponse = await _fixture.HttpClient.GetStreamAsync("", TestContext.Current.CancellationToken);
+        await using var sseResponse = await _fixture.HttpClient.GetStreamAsync("/sse", TestContext.Current.CancellationToken);
         using var streamReader = new StreamReader(sseResponse);
 
         var endpointEvent = await streamReader.ReadLineAsync(TestContext.Current.CancellationToken);
@@ -305,7 +49,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
             """;
         using (var initializeRequestBody = new StringContent(initializeRequest, Encoding.UTF8, "application/json"))
         {
-            var response = await _fixture.HttpClient.PostAsync(messageEndpoint, initializeRequestBody, TestContext.Current.CancellationToken);
+            using var response = await _fixture.HttpClient.PostAsync(messageEndpoint, initializeRequestBody, TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         }
 
@@ -314,7 +58,7 @@ public class SseServerIntegrationTests : LoggedTest, IClassFixture<SseServerInte
             """;
         using (var initializedNotificationBody = new StringContent(initializedNotification, Encoding.UTF8, "application/json"))
         {
-            var response = await _fixture.HttpClient.PostAsync(messageEndpoint, initializedNotificationBody, TestContext.Current.CancellationToken);
+            using var response = await _fixture.HttpClient.PostAsync(messageEndpoint, initializedNotificationBody, TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         }
 

--- a/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpClientConformanceTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpClientConformanceTests.cs
@@ -1,0 +1,134 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.AspNetCore.Tests.Utils;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol.Messages;
+using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Utils.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+
+namespace ModelContextProtocol.AspNetCore.Tests;
+
+public class StreamableHttpClientConformanceTests(ITestOutputHelper outputHelper) : KestrelInMemoryTest(outputHelper), IAsyncDisposable
+{
+    private WebApplication? _app;
+
+    private async Task StartAsync()
+    {
+        Builder.Services.Configure<JsonOptions>(options =>
+        {
+            options.SerializerOptions.TypeInfoResolverChain.Add(McpJsonUtilities.DefaultOptions.TypeInfoResolver!);
+        });
+        _app = Builder.Build();
+
+        var echoTool = McpServerTool.Create(Echo, new()
+        {
+            Services = _app.Services,
+        });
+
+        _app.MapPost("/mcp", async (JsonRpcMessage message) =>
+        {
+            if (message is not JsonRpcRequest request)
+            {
+                // Ignore all non-request notifications.
+                return Results.Accepted();
+            }
+
+            if (request.Method == "initialize")
+            {
+                return Results.Json(new JsonRpcResponse
+                {
+                    Id = request.Id,
+                    Result = JsonSerializer.SerializeToNode(new InitializeResult
+                    {
+                        ProtocolVersion = "2024-11-05",
+                        Capabilities = new()
+                        {
+                            Tools = new(),
+                        },
+                        ServerInfo = new Implementation
+                        {
+                            Name = "my-mcp",
+                            Version = "0.0.1",
+                        },
+                    }, McpJsonUtilities.DefaultOptions)
+                });
+            }
+
+            if (request.Method == "tools/list")
+            {
+                return Results.Json(new JsonRpcResponse
+                {
+                    Id = request.Id,
+                    Result = JsonSerializer.SerializeToNode(new ListToolsResult
+                    {
+                        Tools = [echoTool.ProtocolTool]
+                    }, McpJsonUtilities.DefaultOptions),
+                });
+            }
+
+            if (request.Method == "tools/call")
+            {
+                var parameters = JsonSerializer.Deserialize(request.Params, GetJsonTypeInfo<CallToolRequestParams>());
+                Assert.NotNull(parameters?.Arguments);
+
+                return Results.Json(new JsonRpcResponse
+                {
+                    Id = request.Id,
+                    Result = JsonSerializer.SerializeToNode(new CallToolResponse()
+                    {
+                        Content = [new() { Text = parameters.Arguments["message"].ToString() }],
+                    }, McpJsonUtilities.DefaultOptions),
+                });
+            }
+
+            throw new Exception("Unexpected message!");
+        });
+
+        await _app.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CanCallToolOnSessionlessStreamableHttpServer()
+    {
+        await StartAsync();
+
+        await using var transport = new SseClientTransport(new()
+        {
+            Endpoint = new("http://localhost/mcp"),
+            UseStreamableHttp = true,
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClientFactory.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var echoTool = Assert.Single(tools);
+        Assert.Equal("echo", echoTool.Name);
+        var response = await echoTool.InvokeAsync(new() { ["message"] = "Hello world!" }, TestContext.Current.CancellationToken);
+        Assert.NotNull(response);
+        Assert.Contains("Hello world!", response.ToString());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_app is not null)
+        {
+            await _app.DisposeAsync();
+        }
+        base.Dispose();
+    }
+
+    private static JsonTypeInfo<T> GetJsonTypeInfo<T>() => (JsonTypeInfo<T>)McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(T));
+
+    [McpServerTool(Name = "echo")]
+    private static string Echo(string message)
+    {
+        return message;
+    }
+}

--- a/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerConformanceTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerConformanceTests.cs
@@ -18,7 +18,7 @@ using System.Text.Json.Serialization.Metadata;
 
 namespace ModelContextProtocol.AspNetCore.Tests;
 
-public class StreamableHttpTests(ITestOutputHelper outputHelper) : KestrelInMemoryTest(outputHelper), IAsyncDisposable
+public class StreamableHttpServerConformanceTests(ITestOutputHelper outputHelper) : KestrelInMemoryTest(outputHelper), IAsyncDisposable
 {
     private static McpServerTool[] Tools { get; } = [
         McpServerTool.Create(EchoAsync),
@@ -35,7 +35,7 @@ public class StreamableHttpTests(ITestOutputHelper outputHelper) : KestrelInMemo
         {
             options.ServerInfo = new Implementation
             {
-                Name = nameof(StreamableHttpTests),
+                Name = nameof(StreamableHttpServerConformanceTests),
                 Version = "73",
             };
         }).WithTools(Tools).WithHttpTransport();
@@ -563,7 +563,7 @@ public class StreamableHttpTests(ITestOutputHelper outputHelper) : KestrelInMemo
     private static InitializeResult AssertServerInfo(JsonRpcResponse rpcResponse)
     {
         var initializeResult = AssertType<InitializeResult>(rpcResponse.Result);
-        Assert.Equal(nameof(StreamableHttpTests), initializeResult.ServerInfo.Name);
+        Assert.Equal(nameof(StreamableHttpServerConformanceTests), initializeResult.ServerInfo.Name);
         Assert.Equal("73", initializeResult.ServerInfo.Version);
         return initializeResult;
     }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerIntegrationTests.cs
@@ -1,0 +1,64 @@
+﻿using ModelContextProtocol.Protocol.Transport;
+using System.Net;
+using System.Text;
+
+namespace ModelContextProtocol.AspNetCore.Tests;
+
+public class StreamableHttpServerIntegrationTests(SseServerIntegrationTestFixture fixture, ITestOutputHelper testOutputHelper)
+    : HttpServerIntegrationTests(fixture, testOutputHelper)
+
+{
+     private const string InitializeRequest = """
+        {"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"IntegrationTestClient","version":"1.0.0"}}}
+        """;
+
+    protected override SseClientTransportOptions ClientTransportOptions => new()
+    {
+        Endpoint = new Uri("http://localhost/"),
+        Name = "TestServer",
+        UseStreamableHttp = true,
+    };
+
+    [Fact]
+    public async Task EventSourceResponse_Includes_ExpectedHeaders()
+    {
+        using var initializeRequestBody = new StringContent(InitializeRequest, Encoding.UTF8, "application/json");
+        using var postRequest = new HttpRequestMessage(HttpMethod.Post, "/")
+        {
+            Headers =
+            {
+                Accept = { new("application/json"), new("text/event-stream")}
+            },
+            Content = initializeRequestBody,
+        };
+        using var sseResponse = await _fixture.HttpClient.SendAsync(postRequest, TestContext.Current.CancellationToken);
+
+        sseResponse.EnsureSuccessStatusCode();
+
+        Assert.Equal("text/event-stream", sseResponse.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("identity", sseResponse.Content.Headers.ContentEncoding.ToString());
+        Assert.NotNull(sseResponse.Headers.CacheControl);
+        Assert.True(sseResponse.Headers.CacheControl.NoStore);
+        Assert.True(sseResponse.Headers.CacheControl.NoCache);
+    }
+
+    [Fact]
+    public async Task EventSourceStream_Includes_MessageEventType()
+    {
+        using var initializeRequestBody = new StringContent(InitializeRequest, Encoding.UTF8, "application/json");
+        using var postRequest = new HttpRequestMessage(HttpMethod.Post, "/")
+        {
+            Headers =
+            {
+                Accept = { new("application/json"), new("text/event-stream")}
+            },
+            Content = initializeRequestBody,
+        };
+        using var sseResponse = await _fixture.HttpClient.SendAsync(postRequest, TestContext.Current.CancellationToken);
+        using var sseResponseStream = await sseResponse.Content.ReadAsStreamAsync(TestContext.Current.CancellationToken);
+        using var streamReader = new StreamReader(sseResponseStream);
+
+        var messageEvent = await streamReader.ReadLineAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("event: message", messageEvent);
+    }
+}


### PR DESCRIPTION
Adds client-side [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) support. This is a follow up to #330. After this, I'll add a stateless mode for Streamable HTTP on the server.

Contributes to https://github.com/modelcontextprotocol/csharp-sdk/issues/157
Contributes to https://github.com/modelcontextprotocol/csharp-sdk/issues/158
