### PR TITLE
Set IsError on CallToolResponse to true when result is ErrorContent

### DIFF
--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -280,7 +280,7 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
             IEnumerable<AIContent> contentItems => new()
             {
                 Content = [.. contentItems.Select(static item => item.ToContent())],
-                IsError = contentItems.Any(item => item is ErrorContent)
+                IsError = contentItems.All(item => item is ErrorContent) && contentItems.Any()
             },
             
             IEnumerable<Content> contents => new()

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -193,6 +193,30 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
         return newOptions;
     }
 
+    private static CallToolResponse ConvertAiContentEnumerableToCallToolResponse(IEnumerable<AIContent> contentItems)
+    {
+        List<Content> contentList = [];
+        bool allErrorContent = true;
+        bool hasAny = false;
+
+        foreach (var item in contentItems)
+        {
+            contentList.Add(item.ToContent());
+            hasAny = true;
+
+            if (allErrorContent && item is not ErrorContent)
+            {
+                allErrorContent = false;
+            }
+        }
+
+        return new()
+        {
+            Content = contentList,
+            IsError = allErrorContent && hasAny
+        };
+    }
+
     /// <summary>Gets the <see cref="AIFunction"/> wrapped by this tool.</summary>
     internal AIFunction AIFunction { get; }
 
@@ -277,11 +301,7 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
                 Content = [.. texts.Select(x => new Content() { Type = "text", Text = x ?? string.Empty })]
             },
             
-            IEnumerable<AIContent> contentItems => new()
-            {
-                Content = [.. contentItems.Select(static item => item.ToContent())],
-                IsError = contentItems.All(item => item is ErrorContent) && contentItems.Any()
-            },
+            IEnumerable<AIContent> contentItems => ConvertAiContentEnumerableToCallToolResponse(contentItems),
             
             IEnumerable<Content> contents => new()
             {

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -253,7 +253,8 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
         {
             AIContent aiContent => new()
             {
-                Content = [aiContent.ToContent()]
+                Content = [aiContent.ToContent()],
+                IsError = aiContent is ErrorContent
             },
 
             null => new()
@@ -278,7 +279,8 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
             
             IEnumerable<AIContent> contentItems => new()
             {
-                Content = [.. contentItems.Select(static item => item.ToContent())]
+                Content = [.. contentItems.Select(static item => item.ToContent())],
+                IsError = contentItems.Any(item => item is ErrorContent)
             },
             
             IEnumerable<Content> contents => new()

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -193,30 +193,6 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
         return newOptions;
     }
 
-    private static CallToolResponse ConvertAiContentEnumerableToCallToolResponse(IEnumerable<AIContent> contentItems)
-    {
-        List<Content> contentList = [];
-        bool allErrorContent = true;
-        bool hasAny = false;
-
-        foreach (var item in contentItems)
-        {
-            contentList.Add(item.ToContent());
-            hasAny = true;
-
-            if (allErrorContent && item is not ErrorContent)
-            {
-                allErrorContent = false;
-            }
-        }
-
-        return new()
-        {
-            Content = contentList,
-            IsError = allErrorContent && hasAny
-        };
-    }
-
     /// <summary>Gets the <see cref="AIFunction"/> wrapped by this tool.</summary>
     internal AIFunction AIFunction { get; }
 
@@ -301,7 +277,7 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
                 Content = [.. texts.Select(x => new Content() { Type = "text", Text = x ?? string.Empty })]
             },
             
-            IEnumerable<AIContent> contentItems => ConvertAiContentEnumerableToCallToolResponse(contentItems),
+            IEnumerable<AIContent> contentItems => ConvertAIContentEnumerableToCallToolResponse(contentItems),
             
             IEnumerable<Content> contents => new()
             {
@@ -321,4 +297,27 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
         };
     }
 
+    private static CallToolResponse ConvertAIContentEnumerableToCallToolResponse(IEnumerable<AIContent> contentItems)
+    {
+        List<Content> contentList = [];
+        bool allErrorContent = true;
+        bool hasAny = false;
+
+        foreach (var item in contentItems)
+        {
+            contentList.Add(item.ToContent());
+            hasAny = true;
+
+            if (allErrorContent && item is not ErrorContent)
+            {
+                allErrorContent = false;
+            }
+        }
+
+        return new()
+        {
+            Content = contentList,
+            IsError = allErrorContent && hasAny
+        };
+    }
 }


### PR DESCRIPTION
Currently when providing an ErrorContent type as the result to a tool the IsError property on the resulting CallToolResponse is not set to true.

## Motivation and Context
To allow the calling client to understand the response is an error the IsError property should be set to true when an error has occurred within the tool invocation. Unlike throwing an exception this can protect any potential unwanted information being reported from the exception details.

## How Has This Been Tested?
Adjusted sample tools to confirm IsError is being set to true when an ErrorContent result is returned

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
