### PR TITLE
Backfills trace injection test and migrates from `request.params` to `request.params._meta`

### DIFF
--- a/src/ModelContextProtocol/Diagnostics.cs
+++ b/src/ModelContextProtocol/Diagnostics.cs
@@ -50,22 +50,19 @@ internal static class Diagnostics
         fieldValues = null;
         fieldValue = null;
 
-        JsonNode? parameters = null;
+        JsonNode? meta = null;
         switch (message)
         {
             case JsonRpcRequest request:
-                parameters = request.Params;
+                meta = request.Params?["_meta"];
                 break;
 
             case JsonRpcNotification notification:
-                parameters = notification.Params;
-                break;
-
-            default:
+                meta = notification.Params?["_meta"];
                 break;
         }
 
-        if (parameters?[fieldName] is JsonValue value && value.GetValueKind() == JsonValueKind.String)
+        if (meta?[fieldName] is JsonValue value && value.GetValueKind() == JsonValueKind.String)
         {
             fieldValue = value.GetValue<string>();
         }
@@ -89,14 +86,17 @@ internal static class Diagnostics
             case JsonRpcNotification notification:
                 parameters = notification.Params;
                 break;
-
-            default:
-                break;
         }
 
-        if (parameters is JsonObject jsonObject && jsonObject[key] == null)
+        // Replace any params._meta with the current value
+        if (parameters is JsonObject jsonObject)
         {
-            jsonObject[key] = value;
+            if (jsonObject["_meta"] is not JsonObject meta)
+            {
+                meta = new JsonObject();
+                jsonObject["_meta"] = meta;
+            }
+            meta[key] = value;
         }
     }
 

--- a/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
+++ b/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
@@ -4,6 +4,8 @@ using ModelContextProtocol.Server;
 using OpenTelemetry.Trace;
 using System.Diagnostics;
 using System.IO.Pipelines;
+using System.Text;
+using System.Text.Json;
 
 namespace ModelContextProtocol.Tests;
 
@@ -14,6 +16,7 @@ public class DiagnosticTests
     public async Task Session_TracksActivities()
     {
         var activities = new List<Activity>();
+        var clientToServerLog = new List<string>();
 
         using (var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
             .AddSource("Experimental.ModelContextProtocol")
@@ -28,7 +31,7 @@ public class DiagnosticTests
 
                 var tool = tools.First(t => t.Name == "DoubleValue");
                 await tool.InvokeAsync(new() { ["amount"] = 42 }, TestContext.Current.CancellationToken);
-            });
+            }, clientToServerLog);
         }
 
         Assert.NotEmpty(activities);
@@ -64,6 +67,15 @@ public class DiagnosticTests
 
         Assert.Equal(clientListToolsCall.SpanId, serverListToolsCall.ParentSpanId);
         Assert.Equal(clientListToolsCall.TraceId, serverListToolsCall.TraceId);
+
+        // Validate that the client trace context encoded to request.params.traceparent
+        using var listToolsJson = JsonDocument.Parse(clientToServerLog.First(s => s.Contains("\"method\":\"tools/list\"")));
+        var traceparent = listToolsJson.RootElement.GetProperty("params").GetProperty("traceparent").GetString();
+        Assert.NotNull(traceparent);
+
+        var parts = traceparent.Split('-');
+        Assert.Equal(clientListToolsCall.TraceId.ToString(), parts[1]);
+        Assert.Equal(clientListToolsCall.SpanId.ToString(), parts[2]);
     }
 
     [Fact]
@@ -80,7 +92,7 @@ public class DiagnosticTests
             {
                 await client.CallToolAsync("Throw", cancellationToken: TestContext.Current.CancellationToken);
                 await Assert.ThrowsAsync<McpException>(() => client.CallToolAsync("does-not-exist", cancellationToken: TestContext.Current.CancellationToken));
-            });
+            }, new List<string>());
         }
 
         Assert.NotEmpty(activities);
@@ -120,11 +132,12 @@ public class DiagnosticTests
         Assert.Equal("-32602", doesNotExistToolClient.Tags.Single(t => t.Key == "rpc.jsonrpc.error_code").Value);
     }
 
-    private static async Task RunConnected(Func<IMcpClient, IMcpServer, Task> action)
+    private static async Task RunConnected(Func<IMcpClient, IMcpServer, Task> action, List<string> clientToServerLog)
     {
         Pipe clientToServerPipe = new(), serverToClientPipe = new();
         StreamServerTransport serverTransport = new(clientToServerPipe.Reader.AsStream(), serverToClientPipe.Writer.AsStream());
-        StreamClientTransport clientTransport = new(clientToServerPipe.Writer.AsStream(), serverToClientPipe.Reader.AsStream());
+        StreamClientTransport clientTransport = new(new LoggingStream(
+            clientToServerPipe.Writer.AsStream(), clientToServerLog.Add), serverToClientPipe.Reader.AsStream());
 
         Task serverTask;
 
@@ -154,4 +167,33 @@ public class DiagnosticTests
 
         await serverTask;
     }
+}
+
+public class LoggingStream : Stream
+{
+    private readonly Stream _innerStream;
+    private readonly Action<string> _logAction;
+
+    public LoggingStream(Stream innerStream, Action<string> logAction)
+    {
+        _innerStream = innerStream ?? throw new ArgumentNullException(nameof(innerStream));
+        _logAction = logAction ?? throw new ArgumentNullException(nameof(logAction));
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        var data = Encoding.UTF8.GetString(buffer, offset, count);
+        _logAction(data);
+        _innerStream.Write(buffer, offset, count);
+    }
+
+    public override bool CanRead => _innerStream.CanRead;
+    public override bool CanSeek => _innerStream.CanSeek;
+    public override bool CanWrite => _innerStream.CanWrite;
+    public override long Length => _innerStream.Length;
+    public override long Position { get => _innerStream.Position; set => _innerStream.Position = value; }
+    public override void Flush() => _innerStream.Flush();
+    public override int Read(byte[] buffer, int offset, int count) => _innerStream.Read(buffer, offset, count);
+    public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+    public override void SetLength(long value) => _innerStream.SetLength(value);
 }

--- a/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
+++ b/tests/ModelContextProtocol.Tests/DiagnosticTests.cs
@@ -68,14 +68,10 @@ public class DiagnosticTests
         Assert.Equal(clientListToolsCall.SpanId, serverListToolsCall.ParentSpanId);
         Assert.Equal(clientListToolsCall.TraceId, serverListToolsCall.TraceId);
 
-        // Validate that the client trace context encoded to request.params.traceparent
+        // Validate that the client trace context encoded to request.params._meta[traceparent]
         using var listToolsJson = JsonDocument.Parse(clientToServerLog.First(s => s.Contains("\"method\":\"tools/list\"")));
-        var traceparent = listToolsJson.RootElement.GetProperty("params").GetProperty("traceparent").GetString();
-        Assert.NotNull(traceparent);
-
-        var parts = traceparent.Split('-');
-        Assert.Equal(clientListToolsCall.TraceId.ToString(), parts[1]);
-        Assert.Equal(clientListToolsCall.SpanId.ToString(), parts[2]);
+        var metaJson = listToolsJson.RootElement.GetProperty("params").GetProperty("_meta").GetRawText();
+        Assert.Equal($$"""{"traceparent":"00-{{clientListToolsCall.TraceId}}-{{clientListToolsCall.SpanId}}-01"}""", metaJson);
     }
 
     [Fact]


### PR DESCRIPTION
## Motivation and Context

Before, trace IDs were encoded in the `request.params` object which co-mingled it with fields like tool arguments.

This backfills an encoding test and moves it to `request.params._meta` which is used elsewhere and [proposed as a convention](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/414) due to prior art and also being a bit safer for ad-hoc implementation regardless of this implementation being careful.

This also corrects logic to [replace](https://opentelemetry.io/docs/specs/otel/context/api-propagators/#set) any existing key in the message however unlikely that might be.

## How Has This Been Tested?

Backfilled a unit test

## Breaking Changes

The choice to use request.params was released in https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v0.1.0-preview.9. This changes it to `request.params._meta`. This means that applications already releasing this will need to update both sides to have context propagation. Since this SDK is in pre-release, I didn't add logic to fall back to extract from `request.params`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

* change that introduced use of `request.params` https://github.com/modelcontextprotocol/csharp-sdk/pull/262
* proposal to document `request.params._meta` for use in opentelemetry traces as well other metadata: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/414
