### PR TITLE
Fixed StreamableHttpClientSessionTransport.cs for netstandard

### DIFF
--- a/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs
@@ -75,7 +75,7 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
         using var content = new StringContent(
             JsonSerializer.Serialize(message, McpJsonUtilities.JsonContext.Default.JsonRpcMessage),
             Encoding.UTF8,
-            "application/json; charset=utf-8"
+            "application/json"
         );
 #endif
 


### PR DESCRIPTION
Fixed exception 'The format of value 'application/json; charset=utf-8' is invalid

## Motivation and Context
Without this fix it doesn't work at all with .NET Framework.

"application/json; charset=utf-8" is an invalid header when the encoding is already specified. It fails immediately when creating the McpClient instance with the SseClientTransport using netstandard builds.

## How Has This Been Tested?
Works. Without the fix doesn't work at all.

## Breaking Changes
Not a breaking change.
