### PR TITLE
Ensure IsExternalInit is type forwarded on NET builds

### DIFF
--- a/src/Common/Polyfills/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/Common/Polyfills/System/Collections/Generic/CollectionExtensions.cs
@@ -1,3 +1,4 @@
+#if !NET
 using ModelContextProtocol;
 
 namespace System.Collections.Generic;
@@ -19,3 +20,4 @@ internal static class CollectionExtensions
     public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source) =>
         source.ToDictionary(kv => kv.Key, kv => kv.Value);
 }
+#endif

--- a/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
+++ b/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 namespace System.Diagnostics.CodeAnalysis;
 
 /// <summary>
@@ -162,3 +163,4 @@ internal enum DynamicallyAccessedMemberTypes
     /// </summary>
     All = ~None
 }
+#endif

--- a/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
+++ b/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 namespace System.Diagnostics.CodeAnalysis;
 
 /// <summary>
@@ -48,3 +49,4 @@ internal sealed class DynamicallyAccessedMembersAttribute : Attribute
     /// </summary>
     public DynamicallyAccessedMemberTypes MemberTypes { get; }
 }
+#endif

--- a/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+++ b/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
@@ -137,3 +138,4 @@ namespace System.Diagnostics.CodeAnalysis
         public string[] Members { get; }
     }
 }
+#endif

--- a/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/RequiresDynamicCodeAttribute.cs
+++ b/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/RequiresDynamicCodeAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 namespace System.Diagnostics.CodeAnalysis;
 
 /// <summary>
@@ -36,3 +37,4 @@ internal sealed class RequiresDynamicCodeAttribute : Attribute
     /// </summary>
     public string? Url { get; set; }
 }
+#endif

--- a/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/RequiresUnreferencedCode.cs
+++ b/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/RequiresUnreferencedCode.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 namespace System.Diagnostics.CodeAnalysis;
 
 /// <summary>
@@ -37,3 +38,4 @@ internal sealed class RequiresUnreferencedCodeAttribute : Attribute
     /// </summary>
     public string? Url { get; set; }
 }
+#endif

--- a/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/SetsRequiredMembersAttribute.cs
+++ b/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/SetsRequiredMembersAttribute.cs
@@ -1,5 +1,7 @@
+#if !NET
 namespace System.Diagnostics.CodeAnalysis
 {
     [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
     internal sealed class SetsRequiredMembersAttribute : Attribute;
 }
+#endif

--- a/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
+++ b/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 namespace System.Diagnostics.CodeAnalysis;
 
 /// <summary>Specifies the syntax used in a string.</summary>
@@ -66,3 +67,4 @@ internal sealed class StringSyntaxAttribute : Attribute
     /// <summary>The syntax identifier for strings containing XML.</summary>
     public const string Xml = nameof(Xml);
 }
+#endif

--- a/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttribute.cs
+++ b/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 namespace System.Diagnostics.CodeAnalysis;
 
 /// <summary>
@@ -82,3 +83,4 @@ internal sealed class UnconditionalSuppressMessageAttribute : Attribute
     /// </summary>
     public string? Justification { get; set; }
 }
+#endif

--- a/src/Common/Polyfills/System/IO/StreamExtensions.cs
+++ b/src/Common/Polyfills/System/IO/StreamExtensions.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Text;
 
+#if !NET
 namespace System.IO;
 
 internal static class StreamExtensions
@@ -62,3 +63,4 @@ internal static class StreamExtensions
         }
     }
 }
+#endif

--- a/src/Common/Polyfills/System/IO/TextWriterExtensions.cs
+++ b/src/Common/Polyfills/System/IO/TextWriterExtensions.cs
@@ -1,3 +1,4 @@
+#if !NET
 namespace System.IO;
 
 internal static class TextWriterExtensions
@@ -8,3 +9,4 @@ internal static class TextWriterExtensions
         await writer.FlushAsync();
     }
 }
+#endif

--- a/src/Common/Polyfills/System/Net/Http/HttpClientExtensions.cs
+++ b/src/Common/Polyfills/System/Net/Http/HttpClientExtensions.cs
@@ -1,3 +1,4 @@
+#if !NET
 using ModelContextProtocol;
 
 namespace System.Net.Http;
@@ -20,3 +21,4 @@ internal static class HttpClientExtensions
         return await content.ReadAsStringAsync();
     }
 }
+#endif

--- a/src/Common/Polyfills/System/PasteArguments.cs
+++ b/src/Common/Polyfills/System/PasteArguments.cs
@@ -5,6 +5,7 @@
 // https://github.com/dotnet/runtime/blob/d2650b6ae7023a2d9d2c74c56116f1f18472ab04/src/libraries/System.Private.CoreLib/src/System/PasteArguments.cs
 // and changed from using ValueStringBuilder to StringBuilder.
 
+#if !NET
 using System.Text;
 
 namespace System;
@@ -99,3 +100,4 @@ internal static partial class PasteArguments
     private const char Quote = '\"';
     private const char Backslash = '\\';
 }
+#endif

--- a/src/Common/Polyfills/System/Runtime/CompilerServices/CallerArgumentExpressionAttribute.cs
+++ b/src/Common/Polyfills/System/Runtime/CompilerServices/CallerArgumentExpressionAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 namespace System.Runtime.CompilerServices;
 
 [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
@@ -13,3 +14,4 @@ internal sealed class CallerArgumentExpressionAttribute : Attribute
 
     public string ParameterName { get; }
 }
+#endif

--- a/src/Common/Polyfills/System/Runtime/CompilerServices/CompilerFeatureRequiredAttribute.cs
+++ b/src/Common/Polyfills/System/Runtime/CompilerServices/CompilerFeatureRequiredAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
@@ -30,3 +31,4 @@ namespace System.Runtime.CompilerServices
         public const string RequiredMembers = nameof(RequiredMembers);
     }
 }
+#endif

--- a/src/Common/Polyfills/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/src/Common/Polyfills/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -5,6 +5,7 @@
 // https://github.com/dotnet/runtime/blob/dd75c45c123055baacd7aa4418f425f412797a29/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
 // and then modified to build on netstandard2.0.
 
+#if !NET
 using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
@@ -615,3 +616,4 @@ namespace System.Runtime.CompilerServices
         }
     }
 }
+#endif

--- a/src/Common/Polyfills/System/Runtime/CompilerServices/IsExternalInit.cs
+++ b/src/Common/Polyfills/System/Runtime/CompilerServices/IsExternalInit.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 using System.ComponentModel;
 
 namespace System.Runtime.CompilerServices
@@ -12,3 +13,8 @@ namespace System.Runtime.CompilerServices
     [EditorBrowsable(EditorBrowsableState.Never)]
     internal static class IsExternalInit;
 }
+#else
+// The compiler emits a reference to the internal copy of this type in the non-.NET builds,
+// so we must include a forward to be compatible.
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]
+#endif

--- a/src/Common/Polyfills/System/Runtime/CompilerServices/RequiredMemberAttribute.cs
+++ b/src/Common/Polyfills/System/Runtime/CompilerServices/RequiredMemberAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
 using System.ComponentModel;
 
 namespace System.Runtime.CompilerServices
@@ -10,3 +11,4 @@ namespace System.Runtime.CompilerServices
     [EditorBrowsable(EditorBrowsableState.Never)]
     internal sealed class RequiredMemberAttribute : Attribute;
 }
+#endif

--- a/src/Common/Polyfills/System/Threading/CancellationTokenSourceExtensions.cs
+++ b/src/Common/Polyfills/System/Threading/CancellationTokenSourceExtensions.cs
@@ -1,3 +1,4 @@
+#if !NET
 using ModelContextProtocol;
 
 namespace System.Threading.Tasks;
@@ -12,3 +13,4 @@ internal static class CancellationTokenSourceExtensions
         return Task.CompletedTask;
     }
 }
+#endif

--- a/src/Common/Polyfills/System/Threading/Channels/ChannelExtensions.cs
+++ b/src/Common/Polyfills/System/Threading/Channels/ChannelExtensions.cs
@@ -1,3 +1,4 @@
+#if !NET
 using System.Runtime.CompilerServices;
 
 namespace System.Threading.Channels;
@@ -15,3 +16,4 @@ internal static class ChannelExtensions
         }
     }
 }
+#endif

--- a/src/Common/Polyfills/System/Threading/ForceYielding.cs
+++ b/src/Common/Polyfills/System/Threading/ForceYielding.cs
@@ -1,3 +1,4 @@
+#if !NET
 using System.Runtime.CompilerServices;
 
 namespace System.Threading;
@@ -15,3 +16,4 @@ internal readonly struct ForceYielding : INotifyCompletion, ICriticalNotifyCompl
     public void UnsafeOnCompleted(Action continuation) => ThreadPool.UnsafeQueueUserWorkItem(a => ((Action)a!)(), continuation);
     public void GetResult() { }
 }
+#endif

--- a/src/Common/Polyfills/System/Threading/Tasks/TaskExtensions.cs
+++ b/src/Common/Polyfills/System/Threading/Tasks/TaskExtensions.cs
@@ -1,3 +1,4 @@
+#if !NET
 using ModelContextProtocol;
 
 namespace System.Threading.Tasks;
@@ -50,3 +51,4 @@ internal static class TaskExtensions
         await task.ConfigureAwait(false);
     }
 }
+#endif

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\Polyfills\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="$(RepoRoot)\logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/src/ModelContextProtocol.Core/ModelContextProtocol.Core.csproj
+++ b/src/ModelContextProtocol.Core/ModelContextProtocol.Core.csproj
@@ -20,7 +20,6 @@
 
   <!-- Dependencies only needed by netstandard2.0 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <Compile Include="..\Common\Polyfills\**\*.cs" />
     <Compile Include="..\Common\CancellableStreamReader\**\*.cs" />
     <PackageReference Include="Microsoft.Bcl.Memory" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />

--- a/src/ModelContextProtocol/ModelContextProtocol.csproj
+++ b/src/ModelContextProtocol/ModelContextProtocol.csproj
@@ -17,10 +17,6 @@
     <Compile Include="..\Common\Throw.cs" Link="Throw.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <Compile Include="..\Common\Polyfills\**\*.cs" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\ModelContextProtocol.Core\ModelContextProtocol.Core.csproj" />
   </ItemGroup>


### PR DESCRIPTION
It's included as internal on netstandard/net472, and the C# compiler may bake a reference to that into a consumer. If that consumer is then used with a net8.0+ build, the IsExternalInit needs to be there and forwarded to the real one.

This switches our polyfill files to always be included but the actual contents ifdef'd out on TFMs that already have the contents. That then makes it easier to do specialized ifdef'ing in the future, as this does for IsExternalInit.