### PR TITLE
Remove incorrect acknowledgement from Core README.md

### DIFF
--- a/src/ModelContextProtocol.Core/README.md
+++ b/src/ModelContextProtocol.Core/README.md
@@ -102,11 +102,3 @@ await server.RunAsync(stdioTransport, CancellationToken.None);
 ```
 
 For more advanced scenarios with dependency injection, hosting, and automatic tool discovery, see the `ModelContextProtocol` package.
-
-## Acknowledgements
-
-The MCP C# SDK builds upon the excellent work from the [mcpdotnet](https://github.com/ReallyLiri/mcpdotnet) project by [Liri](https://github.com/ReallyLiri). We extend our gratitude for providing a foundational implementation that inspired this SDK.
-
-## License
-
-This project is licensed under the MIT License. See the [LICENSE](../../LICENSE) file for details.


### PR DESCRIPTION
I used copilot to help come up with the README for #428, but I did not review it carefully enough. I did run the sample code, but I didn't notice that we acknowledged a non-existant GitHub repo rather than [mcpdotnet](https://github.com/PederHP/mcpdotnet), initiated by [Peder Holdgaard Pedersen](https://github.com/PederHP) as we should have. Since we already have this acknowledgement in the README for the primary package and we did not include this acknowledgement in the AspNetCore package, I decided to remove it. I did the same for the license notice since I think that's well covered by the README in the root of the repository.

However, I can add it back with the right acknowledgement and do the same for the AspNetCore package if we think that's better. These do show up on NuGet.org.