### PR TITLE
Send MCP-Protocol-Version header with transport messages

### DIFF
--- a/src/ModelContextProtocol.Core/Client/McpClient.cs
+++ b/src/ModelContextProtocol.Core/Client/McpClient.cs
@@ -118,6 +118,7 @@ internal sealed partial class McpClient : McpEndpoint, IMcpClient
             // Connect transport
             _sessionTransport = await _clientTransport.ConnectAsync(cancellationToken).ConfigureAwait(false);
             InitializeSession(_sessionTransport);
+
             // We don't want the ConnectAsync token to cancel the session after we've successfully connected.
             // The base class handles cleaning up the session in DisposeAsync without our help.
             StartSession(_sessionTransport, fullSessionCancellationToken: CancellationToken.None);
@@ -163,6 +164,8 @@ internal sealed partial class McpClient : McpEndpoint, IMcpClient
                     LogServerProtocolVersionMismatch(EndpointName, requestProtocol, initializeResponse.ProtocolVersion);
                     throw new McpException($"Server protocol version mismatch. Expected {requestProtocol}, got {initializeResponse.ProtocolVersion}");
                 }
+
+                _sessionTransport.ProtocolVersion = initializeResponse.ProtocolVersion;
 
                 // Send initialized notification
                 await SendMessageAsync(

--- a/src/ModelContextProtocol.Core/Client/SseClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/SseClientSessionTransport.cs
@@ -91,7 +91,7 @@ internal sealed partial class SseClientSessionTransport : TransportBase
         {
             Content = content,
         };
-        StreamableHttpClientSessionTransport.CopyAdditionalHeaders(httpRequestMessage.Headers, _options.AdditionalHeaders);
+        StreamableHttpClientSessionTransport.CopyAdditionalHeaders(httpRequestMessage.Headers, _options.AdditionalHeaders, protocolVersion: ProtocolVersion);
         var response = await _httpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
@@ -152,7 +152,7 @@ internal sealed partial class SseClientSessionTransport : TransportBase
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, _sseEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
-            StreamableHttpClientSessionTransport.CopyAdditionalHeaders(request.Headers, _options.AdditionalHeaders);
+            StreamableHttpClientSessionTransport.CopyAdditionalHeaders(request.Headers, _options.AdditionalHeaders, protocolVersion: ProtocolVersion);
 
             using var response = await _httpClient.SendAsync(
                 request,

--- a/src/ModelContextProtocol.Core/Protocol/ITransport.cs
+++ b/src/ModelContextProtocol.Core/Protocol/ITransport.cs
@@ -60,4 +60,12 @@ public interface ITransport : IAsyncDisposable
     /// </para>
     /// </remarks>
     Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets or sets the protocol version that's in use.</summary>
+    /// <remarks>
+    /// Setting the protocol version does not change the protocol version actively employed by the transport.
+    /// It provides that information to the transport for situations where the transport needs to be able to
+    /// propagate the version information, for example as part of HTTP headers or for logging and diagnostic purposes.
+    /// </remarks>
+    string? ProtocolVersion { get; set; }
 }

--- a/src/ModelContextProtocol.Core/Protocol/TransportBase.cs
+++ b/src/ModelContextProtocol.Core/Protocol/TransportBase.cs
@@ -59,6 +59,9 @@ public abstract partial class TransportBase : ITransport
     /// <summary>Gets the logger used by this transport.</summary>
     private protected ILogger Logger => _logger;
 
+    /// <inheritdoc />
+    public string? ProtocolVersion { get; set; }
+
     /// <summary>
     /// Gets the name that identifies this transport endpoint in logs.
     /// </summary>

--- a/src/ModelContextProtocol.Core/Server/SseResponseStreamTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/SseResponseStreamTransport.cs
@@ -34,6 +34,9 @@ public sealed class SseResponseStreamTransport(Stream sseResponseStream, string?
 
     private bool _isConnected;
 
+    /// <inheritdoc />
+    public string? ProtocolVersion { get; set; }
+
     /// <summary>
     /// Starts the transport and writes the JSON-RPC messages sent via <see cref="SendMessageAsync"/>
     /// to the SSE response stream until cancellation is requested or the transport is disposed.

--- a/src/ModelContextProtocol.Core/Server/StreamableHttpPostTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamableHttpPostTransport.cs
@@ -18,6 +18,9 @@ internal sealed class StreamableHttpPostTransport(StreamableHttpServerTransport 
 
     public ChannelReader<JsonRpcMessage> MessageReader => throw new NotSupportedException("JsonRpcMessage.RelatedTransport should only be used for sending messages.");
 
+    /// <inheritdoc />
+    public string? ProtocolVersion { get; set; }
+
     /// <returns>
     /// True, if data was written to the respond body.
     /// False, if nothing was written because the request body did not contain any <see cref="JsonRpcRequest"/> messages to respond to.

--- a/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
@@ -35,6 +35,9 @@ public sealed class StreamableHttpServerTransport : ITransport
     private readonly CancellationTokenSource _disposeCts = new();
 
     private int _getRequestStarted;
+    
+    /// <inheritdoc />
+    public string? ProtocolVersion { get; set; }
 
     /// <summary>
     /// Configures whether the transport should be in stateless mode that does not require all requests for a given session

--- a/tests/Common/Utils/TestServerTransport.cs
+++ b/tests/Common/Utils/TestServerTransport.cs
@@ -10,6 +10,8 @@ public class TestServerTransport : ITransport
 
     public bool IsConnected { get; set; }
 
+    public string? ProtocolVersion { get; set; }
+
     public ChannelReader<JsonRpcMessage> MessageReader => _messageChannel;
 
     public List<JsonRpcMessage> SentMessages { get; } = [];

--- a/tests/ModelContextProtocol.Tests/Client/McpClientFactoryTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientFactoryTests.cs
@@ -110,6 +110,8 @@ public class McpClientFactoryTests
 
         public bool IsConnected => true;
 
+        public string? ProtocolVersion { get; set; }
+
         public ChannelReader<JsonRpcMessage> MessageReader => _channel.Reader;
 
         public Task<ITransport> ConnectAsync(CancellationToken cancellationToken = default) => Task.FromResult<ITransport>(this);


### PR DESCRIPTION
This adds the "MCP-Protocol-Version" header to the client's HTTP requests, per the spec.

I did _not_ update the server following https://github.com/modelcontextprotocol/modelcontextprotocol/pull/548's change from:

> MCP servers **SHOULD** use the `MCP-Protocol-Version` header to determine compatibility with the MCP client."

to

> If the server receives a request with a missing, invalid, or unsupported MCP-Protocol-VERSION, it **MUST** respond with `400 Bad Request`.

as that's presumably going to break a bunch of clients. @dsp-ant, are we sure we want that spec change?