### PR TITLE
Document default value for UseStructuredContent.

### DIFF
--- a/src/ModelContextProtocol.Core/Server/McpServerToolAttribute.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerToolAttribute.cs
@@ -245,8 +245,13 @@ public sealed class McpServerToolAttribute : Attribute
     /// Gets or sets whether the tool should report an output schema for structured content.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// When enabled, the tool will attempt to populate the <see cref="Tool.OutputSchema"/>
     /// and provide structured content in the <see cref="CallToolResult.StructuredContent"/> property.
+    /// </para>
+    /// <para>
+    /// The default is <see langword="false"/>.
+    /// </para>
     /// </remarks>
     public bool UseStructuredContent { get; set; }
 }

--- a/src/ModelContextProtocol.Core/Server/McpServerToolCreateOptions.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerToolCreateOptions.cs
@@ -129,8 +129,13 @@ public sealed class McpServerToolCreateOptions
     /// Gets or sets whether the tool should report an output schema for structured content.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// When enabled, the tool will attempt to populate the <see cref="Tool.OutputSchema"/>
     /// and provide structured content in the <see cref="CallToolResult.StructuredContent"/> property.
+    /// </para>
+    /// <para>
+    /// The default is <see langword="false"/>.
+    /// </para>
     /// </remarks>
     public bool UseStructuredContent { get; set; }
 


### PR DESCRIPTION
For consistency with other boolean properties, document the default value.

PS I also noticed `McpServerToolCreateOptions.UseStructuredContent` is a non-nullable `bool` while the others are `bool?`, maybe this should be updated as well?

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
