### PR TITLE
Make CallToolResult.IsError optional

### DIFF
--- a/src/ModelContextProtocol.Core/Protocol/CallToolResult.cs
+++ b/src/ModelContextProtocol.Core/Protocol/CallToolResult.cs
@@ -44,5 +44,5 @@ public sealed class CallToolResult : Result
     /// and potentially self-correct in subsequent requests.
     /// </remarks>
     [JsonPropertyName("isError")]
-    public bool IsError { get; set; }
+    public bool? IsError { get; set; }
 }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/HttpServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/HttpServerIntegrationTests.cs
@@ -94,7 +94,7 @@ public abstract class HttpServerIntegrationTests : LoggedTest, IClassFixture<Sse
 
         // assert
         Assert.NotNull(result);
-        Assert.False(result.IsError);
+        Assert.Null(result.IsError);
         var textContent = Assert.Single(result.Content.OfType<TextContentBlock>());
         Assert.Equal("Echo: Hello MCP!", textContent.Text);
     }
@@ -115,9 +115,9 @@ public abstract class HttpServerIntegrationTests : LoggedTest, IClassFixture<Sse
         Assert.NotNull(result2);
         Assert.NotNull(result3);
 
-        Assert.False(result1.IsError);
-        Assert.False(result2.IsError);
-        Assert.False(result3.IsError);
+        Assert.Null(result1.IsError);
+        Assert.Null(result2.IsError);
+        Assert.Null(result3.IsError);
         
         var textContent1 = Assert.Single(result1.Content.OfType<TextContentBlock>());
         var textContent2 = Assert.Single(result2.Content.OfType<TextContentBlock>());
@@ -298,7 +298,7 @@ public abstract class HttpServerIntegrationTests : LoggedTest, IClassFixture<Sse
             );
 
             Assert.NotNull(result);
-            Assert.False(result.IsError);
+            Assert.Null(result.IsError);
             var textContent = Assert.Single(result.Content.OfType<TextContentBlock>());
             Assert.Equal($"Echo: Hello MCP! {i}", textContent.Text);
         }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpTests.cs
@@ -171,7 +171,7 @@ public abstract class MapMcpTests(ITestOutputHelper testOutputHelper) : KestrelI
         }, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
-        Assert.False(result.IsError);
+        Assert.Null(result.IsError);
         var textContent = Assert.Single(result.Content);
         Assert.Equal("text", textContent.Type);
         Assert.Equal("Sampling completed successfully. Client responded: Sampling response from client", Assert.IsType<TextContentBlock>(textContent).Text);

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -91,7 +91,7 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
 
         // assert
         Assert.NotNull(result);
-        Assert.False(result.IsError);
+        Assert.Null(result.IsError);
         var textContent = Assert.Single(result.Content.OfType<TextContentBlock>());
         Assert.Equal("Echo: Hello MCP!", textContent.Text);
     }
@@ -107,7 +107,7 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
 
         // assert
         Assert.NotNull(result);
-        Assert.False(result.IsError);
+        Assert.Null(result.IsError);
         var textContent = Assert.Single(result.Content.OfType<TextContentBlock>());
         Assert.Empty(textContent.Text);
     }
@@ -485,7 +485,7 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
 
         // assert
         Assert.NotNull(result);
-        Assert.False(result.IsError);
+        Assert.Null(result.IsError);
         Assert.Single(result.Content, c => c.Type == "text");
 
         await client.DisposeAsync();


### PR DESCRIPTION
Match the spec, and avoid sending the property in the success case.