### PR TITLE
Remove batching support from StreamableHttpServerTransport

### DIFF
--- a/src/ModelContextProtocol/Protocol/Transport/StreamClientSessionTransport.cs
+++ b/src/ModelContextProtocol/Protocol/Transport/StreamClientSessionTransport.cs
@@ -70,7 +70,7 @@ internal class StreamClientSessionTransport : TransportBase
             id = messageWithId.Id.ToString();
         }
 
-        var json = JsonSerializer.Serialize(message, McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcMessage)));
+        var json = JsonSerializer.Serialize(message, McpJsonUtilities.JsonContext.Default.JsonRpcMessage);
 
         using var _ = await _sendLock.LockAsync(cancellationToken).ConfigureAwait(false);
         try

--- a/src/ModelContextProtocol/Shared/McpSession.cs
+++ b/src/ModelContextProtocol/Shared/McpSession.cs
@@ -75,7 +75,7 @@ internal sealed partial class McpSession : IDisposable
             StdioClientSessionTransport or StdioServerTransport => "stdio",
             StreamClientSessionTransport or StreamServerTransport => "stream",
             SseClientSessionTransport or SseResponseStreamTransport => "sse",
-            StreamableHttpServerTransport or StreamableHttpPostTransport => "http",
+            StreamableHttpClientSessionTransport or StreamableHttpServerTransport or StreamableHttpPostTransport => "http",
             _ => "unknownTransport"
         };
 

--- a/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerConformanceTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerConformanceTests.cs
@@ -183,39 +183,6 @@ public class StreamableHttpServerConformanceTests(ITestOutputHelper outputHelper
     }
 
     [Fact]
-    public async Task BatchedJsonRpcRequests_IsHandled_WithCompleteSseResponse()
-    {
-        await StartAsync();
-
-        using var response = await HttpClient.PostAsync("", JsonContent($"[{InitializeRequest},{EchoRequest}]"), TestContext.Current.CancellationToken);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        var eventCount = 0;
-        await foreach (var sseEvent in ReadSseAsync(response.Content))
-        {
-            var jsonRpcResponse = JsonSerializer.Deserialize(sseEvent, GetJsonTypeInfo<JsonRpcResponse>());
-            Assert.NotNull(jsonRpcResponse);
-            var responseId = Assert.IsType<long>(jsonRpcResponse.Id.Id);
-
-            switch (responseId)
-            {
-                case 1:
-                    AssertServerInfo(jsonRpcResponse);
-                    break;
-                case 2:
-                    AssertEchoResponse(jsonRpcResponse);
-                    break;
-                default:
-                    throw new Exception($"Unexpected response ID: {jsonRpcResponse.Id}");
-            }
-
-            eventCount++;
-        }
-
-        Assert.Equal(2, eventCount);
-    }
-
-    [Fact]
     public async Task SingleJsonRpcRequest_ThatThrowsIsHandled_WithCompleteSseResponse()
     {
         await StartAsync();


### PR DESCRIPTION
I closed #158 which was our issue tracking support for JSON-RPC batching because the requirement has been removed from the draft specification as of https://github.com/modelcontextprotocol/modelcontextprotocol/pull/416, and the feature didn't seem particularly useful. The SDK never sent batched messages.

I removed the batching support from the client in my Streamable HTTP client PR (#356), and this follows up to do the same thing for the server.

@stephentoub We could now more conveniently update the StreamableHttpServerTransport.HandlePostRequest(IDuplexPipe httpBodies, CancellationToken cancellationToken) method to take a duplex Stream instead of an IDuplexPipe without introducing extra copying if you also want to do that as part of this change.