### PR TITLE
Bump version to 0.2.0-preview.2

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
     <RepositoryUrl>https://github.com/modelcontextprotocol/csharp-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>preview.2</VersionSuffix>
     <Authors>ModelContextProtocolOfficial</Authors>
     <Copyright>© Anthropic and Contributors.</Copyright>
     <PackageTags>ModelContextProtocol;mcp;ai;llm</PackageTags>


### PR DESCRIPTION
[Release 0.2.0-preview.1 · modelcontextprotocol/csharp-sdk](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/0.2.0-preview.1) was published. This bumps to 0.2.0-preview.2.