### PR TITLE
Respect HandleResponse() and SkipHandler() calls in OnResourceMetadataRequest

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/Authentication/McpAuthenticationHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/Authentication/McpAuthenticationHandler.cs
@@ -78,10 +78,7 @@ public class McpAuthenticationHandler : AuthenticationHandler<McpAuthenticationO
         return absoluteUri.ToString();
     }
 
-    /// <summary>
-    /// Handles the resource metadata request.
-    /// </summary>
-    private async Task HandleResourceMetadataRequestAsync()
+    private async Task<bool> HandleResourceMetadataRequestAsync()
     {
         var resourceMetadata = Options.ResourceMetadata;
 
@@ -93,6 +90,23 @@ public class McpAuthenticationHandler : AuthenticationHandler<McpAuthenticationO
             };
 
             await Options.Events.OnResourceMetadataRequest(context);
+
+            if (context.Result is not null)
+            {
+                if (context.Result.Handled)
+                {
+                    return true;
+                }
+                else if (context.Result.Skipped)
+                {
+                    return false;
+                }
+                else if (context.Result.Failure is not null)
+                {
+                    throw new AuthenticationFailureException("An error occurred from the OnResourceMetadataRequest event.", context.Result.Failure);
+                }
+            }
+
             resourceMetadata = context.ResourceMetadata;
         }
 
@@ -104,6 +118,7 @@ public class McpAuthenticationHandler : AuthenticationHandler<McpAuthenticationO
         }
 
         await Results.Json(resourceMetadata, McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(ProtectedResourceMetadata))).ExecuteAsync(Context);
+        return true;
     }
 
     /// <inheritdoc />

--- a/src/ModelContextProtocol.AspNetCore/Authentication/McpAuthenticationHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/Authentication/McpAuthenticationHandler.cs
@@ -43,8 +43,7 @@ public class McpAuthenticationHandler : AuthenticationHandler<McpAuthenticationO
             return false;
         }
 
-        await HandleResourceMetadataRequestAsync();
-        return true;
+        return await HandleResourceMetadataRequestAsync();
     }
 
     /// <summary>

--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
@@ -212,11 +212,6 @@ internal sealed partial class ClientOAuthProvider
         // Get auth server metadata
         var authServerMetadata = await GetAuthServerMetadataAsync(selectedAuthServer, cancellationToken).ConfigureAwait(false);
 
-        if (authServerMetadata is null)
-        {
-            ThrowFailedToHandleUnauthorizedResponse($"Failed to retrieve metadata for authorization server: '{selectedAuthServer}'");
-        }
-
         // Store auth server metadata for future refresh operations
         _authServerMetadata = authServerMetadata;
 
@@ -238,7 +233,7 @@ internal sealed partial class ClientOAuthProvider
         LogOAuthAuthorizationCompleted();
     }
 
-    private async Task<AuthorizationServerMetadata?> GetAuthServerMetadataAsync(Uri authServerUri, CancellationToken cancellationToken)
+    private async Task<AuthorizationServerMetadata> GetAuthServerMetadataAsync(Uri authServerUri, CancellationToken cancellationToken)
     {
         if (!authServerUri.OriginalString.EndsWith("/"))
         {
@@ -249,7 +244,9 @@ internal sealed partial class ClientOAuthProvider
         {
             try
             {
-                var response = await _httpClient.GetAsync(new Uri(authServerUri, path), cancellationToken).ConfigureAwait(false);
+                var wellKnownEndpoint = new Uri(authServerUri, path);
+
+                var response = await _httpClient.GetAsync(wellKnownEndpoint, cancellationToken).ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode)
                 {
                     continue;
@@ -258,15 +255,28 @@ internal sealed partial class ClientOAuthProvider
                 using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
                 var metadata = await JsonSerializer.DeserializeAsync(stream, McpJsonUtilities.JsonContext.Default.AuthorizationServerMetadata, cancellationToken).ConfigureAwait(false);
 
-                if (metadata != null)
+                if (metadata is null)
                 {
-                    metadata.ResponseTypesSupported ??= ["code"];
-                    metadata.GrantTypesSupported ??= ["authorization_code", "refresh_token"];
-                    metadata.TokenEndpointAuthMethodsSupported ??= ["client_secret_post"];
-                    metadata.CodeChallengeMethodsSupported ??= ["S256"];
-
-                    return metadata;
+                    continue;
                 }
+
+                if (metadata.AuthorizationEndpoint is null)
+                {
+                    ThrowFailedToHandleUnauthorizedResponse($"No authorization_endpoint was provided via '{wellKnownEndpoint}'.");
+                }
+
+                if (metadata.AuthorizationEndpoint.Scheme != Uri.UriSchemeHttp &&
+                    metadata.AuthorizationEndpoint.Scheme != Uri.UriSchemeHttps)
+                {
+                    ThrowFailedToHandleUnauthorizedResponse($"AuthorizationEndpoint must use HTTP or HTTPS. '{metadata.AuthorizationEndpoint}' does not meet this requirement.");
+                }
+
+                metadata.ResponseTypesSupported ??= ["code"];
+                metadata.GrantTypesSupported ??= ["authorization_code", "refresh_token"];
+                metadata.TokenEndpointAuthMethodsSupported ??= ["client_secret_post"];
+                metadata.CodeChallengeMethodsSupported ??= ["S256"];
+
+                return metadata;
             }
             catch (Exception ex)
             {
@@ -274,7 +284,7 @@ internal sealed partial class ClientOAuthProvider
             }
         }
 
-        return null;
+        throw new McpException($"Failed to find .well-known/openid-configuration or .well-known/oauth-authorization-server metadata for authorization server: '{authServerUri}'");
     }
 
     private async Task<TokenContainer> RefreshTokenAsync(string refreshToken, Uri resourceUri, AuthorizationServerMetadata authServerMetadata, CancellationToken cancellationToken)
@@ -320,11 +330,6 @@ internal sealed partial class ClientOAuthProvider
         AuthorizationServerMetadata authServerMetadata,
         string codeChallenge)
     {
-        if (authServerMetadata.AuthorizationEndpoint.Scheme != Uri.UriSchemeHttp &&
-            authServerMetadata.AuthorizationEndpoint.Scheme != Uri.UriSchemeHttps)
-        {
-            throw new ArgumentException("AuthorizationEndpoint must use HTTP or HTTPS.", nameof(authServerMetadata));
-        }
 
         var queryParamsDictionary = new Dictionary<string, string>
         {

--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
@@ -330,7 +330,6 @@ internal sealed partial class ClientOAuthProvider
         AuthorizationServerMetadata authServerMetadata,
         string codeChallenge)
     {
-
         var queryParamsDictionary = new Dictionary<string, string>
         {
             ["client_id"] = GetClientIdOrThrow(),

--- a/tests/ModelContextProtocol.AspNetCore.Tests/AuthEventTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/AuthEventTests.cs
@@ -289,6 +289,87 @@ public class AuthEventTests : KestrelInMemoryTest, IAsyncDisposable
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
 
+    [Fact]
+    public async Task ResourceMetadataEndpoint_HandlesResponse_WhenHandleResponseCalled()
+    {
+        Builder.Services.AddMcpServer().WithHttpTransport();
+
+        // Override the configuration to test HandleResponse behavior
+        Builder.Services.Configure<McpAuthenticationOptions>(
+            McpAuthenticationDefaults.AuthenticationScheme,
+            options =>
+            {
+                options.ResourceMetadata = null;
+                options.Events.OnResourceMetadataRequest = async context =>
+                {
+                    // Call HandleResponse() to discontinue processing and return to client
+                    context.HandleResponse();
+                    await Task.CompletedTask;
+                };
+            }
+        );
+
+        await using var app = Builder.Build();
+
+        app.MapMcp().RequireAuthorization();
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        // Make a direct request to the resource metadata endpoint
+        using var response = await HttpClient.GetAsync(
+            "/.well-known/oauth-protected-resource",
+            TestContext.Current.CancellationToken
+        );
+
+        // The request should be handled by the event handler without returning metadata
+        // Since HandleResponse() was called, the handler should have taken responsibility
+        // for generating the response, which in this case means an empty response
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        // The response should be empty since the event handler called HandleResponse()
+        // but didn't write any content to the response
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Empty(content);
+    }
+
+    [Fact]
+    public async Task ResourceMetadataEndpoint_SkipsHandler_WhenSkipHandlerCalled()
+    {
+        Builder.Services.AddMcpServer().WithHttpTransport();
+
+        // Override the configuration to test SkipHandler behavior
+        Builder.Services.Configure<McpAuthenticationOptions>(
+            McpAuthenticationDefaults.AuthenticationScheme,
+            options =>
+            {
+                options.ResourceMetadata = null;
+                options.Events.OnResourceMetadataRequest = async context =>
+                {
+                    // Call SkipHandler() to discontinue processing in the current handler
+                    context.SkipHandler();
+                    await Task.CompletedTask;
+                };
+            }
+        );
+
+        await using var app = Builder.Build();
+
+        app.MapMcp().RequireAuthorization();
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        // Make a direct request to the resource metadata endpoint
+        using var response = await HttpClient.GetAsync(
+            "/.well-known/oauth-protected-resource",
+            TestContext.Current.CancellationToken
+        );
+
+        // When SkipHandler() is called, the authentication handler should skip processing
+        // and let other handlers in the pipeline handle the request. Since there are no
+        // other handlers configured for this endpoint, this should result in a 404
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
     private async Task<string?> HandleAuthorizationUrlAsync(
         Uri authorizationUri,
         Uri redirectUri,

--- a/tests/ModelContextProtocol.AspNetCore.Tests/AuthEventTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/AuthEventTests.cs
@@ -325,7 +325,7 @@ public class AuthEventTests : KestrelInMemoryTest, IAsyncDisposable
         // Since HandleResponse() was called, the handler should have taken responsibility
         // for generating the response, which in this case means an empty response
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         // The response should be empty since the event handler called HandleResponse()
         // but didn't write any content to the response
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);


### PR DESCRIPTION
This new code handles cases where `RequestContext.HandleResponse()` and `.SkipHandler()` get called in the same way other authentication handlers like RemoteAuthenticationHandler do [here](https://github.com/dotnet/aspnetcore/blob/20d4a005ddec5b5c0447df4abf9a351db41e7a9c/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs#L122-L136).

@DavidParks8