### PR TITLE
Remove special-casing of string enumerables in McpServerTool

### DIFF
--- a/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
@@ -270,12 +270,6 @@ internal sealed partial class AIFunctionMcpServerTool : McpServerTool
                 StructuredContent = structuredContent,
             },
             
-            IEnumerable<string> texts => new()
-            {
-                Content = [.. texts.Select(x => new TextContentBlock { Text = x ?? string.Empty })],
-                StructuredContent = structuredContent,
-            },
-            
             IEnumerable<AIContent> contentItems => ConvertAIContentEnumerableToCallToolResult(contentItems, structuredContent),
             
             IEnumerable<ContentBlock> contents => new()

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
@@ -254,8 +254,7 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
 
         Assert.NotNull(result.Content);
         Assert.NotEmpty(result.Content);
-        Assert.Equal("hello Peter", (result.Content[0] as TextContentBlock)?.Text);
-        Assert.Equal("hello2 Peter", (result.Content[1] as TextContentBlock)?.Text);
+        Assert.Equal("""["hello Peter","hello2 Peter"]""", (result.Content[0] as TextContentBlock)?.Text);
 
         result = await client.CallToolAsync(
             "SecondCustomTool",

--- a/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
@@ -356,9 +356,8 @@ public partial class McpServerToolTests
         var result = await tool.InvokeAsync(
             new RequestContext<CallToolRequestParams>(mockServer.Object),
             TestContext.Current.CancellationToken);
-        Assert.Equal(2, result.Content.Count);
-        Assert.Equal("42", Assert.IsType<TextContentBlock>(result.Content[0]).Text);
-        Assert.Equal("43", Assert.IsType<TextContentBlock>(result.Content[1]).Text);
+        Assert.Single(result.Content);
+        Assert.Equal("""["42","43"]""", Assert.IsType<TextContentBlock>(result.Content[0]).Text);
     }
 
     [Fact]


### PR DESCRIPTION
We special-case string enumerables, translating them to an array of text content blocks, but other enumerables just get serialized, and there's a reasonable expectation that returning a string[] would produce a JSON array of strings. Just delete the special-casing.

Fixes https://github.com/modelcontextprotocol/csharp-sdk/issues/698

cc: @AArnott