### PR TITLE
Remove internal GetBase64Data helper

### DIFF
--- a/src/ModelContextProtocol/AIContentExtensions.cs
+++ b/src/ModelContextProtocol/AIContentExtensions.cs
@@ -178,18 +178,6 @@ public static class AIContentExtensions
         return [.. contents.Select(ToAIContent)];
     }
 
-    /// <summary>Extracts the data from a <see cref="DataContent"/> as a Base64 string.</summary>
-    internal static string GetBase64Data(this DataContent dataContent)
-    {
-#if NET
-        return Convert.ToBase64String(dataContent.Data.Span);
-#else
-        return MemoryMarshal.TryGetArray(dataContent.Data, out ArraySegment<byte> segment) ?
-            Convert.ToBase64String(segment.Array!, segment.Offset, segment.Count) :
-            Convert.ToBase64String(dataContent.Data.ToArray());
-#endif
-    }
-
     internal static Content ToContent(this AIContent content) =>
         content switch
         {
@@ -201,7 +189,7 @@ public static class AIContentExtensions
 
             DataContent dataContent => new()
             {
-                Data = dataContent.GetBase64Data(),
+                Data = dataContent.Base64Data.ToString(),
                 MimeType = dataContent.MediaType,
                 Type =
                     dataContent.HasTopLevelMediaType("image") ? "image" :

--- a/src/ModelContextProtocol/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol/Client/McpClientExtensions.cs
@@ -976,7 +976,7 @@ public static class McpClientExtensions
                     {
                         Type = dc.HasTopLevelMediaType("image") ? "image" : "audio",
                         MimeType = dc.MediaType,
-                        Data = dc.GetBase64Data(),
+                        Data = dc.Base64Data.ToString(),
                     };
                 }
             }

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerResource.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerResource.cs
@@ -400,7 +400,7 @@ internal sealed class AIFunctionMcpServerResource : McpServerResource
 
             DataContent dc => new()
             {
-                Contents = [new BlobResourceContents() { Uri = request.Params!.Uri, MimeType = dc.MediaType, Blob = dc.GetBase64Data() }],
+                Contents = [new BlobResourceContents() { Uri = request.Params!.Uri, MimeType = dc.MediaType, Blob = dc.Base64Data.ToString() }],
             },
 
             string text => new()
@@ -429,7 +429,7 @@ internal sealed class AIFunctionMcpServerResource : McpServerResource
                         {
                             Uri = request.Params!.Uri,
                             MimeType = dc.MediaType,
-                            Blob = dc.GetBase64Data()
+                            Blob = dc.Base64Data.ToString()
                         },
 
                         _ => throw new InvalidOperationException($"Unsupported AIContent type '{ac.GetType()}' returned from resource function."),

--- a/src/ModelContextProtocol/Server/McpServerExtensions.cs
+++ b/src/ModelContextProtocol/Server/McpServerExtensions.cs
@@ -110,7 +110,7 @@ public static class McpServerExtensions
                                 {
                                     Type = dataContent.HasTopLevelMediaType("image") ? "image" : "audio",
                                     MimeType = dataContent.MediaType,
-                                    Data = dataContent.GetBase64Data(),
+                                    Data = dataContent.Base64Data.ToString(),
                                 },
                             });
                             break;


### PR DESCRIPTION
This can now just use DataContent.Base64Data.