### PR TITLE
Clarify default value in ElicitResult documentation

### DIFF
--- a/src/ModelContextProtocol.Core/Protocol/ElicitResult.cs
+++ b/src/ModelContextProtocol.Core/Protocol/ElicitResult.cs
@@ -11,6 +11,9 @@ public sealed class ElicitResult : Result
     /// <summary>
     /// Gets or sets the user action in response to the elicitation.
     /// </summary>
+    /// <value>
+    /// Defaults to "cancel" if not explicitly set.
+    /// </value>
     /// <remarks>
     /// <list type="bullet">
     ///   <item>
@@ -23,7 +26,7 @@ public sealed class ElicitResult : Result
     ///   </item>
     ///   <item>
     ///     <term>"cancel"</term>
-    ///     <description>User dismissed without making an explicit choice</description>
+    ///     <description>User dismissed without making an explicit choice (default)</description>
     ///   </item>
     /// </list>
     /// </remarks>


### PR DESCRIPTION
Updated XML documentation to clarify default value for action.

## Motivation and Context
In the IntelliSense and other documentation it clarifies what any default value would be if not set.

## Breaking Changes
No, documentation only

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed