### PR TITLE
Trim "title" and "description" keywords from root-level schemas.

### DIFF
--- a/src/ModelContextProtocol/McpJsonUtilities.cs
+++ b/src/ModelContextProtocol/McpJsonUtilities.cs
@@ -2,6 +2,7 @@
 using ModelContextProtocol.Protocol;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 
@@ -74,6 +75,25 @@ public static partial class McpJsonUtilities
 
         return false; // No type keyword found.
     }
+
+    private static readonly string[] s_rootSchemaKeywordsToRemove = ["title", "description"];
+    internal static AIJsonSchemaCreateOptions DefaultSchemaCreateOptions { get; } = new()
+    {
+        TransformOptions = new()
+        {
+            TransformSchemaNode = static (ctx, node) =>
+            {
+                if (ctx.Path is [] && node is JsonObject obj)
+                {
+                    foreach (string keywordToRemove in s_rootSchemaKeywordsToRemove)
+                    {
+                        obj.Remove(keywordToRemove);
+                    }
+                }
+                return node;
+            },
+        }
+    };
 
     // Keep in sync with CreateDefaultOptions above.
     [JsonSourceGenerationOptions(JsonSerializerDefaults.Web,

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerPrompt.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerPrompt.cs
@@ -151,7 +151,7 @@ internal sealed class AIFunctionMcpServerPrompt : McpServerPrompt
                     return null;
                 }
             },
-            JsonSchemaCreateOptions = options?.SchemaCreateOptions,
+            JsonSchemaCreateOptions = options?.SchemaCreateOptions ?? McpJsonUtilities.DefaultSchemaCreateOptions,
         };
 
     /// <summary>Creates an <see cref="McpServerPrompt"/> that wraps the specified <see cref="AIFunction"/>.</summary>

--- a/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol/Server/AIFunctionMcpServerTool.cs
@@ -160,7 +160,7 @@ internal sealed class AIFunctionMcpServerTool : McpServerTool
                     return null;
                 }
             },
-            JsonSchemaCreateOptions = options?.SchemaCreateOptions,
+            JsonSchemaCreateOptions = options?.SchemaCreateOptions ?? McpJsonUtilities.DefaultSchemaCreateOptions,
         };
 
     /// <summary>Creates an <see cref="McpServerTool"/> that wraps the specified <see cref="AIFunction"/>.</summary>


### PR DESCRIPTION
Fix #342.