### PR TITLE
wip: add logging handler to MCP Server

### DIFF
--- a/src/ModelContextProtocol/Logging/McpServerLog.cs
+++ b/src/ModelContextProtocol/Logging/McpServerLog.cs
@@ -1,0 +1,59 @@
+namespace ModelContextProtocol.Logging;
+
+/// <summary>
+/// Delegate that allows receivign log details about request/response calls. 
+/// </summary>
+public delegate void McpLogHandler(McpLogContext context);
+
+/// <summary>
+/// Class that provides context details about a given call, for logging purposes.
+/// </summary>
+public sealed class McpLogContext
+{
+    /// <summary>
+    /// Gets <see cref="McpStatus"/> information about when this log was emitted.
+    /// </summary>
+    public McpStatus Status { get; init; }
+    
+    /// <summary>
+    /// Gets information about the JSON message that was received/sent when this event happened.
+    /// </summary>
+    public required string Json { get; init; }
+    
+    /// <summary>
+    /// If applicable, gets the <see cref="Exception"/> that happened when this message was processed.
+    /// </summary>
+    /// <remarks>This property is commonly associated with a <see cref="McpStatus.ErrorOccurred"/> status.</remarks>
+    public Exception? Exception { get; init; }
+    
+    /// <summary>
+    /// Gets information about the method that was called.
+    /// </summary>
+    public string? Method { get; init; }
+    
+    /// <summary>
+    /// Gets a <see cref="IServiceProvider"/> instance that allows you accessing instances registered for the application.
+    /// </summary>
+    public IServiceProvider? ServiceProvider { get; set; }
+}
+
+/// <summary>
+/// Enum that defines possible events that might happen during a MCP messaging workflow.
+/// </summary>
+public enum McpStatus
+{
+    /// <summary>
+    /// Specifies that the given message was received from a MCP Client.
+    /// </summary>
+    RequestReceived,
+    
+    /// <summary>
+    /// Specifies that the MCP Server just sent this message back to the Client.
+    /// </summary>
+    ResponseSent,
+    
+    /// <summary>
+    /// Specifies that an exception happened when trying to process a given request.
+    /// </summary>
+    ErrorOccurred
+}

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
+using ModelContextProtocol.Logging;
 
 namespace ModelContextProtocol.Server;
 
@@ -277,6 +278,15 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
+            request.Server.ServerOptions.LogHandler?.Invoke(new()
+            {
+                Exception = e,
+                ServiceProvider = request.Services,
+                Json = JsonSerializer.Serialize(request.Params, AIFunction.JsonSerializerOptions.GetTypeInfo(typeof(CallToolRequestParams))),
+                Status = McpStatus.ErrorOccurred,
+                Method = RequestMethods.ToolsCall
+            });
+            
             string errorMessage = e is McpException ?
                 $"An error occurred invoking '{request.Params?.Name}': {e.Message}" :
                 $"An error occurred invoking '{request.Params?.Name}'.";

--- a/src/ModelContextProtocol/Server/McpServer.cs
+++ b/src/ModelContextProtocol/Server/McpServer.cs
@@ -562,14 +562,13 @@ internal sealed class McpServer : McpEndpoint, IMcpServer
             requestTypeInfo, responseTypeInfo);
     }
     
-    private void InvokeLogHandler<TParams>(string method, McpStatus status, TParams? args, Exception? exception = null) =>
+    private void InvokeLogHandler<TParams>(string method, McpStatus status, TParams? args) =>
         ServerOptions.LogHandler?.Invoke(new()
         {
             ServiceProvider = Services,
             Json = JsonSerializer.Serialize(args, McpJsonUtilities.DefaultOptions.GetTypeInfo<TParams?>()),
             Status = status,
-            Method = method,
-            Exception = exception,
+            Method = method
         });
 
     private void UpdateEndpointNameWithClientInfo()

--- a/src/ModelContextProtocol/Server/McpServerOptions.cs
+++ b/src/ModelContextProtocol/Server/McpServerOptions.cs
@@ -1,3 +1,4 @@
+using ModelContextProtocol.Logging;
 using ModelContextProtocol.Protocol;
 
 namespace ModelContextProtocol.Server;
@@ -76,4 +77,9 @@ public class McpServerOptions
     /// </para>
     /// </remarks>
     public Implementation? KnownClientInfo { get; set; }
+    
+    /// <summary>
+    /// Gets or sets a log handler that gets notified when log messages are emitted at the request/response flow. 
+    /// </summary>
+    public McpLogHandler? LogHandler { get; set; }
 }


### PR DESCRIPTION
This change aims to add the possibility to receive events from the MCP Server context, allowing you to log information about given requests/responses and possible exceptions that might have been thrown by tools/prompts and resources right before they're handled and sent as formal responses to the Client.

This is a **WIP (work-in-progress)**, so we're still implementing some features and improvements during our internal tests.

## Motivation and Context
Based on this [issue](https://github.com/modelcontextprotocol/csharp-sdk/issues/359), we've created a proposal for letting the developers to access specific message events that could help troubleshooting possible problems when calling MCP resources at the server.

## How Has This Been Tested?
We're currently testing this version generating observability outputs to troubleshoot MCP Tool calls, allowing us to monitor possible unhandled exceptions that might occur and which parameters generated faulty scenarios.

## Breaking Changes
There's no breaking changes associated with this change. This feature is meant to be fully optional.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed