### PR TITLE
Removed space

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,7 +62,7 @@
     <PackageVersion Include="OpenTelemetry" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http " Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0"  />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0"  />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />


### PR DESCRIPTION
PackageVersion for OpenTelemetry.Instrumentation.Http had trailing space causing error noticed in Visual Studio build

<!-- Provide a brief summary of your changes -->
Removed trailing space in Directory.Packages.props for OpenTelemetry.Instrumentation.Http PackageReference

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Caused me a build error in Visual Studio

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes. The error went away.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
It's a removed space that clearly shouldn't be there.