### PR TITLE
Add static resources to EverythingServer sample

### DIFF
--- a/samples/EverythingServer/Program.cs
+++ b/samples/EverythingServer/Program.cs
@@ -44,7 +44,7 @@ builder.Services
         {
             Resources =
             [
-                new ModelContextProtocol.Protocol.Types.Resource { Name = "Static Text Resource", Description = "A static text resource", MimeType = "text/plain", Uri = "test://direct/text/resource" },
+                new ModelContextProtocol.Protocol.Types.Resource { Name = "Direct Text Resource", Description = "A direct text resource", MimeType = "text/plain", Uri = "test://direct/text/resource" },
             ]
         };
     })
@@ -68,7 +68,7 @@ builder.Services
             {
                 Contents = [new TextResourceContents
                 {
-                    Text = "This is a static resource",
+                    Text = "This is a direct resource",
                     MimeType = "text/plain",
                     Uri = uri,
                 }]

--- a/samples/EverythingServer/Program.cs
+++ b/samples/EverythingServer/Program.cs
@@ -62,7 +62,7 @@ builder.Services
     {
         var uri = ctx.Params?.Uri;
 
-        if (uri?.StartsWith("test://static/resource/") == true)
+        if (uri == "test://direct/text/resource")
         {
             return new ReadResourceResult
             {

--- a/samples/EverythingServer/Program.cs
+++ b/samples/EverythingServer/Program.cs
@@ -44,7 +44,7 @@ builder.Services
         {
             Resources =
             [
-                new ModelContextProtocol.Protocol.Types.Resource { Name = "Static Resource", Description = "A static resource", Uri = "test://static/resource/" }
+                new ModelContextProtocol.Protocol.Types.Resource { Name = "Static Text Resource", Description = "A static text resource", MimeType = "text/plain", Uri = "test://direct/text/resource" },
             ]
         };
     })

--- a/samples/EverythingServer/Program.cs
+++ b/samples/EverythingServer/Program.cs
@@ -38,13 +38,23 @@ builder.Services
     .WithTools<TinyImageTool>()
     .WithPrompts<ComplexPromptType>()
     .WithPrompts<SimplePromptType>()
+    .WithListResourcesHandler(async (ctx, ct) =>
+    {
+        return new ListResourcesResult
+        {
+            Resources =
+            [
+                new ModelContextProtocol.Protocol.Types.Resource { Name = "Static Resource", Description = "A static resource", Uri = "test://static/resource/" }
+            ]
+        };
+    })
     .WithListResourceTemplatesHandler(async (ctx, ct) =>
     {
         return new ListResourceTemplatesResult
         {
             ResourceTemplates =
             [
-                new ResourceTemplate { Name = "Static Resource", Description = "A static resource with a numeric ID", UriTemplate = "test://static/resource/{id}" }
+                new ResourceTemplate { Name = "Template Resource", Description = "A template resource with a numeric ID", UriTemplate = "test://template/resource/{id}" }
             ]
         };
     })
@@ -52,12 +62,25 @@ builder.Services
     {
         var uri = ctx.Params?.Uri;
 
-        if (uri is null || !uri.StartsWith("test://static/resource/"))
+        if (uri?.StartsWith("test://static/resource/") == true)
+        {
+            return new ReadResourceResult
+            {
+                Contents = [new TextResourceContents
+                {
+                    Text = "This is a static resource",
+                    MimeType = "text/plain",
+                    Uri = uri,
+                }]
+            };
+        }
+
+        if (uri is null || !uri.StartsWith("test://template/resource/"))
         {
             throw new NotSupportedException($"Unknown resource: {uri}");
         }
 
-        int index = int.Parse(uri["test://static/resource/".Length..]) - 1;
+        int index = int.Parse(uri["test://template/resource/".Length..]) - 1;
 
         if (index < 0 || index >= ResourceGenerator.Resources.Count)
         {

--- a/samples/EverythingServer/ResourceGenerator.cs
+++ b/samples/EverythingServer/ResourceGenerator.cs
@@ -6,7 +6,7 @@ static class ResourceGenerator
 {
     private static readonly List<Resource> _resources = Enumerable.Range(1, 100).Select(i =>
         {
-            var uri = $"test://static/resource/{i}";
+            var uri = $"test://template/resource/{i}";
             if (i % 2 != 0)
             {
                 return new Resource


### PR DESCRIPTION
This PR adds static resources to the EverythingServer sample. In the process, I modified the resource templates so they are clearly distinguished from the static resources.

## Motivation and Context

This helps the EverythingServer live up to its name by supporting all the features in the MCP protocol.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

I tested this on my own branch with the Inspector.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
