### PR TITLE
Use lowercase host in resource URI template derivation.

### DIFF
--- a/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerResource.cs
+++ b/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerResource.cs
@@ -264,7 +264,7 @@ internal sealed class AIFunctionMcpServerResource : McpServerResource
             Name = name,
             Title = options?.Title,
             Description = options?.Description,
-            MimeType = options?.MimeType,
+            MimeType = options?.MimeType ?? "application/octet-stream",
         };
 
         return new AIFunctionMcpServerResource(function, resource);
@@ -295,7 +295,7 @@ internal sealed class AIFunctionMcpServerResource : McpServerResource
     {
         StringBuilder template = new();
 
-        template.Append("resource://").Append(Uri.EscapeDataString(name));
+        template.Append("resource://").Append(Uri.EscapeDataString(name.ToLowerInvariant()));
 
         if (function.JsonSchema.TryGetProperty("properties", out JsonElement properties))
         {

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsResourcesTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsResourcesTests.cs
@@ -268,8 +268,8 @@ public partial class McpServerBuilderExtensionsResourcesTests : ClientServerTest
         sc.AddMcpServer().WithResourcesFromAssembly();
         IServiceProvider services = sc.BuildServiceProvider();
 
-        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResource?.Uri == $"resource://{nameof(SimpleResources.SomeNeatDirectResource)}");
-        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResourceTemplate?.UriTemplate == $"resource://{nameof(SimpleResources.SomeNeatTemplatedResource)}{{?name}}");
+        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResource?.Uri == $"resource://{nameof(SimpleResources.SomeNeatDirectResource).ToLowerInvariant()}");
+        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResourceTemplate?.UriTemplate == $"resource://{nameof(SimpleResources.SomeNeatTemplatedResource).ToLowerInvariant()}{{?name}}");
     }
 
     [Fact]
@@ -279,13 +279,13 @@ public partial class McpServerBuilderExtensionsResourcesTests : ClientServerTest
         sc.AddMcpServer()
             .WithResources<SimpleResources>()
             .WithResources<MoreResources>()
-            .WithResources([McpServerResource.Create(() => "42", new() { UriTemplate = "myResources://Returns42/{something}" })]);
+            .WithResources([McpServerResource.Create(() => "42", new() { UriTemplate = "myResources://returns42/{something}" })]);
         IServiceProvider services = sc.BuildServiceProvider();
 
-        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResource?.Uri == $"resource://{nameof(SimpleResources.SomeNeatDirectResource)}");
-        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResourceTemplate?.UriTemplate == $"resource://{nameof(SimpleResources.SomeNeatTemplatedResource)}{{?name}}");
-        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResourceTemplate?.UriTemplate == $"resource://{nameof(MoreResources.AnotherNeatDirectResource)}");
-        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResourceTemplate.UriTemplate == "myResources://Returns42/{something}");
+        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResource?.Uri == $"resource://{nameof(SimpleResources.SomeNeatDirectResource).ToLowerInvariant()}");
+        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResourceTemplate?.UriTemplate == $"resource://{nameof(SimpleResources.SomeNeatTemplatedResource).ToLowerInvariant()}{{?name}}");
+        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResourceTemplate?.UriTemplate == $"resource://{nameof(MoreResources.AnotherNeatDirectResource).ToLowerInvariant()}");
+        Assert.Contains(services.GetServices<McpServerResource>(), t => t.ProtocolResourceTemplate.UriTemplate == "myResources://returns42/{something}");
     }
 
     [McpServerResourceType]

--- a/tests/ModelContextProtocol.Tests/Server/McpServerResourceTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerResourceTests.cs
@@ -122,159 +122,180 @@ public partial class McpServerResourceTests
     public async Task UriTemplate_CreatedFromParameters_LotsOfTypesSupported()
     {
         const string Name = "Hello";
+        const string ExpectedResourcePrefix = "resource://hello";
+
         McpServerResource t;
         ReadResourceResult? result;
         IMcpServer server = new Mock<IMcpServer>().Object;
 
         t = McpServerResource.Create(() => "42", new() { Name = Name });
-        Assert.Equal($"resource://{Name}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal(ExpectedResourcePrefix, t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}" } }, 
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = ExpectedResourcePrefix } }, 
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((IMcpServer server) => "42", new() { Name = Name });
-        Assert.Equal($"resource://{Name}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal(ExpectedResourcePrefix, t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = ExpectedResourcePrefix } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((string arg1) => arg1, new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?arg1}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?arg1}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?arg1=wOrLd" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?arg1=wOrLd" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("wOrLd", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((string arg1, string? arg2 = null) => arg1 + arg2, new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?arg1,arg2}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?arg1,arg2}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?arg1=wo&arg2=rld" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?arg1=wo&arg2=rld" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("world", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((object a1, bool a2, char a3, byte a4, sbyte a5) => a1.ToString() + a2 + a3 + a4 + a5, new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a1=hi&a2=true&a3=s&a4=12&a5=34" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a1=hi&a2=true&a3=s&a4=12&a5=34" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("hiTrues1234", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((ushort a1, short a2, uint a3, int a4, ulong a5) => (a1 + a2 + a3 + a4 + (long)a5).ToString(), new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a1=10&a2=20&a3=30&a4=40&a5=50" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a1=10&a2=20&a3=30&a4=40&a5=50" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("150", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((long a1, float a2, double a3, decimal a4, TimeSpan a5) => a5.ToString(), new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a1=1&a2=2&a3=3&a4=4&a5=5" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a1=1&a2=2&a3=3&a4=4&a5=5" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("5.00:00:00", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((DateTime a1, DateTimeOffset a2, Uri a3, Guid a4, Version a5) => a4.ToString("N") + a5, new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a1={DateTime.UtcNow:r}&a2={DateTimeOffset.UtcNow:r}&a3=http%3A%2F%2Ftest&a4=14e5f43d-0d41-47d6-8207-8249cf669e41&a5=1.2.3.4" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a1={DateTime.UtcNow:r}&a2={DateTimeOffset.UtcNow:r}&a3=http%3A%2F%2Ftest&a4=14e5f43d-0d41-47d6-8207-8249cf669e41&a5=1.2.3.4" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("14e5f43d0d4147d682078249cf669e411.2.3.4", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((Half a2, Int128 a3, UInt128 a4, IntPtr a5) => (a3 + (Int128)a4 + a5).ToString(), new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a2=1.0&a3=3&a4=4&a5=5" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a2=1.0&a3=3&a4=4&a5=5" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("12", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((UIntPtr a1, DateOnly a2, TimeOnly a3) => a1.ToString(), new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a1,a2,a3}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a1,a2,a3}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a1=123&a2=0001-02-03&a3=01%3A02%3A03" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a1=123&a2=0001-02-03&a3=01%3A02%3A03" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("123", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((bool? a2, char? a3, byte? a4, sbyte? a5) => a2?.ToString() + a3 + a4 + a5, new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a2=true&a3=s&a4=12&a5=34" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a2=true&a3=s&a4=12&a5=34" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("Trues1234", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((ushort? a1, short? a2, uint? a3, int? a4, ulong? a5) => (a1 + a2 + a3 + a4 + (long?)a5).ToString(), new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a1=10&a2=20&a3=30&a4=40&a5=50" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a1=10&a2=20&a3=30&a4=40&a5=50" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("150", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((long? a1, float? a2, double? a3, decimal? a4, TimeSpan? a5) => a5?.ToString(), new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a1=1&a2=2&a3=3&a4=4&a5=5" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a1=1&a2=2&a3=3&a4=4&a5=5" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("5.00:00:00", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((DateTime? a1, DateTimeOffset? a2, Guid? a4) => a4?.ToString("N"), new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a1,a2,a4}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a1,a2,a4}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a1={DateTime.UtcNow:r}&a2={DateTimeOffset.UtcNow:r}&a4=14e5f43d-0d41-47d6-8207-8249cf669e41" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a1={DateTime.UtcNow:r}&a2={DateTimeOffset.UtcNow:r}&a4=14e5f43d-0d41-47d6-8207-8249cf669e41" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("14e5f43d0d4147d682078249cf669e41", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((Half? a2, Int128? a3, UInt128? a4, IntPtr? a5) => (a3 + (Int128?)a4 + a5).ToString(), new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a2=1.0&a3=3&a4=4&a5=5" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a2=1.0&a3=3&a4=4&a5=5" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("12", ((TextResourceContents)result.Contents[0]).Text);
 
         t = McpServerResource.Create((UIntPtr? a1, DateOnly? a2, TimeOnly? a3) => a1?.ToString(), new() { Name = Name });
-        Assert.Equal($"resource://{Name}{{?a1,a2,a3}}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal($"{ExpectedResourcePrefix}{{?a1,a2,a3}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://{Name}?a1=123&a2=0001-02-03&a3=01%3A02%3A03" } },
+            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"{ExpectedResourcePrefix}?a1=123&a2=0001-02-03&a3=01%3A02%3A03" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("123", ((TextResourceContents)result.Contents[0]).Text);
     }
 
     [Theory]
-    [InlineData("resource://Hello?arg1=42&arg2=84")]
-    [InlineData("resource://Hello?arg1=42&arg2=84&arg3=123")]
-    [InlineData("resource://Hello#fragment")]
+    [InlineData("resource://hello?arg1=42&arg2=84")]
+    [InlineData("resource://hello?arg1=42&arg2=84&arg3=123")]
+    [InlineData("resource://hello#fragment")]
     public async Task UriTemplate_NonMatchingUri_ReturnsNull(string uri)
     {
         McpServerResource t = McpServerResource.Create((string arg1) => arg1, new() { Name = "Hello" });
-        Assert.Equal("resource://Hello{?arg1}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal("resource://hello{?arg1}", t.ProtocolResourceTemplate.UriTemplate);
         Assert.Null(await t.ReadAsync(
             new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = uri } },
             TestContext.Current.CancellationToken));
     }
 
     [Theory]
-    [InlineData("resource://Hello?arg1=test")]
-    [InlineData("resource://Hello?arg2=test")]
+    [InlineData("ResourceName", "resource://resourcename")]
+    [InlineData("NAME", "resource://name")]
+    public async Task UriTemplate_NormalizesCasing(string name, string expectedUriTemplate)
+    {
+        McpServerResource t = McpServerResource.Create(() => "resource", new() { Name = name });
+        Assert.Equal(expectedUriTemplate, t.ProtocolResourceTemplate.UriTemplate);
+        Assert.NotNull(await t.ReadAsync(
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = expectedUriTemplate } },
+            TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void MimeType_DefaultsToOctetStream()
+    {
+        McpServerResource t = McpServerResource.Create(() => "resource", new() { Name = "My Cool Resource" });
+        Assert.Equal("application/octet-stream", t.ProtocolResourceTemplate.MimeType);
+    }
+
+    [Theory]
+    [InlineData("resource://hello?arg1=test")]
+    [InlineData("resource://hello?arg2=test")]
     public async Task UriTemplate_MissingParameter_Throws(string uri)
     {
         McpServerResource t = McpServerResource.Create((string arg1, int arg2) => arg1, new() { Name = "Hello" });
-        Assert.Equal("resource://Hello{?arg1,arg2}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal("resource://hello{?arg1,arg2}", t.ProtocolResourceTemplate.UriTemplate);
         await Assert.ThrowsAsync<ArgumentException>(async () => await t.ReadAsync(
             new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = uri } },
             TestContext.Current.CancellationToken));
@@ -284,7 +305,7 @@ public partial class McpServerResourceTests
     public async Task UriTemplate_MissingOptionalParameter_Succeeds()
     {
         McpServerResource t = McpServerResource.Create((string? arg1 = null, int? arg2 = null) => arg1 + arg2, new() { Name = "Hello" });
-        Assert.Equal("resource://Hello{?arg1,arg2}", t.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal("resource://hello{?arg1,arg2}", t.ProtocolResourceTemplate.UriTemplate);
 
         ReadResourceResult? result;
 
@@ -325,7 +346,7 @@ public partial class McpServerResourceTests
         }, new() { Name = "Test" });
 
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
@@ -376,11 +397,11 @@ public partial class McpServerResourceTests
         Mock<IMcpServer> mockServer = new();
 
         await Assert.ThrowsAnyAsync<ArgumentException>(async () => await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken));
 
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Services = services, Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Services = services, Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
@@ -402,7 +423,7 @@ public partial class McpServerResourceTests
         }, new() { Services = services, Name = "Test" });
 
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
@@ -436,7 +457,7 @@ public partial class McpServerResourceTests
             return new ReadResourceResult { Contents = new List<ResourceContents> { new TextResourceContents { Text = "hello" } } };
         }, new() { Name = "Test" });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Single(result.Contents);
@@ -453,7 +474,7 @@ public partial class McpServerResourceTests
             return new TextResourceContents { Text = "hello" };
         }, new() { Name = "Test", SerializerOptions = JsonContext6.Default.Options });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Single(result.Contents);
@@ -474,7 +495,7 @@ public partial class McpServerResourceTests
             ];
         }, new() { Name = "Test" });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal(2, result.Contents.Count);
@@ -492,7 +513,7 @@ public partial class McpServerResourceTests
             return "42";
         }, new() { Name = "Test" });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Single(result.Contents);
@@ -509,7 +530,7 @@ public partial class McpServerResourceTests
             return new List<string> { "42", "43" };
         }, new() { Name = "Test", SerializerOptions = JsonContext6.Default.Options });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal(2, result.Contents.Count);
@@ -527,7 +548,7 @@ public partial class McpServerResourceTests
             return new DataContent(new byte[] { 0, 1, 2 }, "application/octet-stream");
         }, new() { Name = "Test" });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Single(result.Contents);
@@ -549,7 +570,7 @@ public partial class McpServerResourceTests
             };
         }, new() { Name = "Test", SerializerOptions = JsonContext6.Default.Options });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal(2, result.Contents.Count);


### PR DESCRIPTION
Makes the following changes:

* When deriving a resource URI template, converts the host component to lowercase.
* Defaults the mimetype to "application/octetstream".

This should mitigate some of the issues described in #516.