### PR TITLE
SSE client transport: tolerate return of RPC responses in POST requests.

### DIFF
--- a/src/ModelContextProtocol/Client/SseClientSessionTransport.cs
+++ b/src/ModelContextProtocol/Client/SseClientSessionTransport.cs
@@ -105,13 +105,6 @@ internal sealed partial class SseClientSessionTransport : TransportBase
 
             response.EnsureSuccessStatusCode();
         }
-
-        if (response.Content.Headers.ContentType?.MediaType is "application/json")
-        {
-            // Certain MCP servers implementing SSE may return the response in the current POST request instead of the SSE stream.
-            // Even though this is not officially part of the SSE protocol, we handle it here.
-            await ProcessInboundMessage(await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
-        }
     }
 
     private async Task CloseAsync()
@@ -178,7 +171,7 @@ internal sealed partial class SseClientSessionTransport : TransportBase
                         break;
 
                     case "message":
-                        await ProcessInboundMessage(sseEvent.Data, cancellationToken).ConfigureAwait(false);
+                        await ProcessSseMessage(sseEvent.Data, cancellationToken).ConfigureAwait(false);
                         break;
                 }
             }
@@ -204,7 +197,7 @@ internal sealed partial class SseClientSessionTransport : TransportBase
         }
     }
 
-    private async Task ProcessInboundMessage(string data, CancellationToken cancellationToken)
+    private async Task ProcessSseMessage(string data, CancellationToken cancellationToken)
     {
         if (!IsConnected)
         {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
@@ -40,6 +40,7 @@ public partial class SseIntegrationTests(ITestOutputHelper outputHelper) : Kestr
 
         // Send a test message through POST endpoint
         await mcpClient.SendNotificationAsync("test/message", new Envelope { Message = "Hello, SSE!" }, serializerOptions: JsonContext.Default.Options, cancellationToken: TestContext.Current.CancellationToken);
+
         Assert.True(true);
     }
 

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseIntegrationTests.cs
@@ -8,7 +8,6 @@ using ModelContextProtocol.AspNetCore.Tests.Utils;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using TestServerWithHosting.Tools;
 


### PR DESCRIPTION
Reinstates a piece of logic that tolerated the return of responses in the POST request itself. I've tweaked the heuristic somewhat so that it only falls back to that mode if the response content type is `application/json`. I have tested this against the impacted MCP server (Haystack Search) and validated that the fix works. cc @aarnott

Fix #439.