### PR TITLE
Make enums serialize as strings if using the reflection-based serializer.

### DIFF
--- a/src/ModelContextProtocol/McpJsonUtilities.cs
+++ b/src/ModelContextProtocol/McpJsonUtilities.cs
@@ -38,8 +38,12 @@ public static partial class McpJsonUtilities
         // Copy the configuration from the source generated context.
         JsonSerializerOptions options = new(JsonContext.Default.Options);
 
-        // Chain with all supported types from MEAI
+        // Chain with all supported types and converters from MEAI
         options.TypeInfoResolverChain.Add(AIJsonUtilities.DefaultOptions.TypeInfoResolver!);
+        foreach (JsonConverter converter in AIJsonUtilities.DefaultOptions.Converters)
+        {
+            options.Converters.Add(converter);
+        }
 
         options.MakeReadOnly();
         return options;

--- a/tests/ModelContextProtocol.Tests/McpJsonUtilitiesTests.cs
+++ b/tests/ModelContextProtocol.Tests/McpJsonUtilitiesTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace ModelContextProtocol.Tests;
 
-public static class McpJsonUtilitiesTests
+public static partial class McpJsonUtilitiesTests
 {
     [Fact]
     public static void DefaultOptions_IsSingleton()
@@ -22,4 +24,27 @@ public static class McpJsonUtilitiesTests
 
         Assert.Equal(JsonSerializer.IsReflectionEnabledByDefault, options.TryGetTypeInfo(anonType, out _));
     }
+
+    [Fact]
+    public static void DefaultOptions_UnknownEnumHandling()
+    {
+        var options = McpJsonUtilities.DefaultOptions;
+
+        if (JsonSerializer.IsReflectionEnabledByDefault)
+        {
+            Assert.Equal("\"A\"", JsonSerializer.Serialize(EnumWithoutAnnotation.A, options));
+            Assert.Equal("\"A\"", JsonSerializer.Serialize(EnumWithAnnotation.A, options));
+        }
+        else
+        {
+            options = new(options) { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
+            Assert.Equal("1", JsonSerializer.Serialize(EnumWithoutAnnotation.A, options));
+            Assert.Equal("\"A\"", JsonSerializer.Serialize(EnumWithAnnotation.A, options));
+        }
+    }
+
+    public enum EnumWithoutAnnotation { A = 1, B = 2, C = 3 }
+
+    [JsonConverter(typeof(JsonStringEnumConverter<EnumWithAnnotation>))]
+    public enum EnumWithAnnotation { A = 1, B = 2, C = 3 }
 }


### PR DESCRIPTION
While triaging https://github.com/modelcontextprotocol/csharp-sdk/issues/460 it occurred to me that Microsoft.Extensions.AI is enabling string-based enum serialization only when reflection-based serialization is turned on. This PR enables that behavior for MCP as well, however I'm not sure if it should be merged: it does introduce inconsistency between the reflection and source gen worlds after all.