### PR TITLE
Adding ignores for common configs in samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,10 @@ docs/api
 # Rider
 .idea/
 .idea_modules/
+
+# Development configuration files (may contain secrets)
+**/appsettings.Development.json
+**/appsettings.Local.json
+**/appsettings.*.json
+!**/appsettings.json
+ 


### PR DESCRIPTION
The gitignore should ignore common config files that would be added by devs to the sample projects when running locally. To avoid the inconvenience of managing this manually I am proposing adding these settings to the gitignore.

## Motivation and Context
helps prevents secrets from getting pushed by accident.

## How Has This Been Tested?
yes, made sure the appsettings.development.json was ignored.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [N/A] I have added appropriate error handling
- [ N/A] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
