### PR TITLE
Adapt GetAlerts endpoint to use the latest weather API spec

### DIFF
--- a/samples/QuickstartWeatherServer/Tools/WeatherTools.cs
+++ b/samples/QuickstartWeatherServer/Tools/WeatherTools.cs
@@ -12,7 +12,7 @@ public sealed class WeatherTools
     [McpServerTool, Description("Get weather alerts for a US state.")]
     public static async Task<string> GetAlerts(
         HttpClient client,
-        [Description("The US state to get alerts for.")] string state)
+        [Description("The US state to get alerts for. Use the 2 letter abbreviation for the state (e.g. NY).")] string state)
     {
         using var jsonDocument = await client.ReadJsonDocumentAsync($"/alerts/active/area/{state}");
         var jsonElement = jsonDocument.RootElement;


### PR DESCRIPTION
Make the LLM pass the 2 letter abbreviation for the state (e.g. NY) when calling `GetAlerts`, instead of its full name.

## Motivation and Context
The latest *api.weather.gov* API spec requires to pass a 2 letter identifier for the state when calling the `/alerts/active/area/` endpoint. Passing the full state name no longer works.

## How Has This Been Tested?
I called the MCP server from Claude Desktop, asking it the following:
1. *get the weather for sacramento* => this prompted it to call `GetForecast` endpoint
2. *any alerts I should be aware of?* => this prompted it to call `GetAlerts` endpoint


## Breaking Changes
No. It's just updating the sample code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A
