### PR TITLE
Convert records to classes

### DIFF
--- a/src/ModelContextProtocol/Client/SseClientTransportOptions.cs
+++ b/src/ModelContextProtocol/Client/SseClientTransportOptions.cs
@@ -3,7 +3,7 @@ namespace ModelContextProtocol.Client;
 /// <summary>
 /// Provides options for configuring <see cref="SseClientTransport"/> instances.
 /// </summary>
-public record SseClientTransportOptions
+public class SseClientTransportOptions
 {
     /// <summary>
     /// Gets or sets the base address of the server for SSE connections.

--- a/src/ModelContextProtocol/Client/SseClientTransportOptions.cs
+++ b/src/ModelContextProtocol/Client/SseClientTransportOptions.cs
@@ -43,12 +43,12 @@ public class SseClientTransportOptions
     /// <see href="https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse">HTTP with SSE transport specification</see>.
     /// </para>
     /// </remarks>
-    public HttpTransportMode TransportMode { get; init; } = HttpTransportMode.AutoDetect;
+    public HttpTransportMode TransportMode { get; set; } = HttpTransportMode.AutoDetect;
 
     /// <summary>
     /// Gets a transport identifier used for logging purposes.
     /// </summary>
-    public string? Name { get; init; }
+    public string? Name { get; set; }
 
     /// <summary>
     /// Gets or sets a timeout used to establish the initial connection to the SSE server. Defaults to 30 seconds.
@@ -61,7 +61,7 @@ public class SseClientTransportOptions
     /// </list>
     /// If the timeout expires before the connection is established, a <see cref="TimeoutException"/> will be thrown.
     /// </remarks>
-    public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Gets custom HTTP headers to include in requests to the SSE server.
@@ -69,5 +69,5 @@ public class SseClientTransportOptions
     /// <remarks>
     /// Use this property to specify custom HTTP headers that should be sent with each request to the server.
     /// </remarks>
-    public Dictionary<string, string>? AdditionalHeaders { get; init; }
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/src/ModelContextProtocol/Client/SseClientTransportOptions.cs
+++ b/src/ModelContextProtocol/Client/SseClientTransportOptions.cs
@@ -11,7 +11,7 @@ public class SseClientTransportOptions
     public required Uri Endpoint
     {
         get;
-        init
+        set
         {
             if (value is null)
             {

--- a/src/ModelContextProtocol/Client/StdioClientTransportOptions.cs
+++ b/src/ModelContextProtocol/Client/StdioClientTransportOptions.cs
@@ -3,7 +3,7 @@ namespace ModelContextProtocol.Client;
 /// <summary>
 /// Provides options for configuring <see cref="StdioClientTransport"/> instances.
 /// </summary>
-public record StdioClientTransportOptions
+public class StdioClientTransportOptions
 {
     /// <summary>
     /// Gets or sets the command to execute to start the server process.

--- a/src/ModelContextProtocol/ProgressNotificationValue.cs
+++ b/src/ModelContextProtocol/ProgressNotificationValue.cs
@@ -1,7 +1,7 @@
 namespace ModelContextProtocol;
 
 /// <summary>Provides a progress value that can be sent using <see cref="IProgress{ProgressNotificationValue}"/>.</summary>
-public record struct ProgressNotificationValue
+public class ProgressNotificationValue
 {
     /// <summary>
     /// Gets or sets the progress thus far.

--- a/src/ModelContextProtocol/Protocol/Annotations.cs
+++ b/src/ModelContextProtocol/Protocol/Annotations.cs
@@ -9,7 +9,7 @@ namespace ModelContextProtocol.Protocol;
 /// Annotations enable filtering and prioritization of content for different audiences.
 /// See the <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/">schema</see> for details.
 /// </remarks>
-public record Annotations
+public class Annotations
 {
     /// <summary>
     /// Gets or sets the intended audience for this content as an array of <see cref="Role"/> values.

--- a/src/ModelContextProtocol/Protocol/InitializeResult.cs
+++ b/src/ModelContextProtocol/Protocol/InitializeResult.cs
@@ -19,7 +19,7 @@ namespace ModelContextProtocol.Protocol;
 /// See the <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/">schema</see> for details.
 /// </para>
 /// </remarks>
-public record InitializeResult
+public class InitializeResult
 {
     /// <summary>
     /// Gets or sets the version of the Model Context Protocol that the server will use for this session.

--- a/src/ModelContextProtocol/Protocol/JsonRpcErrorDetail.cs
+++ b/src/ModelContextProtocol/Protocol/JsonRpcErrorDetail.cs
@@ -11,7 +11,7 @@ namespace ModelContextProtocol.Protocol;
 /// a standard format for error responses that includes a numeric code, a human-readable message,
 /// and optional additional data.
 /// </remarks>
-public record JsonRpcErrorDetail
+public class JsonRpcErrorDetail
 {
     /// <summary>
     /// Gets an integer error code according to the JSON-RPC specification.

--- a/src/ModelContextProtocol/Protocol/PingResult.cs
+++ b/src/ModelContextProtocol/Protocol/PingResult.cs
@@ -14,4 +14,4 @@ namespace ModelContextProtocol.Protocol;
 /// is still responsive.
 /// </para>
 /// </remarks>
-public record PingResult;
+public class PingResult;

--- a/src/ModelContextProtocol/Protocol/Resource.cs
+++ b/src/ModelContextProtocol/Protocol/Resource.cs
@@ -8,7 +8,7 @@ namespace ModelContextProtocol.Protocol;
 /// <remarks>
 /// See the <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/">schema</see> for details.
 /// </remarks>
-public record Resource
+public class Resource
 {
     /// <summary>
     /// Gets or sets the URI of this resource.

--- a/src/ModelContextProtocol/Protocol/ResourceTemplate.cs
+++ b/src/ModelContextProtocol/Protocol/ResourceTemplate.cs
@@ -9,7 +9,7 @@ namespace ModelContextProtocol.Protocol;
 /// Resource templates provide metadata about resources available on the server,
 /// including how to construct URIs for those resources.
 /// </remarks>
-public record ResourceTemplate
+public class ResourceTemplate
 {
     /// <summary>
     /// Gets or sets the URI template (according to RFC 6570) that can be used to construct resource URIs.


### PR DESCRIPTION
I noticed that we're somewhat inconsistent in our use of classes vs. records. In lieu of a good reason to use records (promoting `with` expressions in immutable types, need for structural equality comparison) this PR is changing all records to being regular classes for consistency and reduced IL size.