### PR TITLE
Bump version to 0.2.0-preview.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,8 +5,8 @@
     <PackageProjectUrl>https://github.com/modelcontextprotocol/csharp-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/modelcontextprotocol/csharp-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>preview.14</VersionSuffix>
+    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
     <Authors>ModelContextProtocolOfficial</Authors>
     <Copyright>© Anthropic and Contributors.</Copyright>
     <PackageTags>ModelContextProtocol;mcp;ai;llm</PackageTags>


### PR DESCRIPTION
[v0.1.0-preview.14](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v0.1.0-preview.14) was published: https://www.nuget.org/packages/ModelContextProtocol/0.1.0-preview.14

For the next release, we'll take a dependency on Microsoft.Extensions.AI's stable version 9.5.0. Good time to bump the version here to 0.2.0-preview.*.