### PR TITLE
Add middleware and authz support for server-side handlers

### DIFF
--- a/docs/concepts/filters.md
+++ b/docs/concepts/filters.md
@@ -1,0 +1,262 @@
+---
+title: Filters
+author: halter73
+description: MCP Server Handler Filters
+uid: filters
+---
+
+# MCP Server Handler Filters
+
+This document describes the filter functionality in the MCP Server, which allows you to add middleware-style filters to handler pipelines.
+
+## Overview
+
+For each handler type in the MCP Server, there are corresponding `AddXXXFilter` methods in `McpServerBuilderExtensions.cs` that allow you to add filters to the handler pipeline. The filters are stored in `McpServerOptions.Filters` and applied during server configuration.
+
+## Available Filter Methods
+
+The following filter methods are available:
+
+- `AddListResourceTemplatesFilter` - Filter for list resource templates handlers
+- `AddListToolsFilter` - Filter for list tools handlers
+- `AddCallToolFilter` - Filter for call tool handlers
+- `AddListPromptsFilter` - Filter for list prompts handlers
+- `AddGetPromptFilter` - Filter for get prompt handlers
+- `AddListResourcesFilter` - Filter for list resources handlers
+- `AddReadResourceFilter` - Filter for read resource handlers
+- `AddCompleteFilter` - Filter for completion handlers
+- `AddSubscribeToResourcesFilter` - Filter for resource subscription handlers
+- `AddUnsubscribeFromResourcesFilter` - Filter for resource unsubscription handlers
+- `AddSetLoggingLevelFilter` - Filter for logging level handlers
+
+## Usage
+
+Filters are functions that take a handler and return a new handler, allowing you to wrap the original handler with additional functionality:
+
+```csharp
+services.AddMcpServer()
+    .WithListToolsHandler(async (context, cancellationToken) =>
+    {
+        // Your base handler logic
+        return new ListToolsResult { Tools = GetTools() };
+    })
+    .AddListToolsFilter(next => async (context, cancellationToken) =>
+    {
+        // Pre-processing logic
+        Console.WriteLine("Before handler execution");
+
+        var result = await next(context, cancellationToken);
+
+        // Post-processing logic
+        Console.WriteLine("After handler execution");
+        return result;
+    });
+```
+
+## Filter Execution Order
+
+```csharp
+services.AddMcpServer()
+    .WithListToolsHandler(baseHandler)
+    .AddListToolsFilter(filter1)  // Executes first (outermost)
+    .AddListToolsFilter(filter2)  // Executes second
+    .AddListToolsFilter(filter3); // Executes third (closest to handler)
+```
+
+Execution flow: `filter1 -> filter2 -> filter3 -> baseHandler -> filter3 -> filter2 -> filter1`
+
+## Common Use Cases
+
+### Logging
+```csharp
+.AddListToolsFilter(next => async (context, cancellationToken) =>
+{
+    Console.WriteLine($"Processing request from {context.Meta.ProgressToken}");
+    var result = await next(context, cancellationToken);
+    Console.WriteLine($"Returning {result.Tools?.Count ?? 0} tools");
+    return result;
+});
+```
+
+### Error Handling
+```csharp
+.AddCallToolFilter(next => async (context, cancellationToken) =>
+{
+    try
+    {
+        return await next(context, cancellationToken);
+    }
+    catch (Exception ex)
+    {
+        return new CallToolResult
+        {
+            Content = new[] { new TextContent { Type = "text", Text = $"Error: {ex.Message}" } },
+            IsError = true
+        };
+    }
+});
+```
+
+### Performance Monitoring
+```csharp
+.AddListToolsFilter(next => async (context, cancellationToken) =>
+{
+    var stopwatch = Stopwatch.StartNew();
+    var result = await next(context, cancellationToken);
+    stopwatch.Stop();
+    Console.WriteLine($"Handler took {stopwatch.ElapsedMilliseconds}ms");
+    return result;
+});
+```
+
+### Caching
+```csharp
+.AddListResourcesFilter(next => async (context, cancellationToken) =>
+{
+    var cacheKey = $"resources:{context.Params.Cursor}";
+    if (cache.TryGetValue(cacheKey, out var cached))
+        return cached;
+
+    var result = await next(context, cancellationToken);
+    cache.Set(cacheKey, result, TimeSpan.FromMinutes(5));
+    return result;
+});
+```
+
+## Built-in Authorization Filters
+
+When using the ASP.NET Core integration (`ModelContextProtocol.AspNetCore`), authorization filters are automatically configured to support `[Authorize]` and `[AllowAnonymous]` attributes on MCP server tools, prompts, and resources.
+
+### Authorization Attributes Support
+
+The MCP server automatically respects the following authorization attributes:
+
+- **`[Authorize]`** - Requires authentication for access
+- **`[Authorize(Roles = "RoleName")]`** - Requires specific roles
+- **`[Authorize(Policy = "PolicyName")]`** - Requires specific authorization policies
+- **`[AllowAnonymous]`** - Explicitly allows anonymous access (overrides `[Authorize]`)
+
+### Tool Authorization
+
+Tools can be decorated with authorization attributes to control access:
+
+```csharp
+[McpServerToolType]
+public class WeatherTools
+{
+    [McpServerTool, Description("Gets public weather data")]
+    public static string GetWeather(string location)
+    {
+        return $"Weather for {location}: Sunny, 25°C";
+    }
+
+    [McpServerTool, Description("Gets detailed weather forecast")]
+    [Authorize] // Requires authentication
+    public static string GetDetailedForecast(string location)
+    {
+        return $"Detailed forecast for {location}: ...";
+    }
+
+    [McpServerTool, Description("Manages weather alerts")]
+    [Authorize(Roles = "Admin")] // Requires Admin role
+    public static string ManageWeatherAlerts(string alertType)
+    {
+        return $"Managing alert: {alertType}";
+    }
+}
+```
+
+### Class-Level Authorization
+
+You can apply authorization at the class level, which affects all tools in the class:
+
+```csharp
+[McpServerToolType]
+[Authorize] // All tools require authentication
+public class AdminTools
+{
+    [McpServerTool, Description("Admin-only tool")]
+    public static string AdminOperation()
+    {
+        return "Admin operation completed";
+    }
+
+    [McpServerTool, Description("Public tool accessible to anonymous users")]
+    [AllowAnonymous] // Overrides class-level [Authorize]
+    public static string PublicOperation()
+    {
+        return "Public operation completed";
+    }
+}
+```
+
+### How Authorization Filters Work
+
+The authorization filters work differently for list operations versus individual operations:
+
+#### List Operations (ListTools, ListPrompts, ListResources)
+For list operations, the filters automatically remove unauthorized items from the results. Users only see tools, prompts, or resources they have permission to access.
+
+#### Individual Operations (CallTool, GetPrompt, ReadResource)
+For individual operations, the filters return authorization errors when access is denied:
+
+- **Tools**: Returns a `CallToolResult` with `IsError = true` and an error message
+- **Prompts**: Throws an `McpException` with "Access forbidden" message
+- **Resources**: Throws an `McpException` with "Access forbidden" message
+
+### Setup Requirements
+
+To use authorization features, you must configure authentication and authorization in your ASP.NET Core application:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+// Add authentication
+builder.Services.AddAuthentication("Bearer")
+    .AddJwtBearer("Bearer", options => { /* JWT configuration */ });
+
+// Add authorization (required for [Authorize] attributes to work)
+builder.Services.AddAuthorization();
+
+// Add MCP server
+builder.Services.AddMcpServer()
+    .WithTools<WeatherTools>();
+
+var app = builder.Build();
+
+// Use authentication and authorization middleware
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapMcp();
+app.Run();
+```
+
+### Custom Authorization Filters
+
+You can also create custom authorization filters using the filter methods:
+
+```csharp
+.AddCallToolFilter(next => async (context, cancellationToken) =>
+{
+    // Custom authorization logic
+    if (context.User?.Identity?.IsAuthenticated != true)
+    {
+        return new CallToolResult
+        {
+            Content = [new TextContent { Text = "Custom: Authentication required" }],
+            IsError = true
+        };
+    }
+
+    return await next(context, cancellationToken);
+});
+```
+
+### RequestContext
+
+Within filters, you have access to:
+
+- `context.User` - The current user's `ClaimsPrincipal`
+- `context.Services` - The request's service provider for resolving authorization services
+- `context.MatchedPrimitive` - The matched tool/prompt/resource with its metadata including authorization attributes via `context.MatchedPrimitive.Metadata`

--- a/docs/concepts/toc.yml
+++ b/docs/concepts/toc.yml
@@ -13,3 +13,7 @@ items:
   items:
   - name: Logging
     uid: logging
+- name: Server Features
+  items:
+  - name: Filters
+    uid: filters

--- a/samples/AspNetCoreMcpServer/Properties/launchSettings.json
+++ b/samples/AspNetCoreMcpServer/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "applicationUrl": "http://localhost:3001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "OTEL_SERVICE_NAME": "aspnetcore-mcp-server",
+        "OTEL_SERVICE_NAME": "aspnetcore-mcp-server"
       }
     },
     "https": {
@@ -16,7 +16,7 @@
       "applicationUrl": "https://localhost:7133;http://localhost:3001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "OTEL_SERVICE_NAME": "aspnetcore-mcp-server",
+        "OTEL_SERVICE_NAME": "aspnetcore-mcp-server"
       }
     }
   }

--- a/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
+++ b/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
@@ -1,0 +1,222 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace ModelContextProtocol.AspNetCore;
+
+/// <summary>
+/// Evaluates authorization policies from endpoint metadata.
+/// </summary>
+internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? policyProvider = null) : IConfigureOptions<McpServerOptions>
+{
+    public void Configure(McpServerOptions options)
+    {
+        ConfigureListToolsFilter(options);
+        ConfigureCallToolFilter(options);
+
+        ConfigureListResourcesFilter(options);
+        ConfigureListResourceTemplatesFilter(options);
+        ConfigureReadResourceFilter(options);
+
+        ConfigureListPromptsFilter(options);
+        ConfigureGetPromptFilter(options);
+    }
+
+    private void ConfigureListToolsFilter(McpServerOptions options)
+    {
+        options.Filters.ListToolsFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var result = await next(context, cancellationToken);
+            await FilterAuthorizedItemsAsync(
+                result.Tools, static tool => tool.McpServerTool,
+                context.User, context.Services, context);
+            return result;
+        });
+    }
+
+    private void ConfigureCallToolFilter(McpServerOptions options)
+    {
+        options.Filters.CallToolFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
+            if (!authResult.Succeeded)
+            {
+                return new CallToolResult
+                {
+                    Content = [new TextContentBlock { Text = "Access forbidden: This tool requires authorization." }],
+                    IsError = true
+                };
+            }
+
+            return await next(context, cancellationToken);
+        });
+    }
+
+    private void ConfigureListResourcesFilter(McpServerOptions options)
+    {
+        options.Filters.ListResourcesFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var result = await next(context, cancellationToken);
+            await FilterAuthorizedItemsAsync(
+                result.Resources, static resource => resource.McpServerResource,
+                context.User, context.Services, context);
+            return result;
+        });
+    }
+
+    private void ConfigureListResourceTemplatesFilter(McpServerOptions options)
+    {
+        options.Filters.ListResourceTemplatesFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var result = await next(context, cancellationToken);
+            await FilterAuthorizedItemsAsync(
+                result.ResourceTemplates, static resourceTemplate => resourceTemplate.McpServerResource,
+                context.User, context.Services, context);
+            return result;
+        });
+    }
+
+    private void ConfigureReadResourceFilter(McpServerOptions options)
+    {
+        options.Filters.ReadResourceFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
+            if (!authResult.Succeeded)
+            {
+                throw new McpException("Access forbidden: This resource requires authorization.", McpErrorCode.InvalidRequest);
+            }
+
+            return await next(context, cancellationToken);
+        });
+    }
+
+    private void ConfigureListPromptsFilter(McpServerOptions options)
+    {
+        options.Filters.ListPromptsFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var result = await next(context, cancellationToken);
+            await FilterAuthorizedItemsAsync(
+                result.Prompts, static prompt => prompt.McpServerPrompt,
+                context.User, context.Services, context);
+            return result;
+        });
+    }
+
+    private void ConfigureGetPromptFilter(McpServerOptions options)
+    {
+        options.Filters.GetPromptFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
+            if (!authResult.Succeeded)
+            {
+                throw new McpException("Access forbidden: This prompt requires authorization.", McpErrorCode.InvalidRequest);
+            }
+
+            return await next(context, cancellationToken);
+        });
+    }
+
+    /// <summary>
+    /// Filters a collection of items based on authorization policies in their metadata.
+    /// For list operations where we need to filter results by authorization.
+    /// </summary>
+    private async ValueTask FilterAuthorizedItemsAsync<T>(IList<T> items, Func<T, IMcpServerPrimitive?> primitiveSelector,
+        ClaimsPrincipal? user, IServiceProvider? requestServices, object context)
+    {
+        for (int i = items.Count - 1; i >= 0; i--)
+        {
+            var authorizationResult = await GetAuthorizationResultAsync(
+                user, primitiveSelector(items[i]), requestServices, context);
+
+            if (!authorizationResult.Succeeded)
+            {
+                items.RemoveAt(i);
+            }
+        }
+    }
+
+    private async ValueTask<AuthorizationResult> GetAuthorizationResultAsync(
+        ClaimsPrincipal? user, IMcpServerPrimitive? primitive, IServiceProvider? requestServices, object context)
+    {
+        // If no primitive was found for this request or there is IAllowAnonymous metadata anywhere on the class or method,
+        // the request should go through as normal.
+        if (primitive is null || primitive.Metadata.Any(static m => m is IAllowAnonymous))
+        {
+            return AuthorizationResult.Success();
+        }
+
+        // There are no [Authorize] style attributes applied to the method or containing class. Any fallback policies
+        // have already been enforced at the HTTP request level by the ASP.NET Core authorization middleware.
+        if (!primitive.Metadata.Any(static m => m is IAuthorizeData or AuthorizationPolicy or IAuthorizationRequirementData))
+        {
+            return AuthorizationResult.Success();
+        }
+
+        if (policyProvider is null)
+        {
+            throw new InvalidOperationException($"You must call AddAuthorization() because an authorization related attribute was found on {primitive.Id}");
+        }
+
+        // TODO: Cache policy lookup. We would probably use a singleton (not-static) ConditionalWeakTable<IMcpServerPrimitive, AuthorizationPolicy?>.
+        var policy = await CombineAsync(policyProvider, primitive.Metadata);
+        if (policy is null)
+        {
+            return AuthorizationResult.Success();
+        }
+
+        if (requestServices is null)
+        {
+            // The IAuthorizationPolicyProvider service must be non-null to get to this line, so it's very unexpected for RequestContext.Services to not be set.
+            throw new InvalidOperationException("RequestContext.Services is not set! The IMcpServer must be initialized with a non-null IServiceProvider.");
+        }
+
+        // ASP.NET Core's AuthorizationMiddleware resolves the IAuthorizationService from scoped request services, so we do the same.
+        var authService = requestServices.GetRequiredService<IAuthorizationService>();
+        return await authService.AuthorizeAsync(user ?? new ClaimsPrincipal(new ClaimsIdentity()), context, policy);
+    }
+
+    /// <summary>
+    /// Combines authorization policies and requirements from endpoint metadata without considering <see cref="IAllowAnonymous"/>.
+    /// </summary>
+    /// <param name="policyProvider">The authorization policy provider.</param>
+    /// <param name="endpointMetadata">The endpoint metadata collection.</param>
+    /// <returns>The combined authorization policy, or null if no authorization is required.</returns>
+    private static async ValueTask<AuthorizationPolicy?> CombineAsync(IAuthorizationPolicyProvider policyProvider, IReadOnlyList<object> endpointMetadata)
+    {
+        // https://github.com/dotnet/aspnetcore/issues/63365 tracks adding this as public API to AuthorizationPolicy itself.
+        // Copied from https://github.com/dotnet/aspnetcore/blob/9f2977bf9cfb539820983bda3bedf81c8cda9f20/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs#L116-L138
+        var authorizeData = endpointMetadata.OfType<IAuthorizeData>();
+        var policies = endpointMetadata.OfType<AuthorizationPolicy>();
+
+        var policy = await AuthorizationPolicy.CombineAsync(policyProvider, authorizeData, policies);
+
+        AuthorizationPolicyBuilder? reqPolicyBuilder = null;
+
+        foreach (var m in endpointMetadata)
+        {
+            if (m is not IAuthorizationRequirementData requirementData)
+            {
+                continue;
+            }
+
+            reqPolicyBuilder ??= new AuthorizationPolicyBuilder();
+            foreach (var requirement in requirementData.GetRequirements())
+            {
+                reqPolicyBuilder.AddRequirements(requirement);
+            }
+        }
+
+        if (reqPolicyBuilder is null)
+        {
+            return policy;
+        }
+
+        // Combine policy with requirements or just use requirements if no policy
+        return (policy is null)
+            ? reqPolicyBuilder.Build()
+            : AuthorizationPolicy.Combine(policy, reqPolicyBuilder.Build());
+    }
+}

--- a/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
+++ b/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
@@ -283,7 +283,6 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
             throw new InvalidOperationException($"You must call AddAuthorization() because an authorization related attribute was found on {primitive.Id}");
         }
 
-        // TODO: Cache policy lookup. We would probably use a singleton (not-static) ConditionalWeakTable<IMcpServerPrimitive, AuthorizationPolicy?>.
         var policy = await CombineAsync(policyProvider, primitive.Metadata);
         if (policy is null)
         {

--- a/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
+++ b/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,8 +11,10 @@ namespace ModelContextProtocol.AspNetCore;
 /// <summary>
 /// Evaluates authorization policies from endpoint metadata.
 /// </summary>
-internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? policyProvider = null) : IConfigureOptions<McpServerOptions>
+internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? policyProvider = null) : IConfigureOptions<McpServerOptions>, IPostConfigureOptions<McpServerOptions>
 {
+    private static readonly string AuthorizationFilterInvokedKey = "ModelContextProtocol.AspNetCore.AuthorizationFilter.Invoked";
+
     public void Configure(McpServerOptions options)
     {
         ConfigureListToolsFilter(options);
@@ -25,14 +28,45 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
         ConfigureGetPromptFilter(options);
     }
 
+    public void PostConfigure(string? name, McpServerOptions options)
+    {
+        CheckListToolsFilter(options);
+        CheckCallToolFilter(options);
+
+        CheckListResourcesFilter(options);
+        CheckListResourceTemplatesFilter(options);
+        CheckReadResourceFilter(options);
+
+        CheckListPromptsFilter(options);
+        CheckGetPromptFilter(options);
+    }
+
     private void ConfigureListToolsFilter(McpServerOptions options)
     {
         options.Filters.ListToolsFilters.Add(next => async (context, cancellationToken) =>
         {
+            context.Items[AuthorizationFilterInvokedKey] = true;
+
             var result = await next(context, cancellationToken);
             await FilterAuthorizedItemsAsync(
                 result.Tools, static tool => tool.McpServerTool,
                 context.User, context.Services, context);
+            return result;
+        });
+    }
+
+    private void CheckListToolsFilter(McpServerOptions options)
+    {
+        options.Filters.ListToolsFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var result = await next(context, cancellationToken);
+
+            if (HasAuthorizationMetadata(result.Tools.Select(static tool => tool.McpServerTool))
+                && !context.Items.ContainsKey(AuthorizationFilterInvokedKey))
+            {
+                throw new InvalidOperationException("Authorization filter was not invoked for tools/list operation, but authorization metadata was found on the tools. Ensure that AddAuthorizationFilters() is called on the IMcpServerBuilder to configure authorization filters.");
+            }
+
             return result;
         });
     }
@@ -51,6 +85,22 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
                 };
             }
 
+            context.Items[AuthorizationFilterInvokedKey] = true;
+
+            return await next(context, cancellationToken);
+        });
+    }
+
+    private void CheckCallToolFilter(McpServerOptions options)
+    {
+        options.Filters.CallToolFilters.Add(next => async (context, cancellationToken) =>
+        {
+            if (HasAuthorizationMetadata(context.MatchedPrimitive)
+                && !context.Items.ContainsKey(AuthorizationFilterInvokedKey))
+            {
+                throw new InvalidOperationException("Authorization filter was not invoked for tools/call operation, but authorization metadata was found on the tool. Ensure that AddAuthorizationFilters() is called on the IMcpServerBuilder to configure authorization filters.");
+            }
+
             return await next(context, cancellationToken);
         });
     }
@@ -59,6 +109,8 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
     {
         options.Filters.ListResourcesFilters.Add(next => async (context, cancellationToken) =>
         {
+            context.Items[AuthorizationFilterInvokedKey] = true;
+
             var result = await next(context, cancellationToken);
             await FilterAuthorizedItemsAsync(
                 result.Resources, static resource => resource.McpServerResource,
@@ -67,10 +119,28 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
         });
     }
 
+    private void CheckListResourcesFilter(McpServerOptions options)
+    {
+        options.Filters.ListResourcesFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var result = await next(context, cancellationToken);
+
+            if (HasAuthorizationMetadata(result.Resources.Select(static resource => resource.McpServerResource))
+                && !context.Items.ContainsKey(AuthorizationFilterInvokedKey))
+            {
+                throw new InvalidOperationException("Authorization filter was not invoked for resources/list operation, but authorization metadata was found on the resources. Ensure that AddAuthorizationFilters() is called on the IMcpServerBuilder to configure authorization filters.");
+            }
+
+            return result;
+        });
+    }
+
     private void ConfigureListResourceTemplatesFilter(McpServerOptions options)
     {
         options.Filters.ListResourceTemplatesFilters.Add(next => async (context, cancellationToken) =>
         {
+            context.Items[AuthorizationFilterInvokedKey] = true;
+
             var result = await next(context, cancellationToken);
             await FilterAuthorizedItemsAsync(
                 result.ResourceTemplates, static resourceTemplate => resourceTemplate.McpServerResource,
@@ -79,10 +149,28 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
         });
     }
 
+    private void CheckListResourceTemplatesFilter(McpServerOptions options)
+    {
+        options.Filters.ListResourceTemplatesFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var result = await next(context, cancellationToken);
+
+            if (HasAuthorizationMetadata(result.ResourceTemplates.Select(static resourceTemplate => resourceTemplate.McpServerResource))
+                && !context.Items.ContainsKey(AuthorizationFilterInvokedKey))
+            {
+                throw new InvalidOperationException("Authorization filter was not invoked for resources/templates/list operation, but authorization metadata was found on the resource templates. Ensure that AddAuthorizationFilters() is called on the IMcpServerBuilder to configure authorization filters.");
+            }
+
+            return result;
+        });
+    }
+
     private void ConfigureReadResourceFilter(McpServerOptions options)
     {
         options.Filters.ReadResourceFilters.Add(next => async (context, cancellationToken) =>
         {
+            context.Items[AuthorizationFilterInvokedKey] = true;
+
             var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
             if (!authResult.Succeeded)
             {
@@ -93,10 +181,26 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
         });
     }
 
+    private void CheckReadResourceFilter(McpServerOptions options)
+    {
+        options.Filters.ReadResourceFilters.Add(next => async (context, cancellationToken) =>
+        {
+            if (HasAuthorizationMetadata(context.MatchedPrimitive)
+                && !context.Items.ContainsKey(AuthorizationFilterInvokedKey))
+            {
+                throw new InvalidOperationException("Authorization filter was not invoked for resources/read operation, but authorization metadata was found on the resource. Ensure that AddAuthorizationFilters() is called on the IMcpServerBuilder to configure authorization filters.");
+            }
+
+            return await next(context, cancellationToken);
+        });
+    }
+
     private void ConfigureListPromptsFilter(McpServerOptions options)
     {
         options.Filters.ListPromptsFilters.Add(next => async (context, cancellationToken) =>
         {
+            context.Items[AuthorizationFilterInvokedKey] = true;
+
             var result = await next(context, cancellationToken);
             await FilterAuthorizedItemsAsync(
                 result.Prompts, static prompt => prompt.McpServerPrompt,
@@ -105,14 +209,46 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
         });
     }
 
+    private void CheckListPromptsFilter(McpServerOptions options)
+    {
+        options.Filters.ListPromptsFilters.Add(next => async (context, cancellationToken) =>
+        {
+            var result = await next(context, cancellationToken);
+
+            if (HasAuthorizationMetadata(result.Prompts.Select(static prompt => prompt.McpServerPrompt))
+                && !context.Items.ContainsKey(AuthorizationFilterInvokedKey))
+            {
+                throw new InvalidOperationException("Authorization filter was not invoked for prompts/list operation, but authorization metadata was found on the prompts. Ensure that AddAuthorizationFilters() is called on the IMcpServerBuilder to configure authorization filters.");
+            }
+
+            return result;
+        });
+    }
+
     private void ConfigureGetPromptFilter(McpServerOptions options)
     {
         options.Filters.GetPromptFilters.Add(next => async (context, cancellationToken) =>
         {
+            context.Items[AuthorizationFilterInvokedKey] = true;
+
             var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
             if (!authResult.Succeeded)
             {
                 throw new McpException("Access forbidden: This prompt requires authorization.", McpErrorCode.InvalidRequest);
+            }
+
+            return await next(context, cancellationToken);
+        });
+    }
+
+    private void CheckGetPromptFilter(McpServerOptions options)
+    {
+        options.Filters.GetPromptFilters.Add(next => async (context, cancellationToken) =>
+        {
+            if (HasAuthorizationMetadata(context.MatchedPrimitive)
+                && !context.Items.ContainsKey(AuthorizationFilterInvokedKey))
+            {
+                throw new InvalidOperationException("Authorization filter was not invoked for prompts/get operation, but authorization metadata was found on the prompt. Ensure that AddAuthorizationFilters() is called on the IMcpServerBuilder to configure authorization filters.");
             }
 
             return await next(context, cancellationToken);
@@ -141,16 +277,7 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
     private async ValueTask<AuthorizationResult> GetAuthorizationResultAsync(
         ClaimsPrincipal? user, IMcpServerPrimitive? primitive, IServiceProvider? requestServices, object context)
     {
-        // If no primitive was found for this request or there is IAllowAnonymous metadata anywhere on the class or method,
-        // the request should go through as normal.
-        if (primitive is null || primitive.Metadata.Any(static m => m is IAllowAnonymous))
-        {
-            return AuthorizationResult.Success();
-        }
-
-        // There are no [Authorize] style attributes applied to the method or containing class. Any fallback policies
-        // have already been enforced at the HTTP request level by the ASP.NET Core authorization middleware.
-        if (!primitive.Metadata.Any(static m => m is IAuthorizeData or AuthorizationPolicy or IAuthorizationRequirementData))
+        if (!HasAuthorizationMetadata(primitive))
         {
             return AuthorizationResult.Success();
         }
@@ -219,4 +346,19 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
             ? reqPolicyBuilder.Build()
             : AuthorizationPolicy.Combine(policy, reqPolicyBuilder.Build());
     }
+
+    private static bool HasAuthorizationMetadata([NotNullWhen(true)] IMcpServerPrimitive? primitive)
+    {
+        // If no primitive was found for this request or there is IAllowAnonymous metadata anywhere on the class or method,
+        // the request should go through as normal.
+        if (primitive is null || primitive.Metadata.Any(static m => m is IAllowAnonymous))
+        {
+            return false;
+        }
+
+        return primitive.Metadata.Any(static m => m is IAuthorizeData or AuthorizationPolicy or IAuthorizationRequirementData);
+    }
+
+    private static bool HasAuthorizationMetadata(IEnumerable<IMcpServerPrimitive?> primitives)
+        => primitives.Any(HasAuthorizationMetadata);
 }

--- a/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
+++ b/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
@@ -78,11 +78,7 @@ internal sealed class AuthorizationFilterSetup(IAuthorizationPolicyProvider? pol
             var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
             if (!authResult.Succeeded)
             {
-                return new CallToolResult
-                {
-                    Content = [new TextContentBlock { Text = "Access forbidden: This tool requires authorization." }],
-                    IsError = true
-                };
+                throw new McpException("Access forbidden: This tool requires authorization.", McpErrorCode.InvalidRequest);
             }
 
             context.Items[AuthorizationFilterInvokedKey] = true;

--- a/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.AspNetCore;
 using ModelContextProtocol.Server;
 
@@ -28,6 +29,9 @@ public static class HttpMcpServerBuilderExtensions
         builder.Services.TryAddSingleton<SseHandler>();
         builder.Services.AddHostedService<IdleTrackingBackgroundService>();
         builder.Services.AddDataProtection();
+
+        // Register authorization filter setup for automatic filter configuration
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<McpServerOptions>, AuthorizationFilterSetup>());
 
         if (configureOptions is not null)
         {

--- a/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol.AspNetCore;
@@ -30,13 +31,35 @@ public static class HttpMcpServerBuilderExtensions
         builder.Services.AddHostedService<IdleTrackingBackgroundService>();
         builder.Services.AddDataProtection();
 
-        // Register authorization filter setup for automatic filter configuration
-        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<McpServerOptions>, AuthorizationFilterSetup>());
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IPostConfigureOptions<McpServerOptions>, AuthorizationFilterSetup>());
 
         if (configureOptions is not null)
         {
             builder.Services.Configure(configureOptions);
         }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds authorization filters to support <see cref="AuthorizeAttribute"/>
+    /// on MCP server tools, prompts, and resources. This method should always be called when using
+    /// ASP.NET Core integration to ensure proper authorization support.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// This method automatically configures authorization filters for all MCP server handlers. These filters respect
+    /// authorization attributes such as <see cref="AuthorizeAttribute"/>
+    /// and <see cref="AllowAnonymousAttribute"/>.
+    /// </remarks>
+    public static IMcpServerBuilder AddAuthorizationFilters(this IMcpServerBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Allow the authorization filters to get added multiple times in case other middleware changes the matched primitive.
+        builder.Services.AddTransient<IConfigureOptions<McpServerOptions>, AuthorizationFilterSetup>();
 
         return builder;
     }

--- a/src/ModelContextProtocol.AspNetCore/SseHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/SseHandler.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -97,7 +96,7 @@ internal sealed class SseHandler(
             return;
         }
 
-        var message = (JsonRpcMessage?)await context.Request.ReadFromJsonAsync(McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcMessage)), context.RequestAborted);
+        var message = await StreamableHttpHandler.ReadJsonRpcMessageAsync(context);
         if (message is null)
         {
             await Results.BadRequest("No message in request body.").ExecuteAsync(context);

--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -8,7 +8,6 @@ using Microsoft.Net.Http.Headers;
 using ModelContextProtocol.AspNetCore.Stateless;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
-using System.IO.Pipelines;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text.Json;
@@ -26,6 +25,8 @@ internal sealed class StreamableHttpHandler(
     IServiceProvider applicationServices)
 {
     private const string McpSessionIdHeaderName = "Mcp-Session-Id";
+
+    private static readonly JsonTypeInfo<JsonRpcMessage> s_messageTypeInfo = GetRequiredJsonTypeInfo<JsonRpcMessage>();
     private static readonly JsonTypeInfo<JsonRpcError> s_errorTypeInfo = GetRequiredJsonTypeInfo<JsonRpcError>();
 
     public HttpServerTransportOptions HttpServerTransportOptions => httpServerTransportOptions.Value;
@@ -55,8 +56,17 @@ internal sealed class StreamableHttpHandler(
 
         await using var _ = await session.AcquireReferenceAsync(context.RequestAborted);
 
+        var message = await ReadJsonRpcMessageAsync(context);
+        if (message is null)
+        {
+            await WriteJsonRpcErrorAsync(context,
+                "Bad Request: The POST body did not contain a valid JSON-RPC message.",
+                StatusCodes.Status400BadRequest);
+            return;
+        }
+
         InitializeSseResponse(context);
-        var wroteResponse = await session.Transport.HandlePostRequest(new HttpDuplexPipe(context), context.RequestAborted);
+        var wroteResponse = await session.Transport.HandlePostRequest(message, context.Response.Body, context.RequestAborted);
         if (!wroteResponse)
         {
             // We wound up writing nothing, so there should be no Content-Type response header.
@@ -264,6 +274,22 @@ internal sealed class StreamableHttpHandler(
         return WebEncoders.Base64UrlEncode(buffer);
     }
 
+    internal static async Task<JsonRpcMessage?> ReadJsonRpcMessageAsync(HttpContext context)
+    {
+        // Implementation for reading a JSON-RPC message from the request body
+        var message = await context.Request.ReadFromJsonAsync(s_messageTypeInfo, context.RequestAborted);
+
+        if (context.User?.Identity?.IsAuthenticated ?? false)
+        {
+            message?.Context = new()
+            {
+                User = context.User,
+            };
+        }
+
+        return message;
+    }
+
     private void ScheduleStatelessSessionIdWrite(HttpContext context, StreamableHttpServerTransport transport)
     {
         transport.OnInitRequestReceived = initRequestParams =>
@@ -304,17 +330,11 @@ internal sealed class StreamableHttpHandler(
         return null;
     }
 
-    private static JsonTypeInfo<T> GetRequiredJsonTypeInfo<T>() => (JsonTypeInfo<T>)McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(T));
+    internal static JsonTypeInfo<T> GetRequiredJsonTypeInfo<T>() => (JsonTypeInfo<T>)McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(T));
 
     private static bool MatchesApplicationJsonMediaType(MediaTypeHeaderValue acceptHeaderValue)
         => acceptHeaderValue.MatchesMediaType("application/json");
 
     private static bool MatchesTextEventStreamMediaType(MediaTypeHeaderValue acceptHeaderValue)
         => acceptHeaderValue.MatchesMediaType("text/event-stream");
-
-    private sealed class HttpDuplexPipe(HttpContext context) : IDuplexPipe
-    {
-        public PipeReader Input => context.Request.BodyReader;
-        public PipeWriter Output => context.Response.BodyWriter;
-    }
 }

--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -279,9 +279,11 @@ internal sealed class StreamableHttpHandler(
         // Implementation for reading a JSON-RPC message from the request body
         var message = await context.Request.ReadFromJsonAsync(s_messageTypeInfo, context.RequestAborted);
 
-        if (context.User?.Identity?.IsAuthenticated ?? false)
+        if (context.User?.Identity?.IsAuthenticated ?? false && message is not null)
         {
-            message?.Context = new()
+            // We get weird CS0131 errors only on the Windows build GitHub Action if we use "message?.Context = ..."
+            // https://productionresultssa0.blob.core.windows.net/actions-results/f2218319-0fdd-473b-891d-06e5a4a0f826/workflow-job-run-98901492-cf7c-5406-85d9-0f7057e0516f/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-08-26T16%3A06%3A31Z&sig=RvEQo6DgrpDUW9mnbgDvf6FVDAAoHKzk9rsDdcPxOhw%3D&ske=2025-08-27T03%3A39%3A43Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-08-26T15%3A39%3A43Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-08-26T15%3A56%3A26Z&sv=2025-05-05
+            message!.Context = new()
             {
                 User = context.User,
             };

--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -279,10 +279,9 @@ internal sealed class StreamableHttpHandler(
         // Implementation for reading a JSON-RPC message from the request body
         var message = await context.Request.ReadFromJsonAsync(s_messageTypeInfo, context.RequestAborted);
 
-        if (context.User?.Identity?.IsAuthenticated ?? false && message is not null)
+        if (context.User?.Identity?.IsAuthenticated == true && message is not null)
         {
-            // We get weird CS0131 errors only on the Windows build GitHub Action if we use "message?.Context = ..."
-            message!.Context = new()
+            message.Context = new()
             {
                 User = context.User,
             };

--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -282,7 +282,6 @@ internal sealed class StreamableHttpHandler(
         if (context.User?.Identity?.IsAuthenticated ?? false && message is not null)
         {
             // We get weird CS0131 errors only on the Windows build GitHub Action if we use "message?.Context = ..."
-            // https://productionresultssa0.blob.core.windows.net/actions-results/f2218319-0fdd-473b-891d-06e5a4a0f826/workflow-job-run-98901492-cf7c-5406-85d9-0f7057e0516f/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-08-26T16%3A06%3A31Z&sig=RvEQo6DgrpDUW9mnbgDvf6FVDAAoHKzk9rsDdcPxOhw%3D&ske=2025-08-27T03%3A39%3A43Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-08-26T15%3A39%3A43Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-08-26T15%3A56%3A26Z&sv=2025-05-05
             message!.Context = new()
             {
                 User = context.User,

--- a/src/ModelContextProtocol.Core/Protocol/CompletionsCapability.cs
+++ b/src/ModelContextProtocol.Core/Protocol/CompletionsCapability.cs
@@ -9,7 +9,7 @@ namespace ModelContextProtocol.Protocol;
 /// </summary>
 /// <remarks>
 /// <para>
-/// When enabled, this capability allows a Model Context Protocol server to provide 
+/// When enabled, this capability allows a Model Context Protocol server to provide
 /// auto-completion suggestions. This capability is advertised to clients during the initialize handshake.
 /// </para>
 /// <para>
@@ -33,5 +33,5 @@ public sealed class CompletionsCapability
     /// and should return appropriate completion suggestions.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>? CompleteHandler { get; set; }
+    public McpRequestHandler<CompleteRequestParams, CompleteResult>? CompleteHandler { get; set; }
 }

--- a/src/ModelContextProtocol.Core/Protocol/JsonRpcMessage.cs
+++ b/src/ModelContextProtocol.Core/Protocol/JsonRpcMessage.cs
@@ -1,5 +1,6 @@
 using ModelContextProtocol.Server;
 using System.ComponentModel;
+using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -29,28 +30,21 @@ public abstract class JsonRpcMessage
     public string JsonRpc { get; init; } = "2.0";
 
     /// <summary>
-    /// Gets or sets the transport the <see cref="JsonRpcMessage"/> was received on or should be sent over.
+    /// Gets or sets the contextual information for this JSON-RPC message.
     /// </summary>
     /// <remarks>
-    /// This is used to support the Streamable HTTP transport where the specification states that the server
-    /// SHOULD include JSON-RPC responses in the HTTP response body for the POST request containing
-    /// the corresponding JSON-RPC request. It may be <see langword="null"/> for other transports.
+    /// This property contains transport-specific and runtime context information that accompanies
+    /// JSON-RPC messages but is not serialized as part of the JSON-RPC payload. This includes
+    /// transport references, execution context, and authenticated user information.
     /// </remarks>
-    [JsonIgnore]
-    public ITransport? RelatedTransport { get; set; }
-
-    /// <summary>
-    /// Gets or sets the <see cref="ExecutionContext"/> that should be used to run any handlers
-    /// </summary>
     /// <remarks>
-    /// This is used to support the Streamable HTTP transport in its default stateful mode. In this mode,
-    /// the <see cref="IMcpServer"/> outlives the initial HTTP request context it was created on, and new
-    /// JSON-RPC messages can originate from future HTTP requests. This allows the transport to flow the
-    /// context with the JSON-RPC message. This is particularly useful for enabling IHttpContextAccessor
-    /// in tool calls.
+    /// This property should only be set when implementing a custom <see cref="ITransport"/>
+    /// that needs to pass additional per-message context or to pass a <see cref="JsonRpcMessageContext.User"/>
+    /// to <see cref="StreamableHttpServerTransport.HandlePostRequest(JsonRpcMessage, Stream, CancellationToken)"/>
+    /// or <see cref="SseResponseStreamTransport.OnMessageReceivedAsync(JsonRpcMessage, CancellationToken)"/> .
     /// </remarks>
     [JsonIgnore]
-    public ExecutionContext? ExecutionContext { get; set; }
+    public JsonRpcMessageContext? Context { get; set; }
 
     /// <summary>
     /// Provides a <see cref="JsonConverter"/> for <see cref="JsonRpcMessage"/> messages,

--- a/src/ModelContextProtocol.Core/Protocol/JsonRpcMessageContext.cs
+++ b/src/ModelContextProtocol.Core/Protocol/JsonRpcMessageContext.cs
@@ -1,0 +1,61 @@
+using ModelContextProtocol.Server;
+using System.Security.Claims;
+using System.Text.Json.Serialization;
+
+namespace ModelContextProtocol.Protocol;
+
+/// <summary>
+/// Contains contextual information for JSON-RPC messages that is not part of the JSON-RPC protocol specification.
+/// </summary>
+/// <remarks>
+/// This class holds transport-specific and runtime context information that accompanies JSON-RPC messages
+/// but is not serialized as part of the JSON-RPC payload. This includes transport references, execution context,
+/// and authenticated user information.
+/// </remarks>
+public class JsonRpcMessageContext
+{
+    /// <summary>
+    /// Gets or sets the transport the <see cref="JsonRpcMessage"/> was received on or should be sent over.
+    /// </summary>
+    /// <remarks>
+    /// This is used to support the Streamable HTTP transport where the specification states that the server
+    /// SHOULD include JSON-RPC responses in the HTTP response body for the POST request containing
+    /// the corresponding JSON-RPC request. It may be <see langword="null"/> for other transports.
+    /// </remarks>
+    public ITransport? RelatedTransport { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="ExecutionContext"/> that should be used to run any handlers
+    /// </summary>
+    /// <remarks>
+    /// This is used to support the Streamable HTTP transport in its default stateful mode. In this mode,
+    /// the <see cref="IMcpServer"/> outlives the initial HTTP request context it was created on, and new
+    /// JSON-RPC messages can originate from future HTTP requests. This allows the transport to flow the
+    /// context with the JSON-RPC message. This is particularly useful for enabling IHttpContextAccessor
+    /// in tool calls.
+    /// </remarks>
+    public ExecutionContext? ExecutionContext { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authenticated user associated with this JSON-RPC message.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property contains the <see cref="ClaimsPrincipal"/> representing the authenticated user
+    /// who initiated this JSON-RPC message. This enables request handlers to access user identity
+    /// and authorization information without requiring dependency on HTTP context accessors
+    /// or other HTTP-specific abstractions.
+    /// </para>
+    /// <para>
+    /// The user information is automatically populated by the transport layer when processing
+    /// incoming HTTP requests in ASP.NET Core scenarios. For other transport types or scenarios
+    /// where user authentication is not applicable, this property may be <see langword="null"/>.
+    /// </para>
+    /// <para>
+    /// This property is particularly useful in the Streamable HTTP transport where JSON-RPC messages
+    /// may outlive the original HTTP request context, allowing user identity to be preserved
+    /// throughout the message processing pipeline.
+    /// </para>
+    /// </remarks>
+    public ClaimsPrincipal? User { get; set; }
+}

--- a/src/ModelContextProtocol.Core/Protocol/JsonRpcRequest.cs
+++ b/src/ModelContextProtocol.Core/Protocol/JsonRpcRequest.cs
@@ -9,7 +9,7 @@ namespace ModelContextProtocol.Protocol;
 /// <remarks>
 /// Requests are messages that require a response from the receiver. Each request includes a unique ID
 /// that will be included in the corresponding response message (either a success response or an error).
-/// 
+///
 /// The receiver of a request message is expected to execute the specified method with the provided parameters
 /// and return either a <see cref="JsonRpcResponse"/> with the result, or a <see cref="JsonRpcError"/>
 /// if the method execution fails.
@@ -36,7 +36,7 @@ public sealed class JsonRpcRequest : JsonRpcMessageWithId
             Id = id,
             Method = Method,
             Params = Params,
-            RelatedTransport = RelatedTransport,
+            Context = Context,
         };
     }
 }

--- a/src/ModelContextProtocol.Core/Protocol/LoggingCapability.cs
+++ b/src/ModelContextProtocol.Core/Protocol/LoggingCapability.cs
@@ -18,5 +18,5 @@ public sealed class LoggingCapability
     /// Gets or sets the handler for set logging level requests from clients.
     /// </summary>
     [JsonIgnore]
-    public Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>? SetLoggingLevelHandler { get; set; }
+    public McpRequestHandler<SetLevelRequestParams, EmptyResult>? SetLoggingLevelHandler { get; set; }
 }

--- a/src/ModelContextProtocol.Core/Protocol/Prompt.cs
+++ b/src/ModelContextProtocol.Core/Protocol/Prompt.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
 
 namespace ModelContextProtocol.Protocol;
 
@@ -59,4 +60,10 @@ public sealed class Prompt : IBaseMetadata
     /// </remarks>
     [JsonPropertyName("_meta")]
     public JsonObject? Meta { get; set; }
+
+    /// <summary>
+    /// Gets or sets the callable server prompt corresponding to this metadata if any.
+    /// </summary>
+    [JsonIgnore]
+    public McpServerPrompt? McpServerPrompt { get; set; }
 }

--- a/src/ModelContextProtocol.Core/Protocol/PromptsCapability.cs
+++ b/src/ModelContextProtocol.Core/Protocol/PromptsCapability.cs
@@ -22,10 +22,10 @@ public sealed class PromptsCapability
     /// Gets or sets whether this server supports notifications for changes to the prompt list.
     /// </summary>
     /// <remarks>
-    /// When set to <see langword="true"/>, the server will send notifications using 
-    /// <see cref="NotificationMethods.PromptListChangedNotification"/> when prompts are added, 
+    /// When set to <see langword="true"/>, the server will send notifications using
+    /// <see cref="NotificationMethods.PromptListChangedNotification"/> when prompts are added,
     /// removed, or modified. Clients can register handlers for these notifications to
-    /// refresh their prompt cache. This capability enables clients to stay synchronized with server-side changes 
+    /// refresh their prompt cache. This capability enables clients to stay synchronized with server-side changes
     /// to available prompts.
     /// </remarks>
     [JsonPropertyName("listChanged")]
@@ -40,15 +40,15 @@ public sealed class PromptsCapability
     /// along with any prompts defined in <see cref="PromptCollection"/>.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>? ListPromptsHandler { get; set; }
+    public McpRequestHandler<ListPromptsRequestParams, ListPromptsResult>? ListPromptsHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.PromptsGet"/> requests.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This handler is invoked when a client requests details for a specific prompt by name and provides arguments 
-    /// for the prompt if needed. The handler receives the request context containing the prompt name and any arguments, 
+    /// This handler is invoked when a client requests details for a specific prompt by name and provides arguments
+    /// for the prompt if needed. The handler receives the request context containing the prompt name and any arguments,
     /// and should return a <see cref="GetPromptResult"/> with the prompt messages and other details.
     /// </para>
     /// <para>
@@ -57,7 +57,7 @@ public sealed class PromptsCapability
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>? GetPromptHandler { get; set; }
+    public McpRequestHandler<GetPromptRequestParams, GetPromptResult>? GetPromptHandler { get; set; }
 
     /// <summary>
     /// Gets or sets a collection of prompts that will be served by the server.
@@ -69,7 +69,7 @@ public sealed class PromptsCapability
     /// when those are provided:
     /// </para>
     /// <para>
-    /// - For <see cref="RequestMethods.PromptsList"/> requests: The server returns all prompts from this collection 
+    /// - For <see cref="RequestMethods.PromptsList"/> requests: The server returns all prompts from this collection
     ///   plus any additional prompts provided by the <see cref="ListPromptsHandler"/> if it's set.
     /// </para>
     /// <para>

--- a/src/ModelContextProtocol.Core/Protocol/Resource.cs
+++ b/src/ModelContextProtocol.Core/Protocol/Resource.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
 
 namespace ModelContextProtocol.Protocol;
 
@@ -87,4 +88,10 @@ public sealed class Resource : IBaseMetadata
     /// </remarks>
     [JsonPropertyName("_meta")]
     public JsonObject? Meta { get; init; }
+
+    /// <summary>
+    /// Gets or sets the callable server resource corresponding to this metadata if any.
+    /// </summary>
+    [JsonIgnore]
+    public McpServerResource? McpServerResource { get; set; }
 }

--- a/src/ModelContextProtocol.Core/Protocol/ResourceTemplate.cs
+++ b/src/ModelContextProtocol.Core/Protocol/ResourceTemplate.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
 
 namespace ModelContextProtocol.Protocol;
 
@@ -84,6 +85,12 @@ public sealed class ResourceTemplate : IBaseMetadata
     [JsonIgnore]
     public bool IsTemplated => UriTemplate.Contains('{');
 
+    /// <summary>
+    /// Gets or sets the callable server resource corresponding to this metadata if any.
+    /// </summary>
+    [JsonIgnore]
+    public McpServerResource? McpServerResource { get; set; }
+
     /// <summary>Converts the <see cref="ResourceTemplate"/> into a <see cref="Resource"/>.</summary>
     /// <returns>A <see cref="Resource"/> if <see cref="IsTemplated"/> is <see langword="false"/>; otherwise, <see langword="null"/>.</returns>
     public Resource? AsResource()
@@ -102,6 +109,7 @@ public sealed class ResourceTemplate : IBaseMetadata
             MimeType = MimeType,
             Annotations = Annotations,
             Meta = Meta,
+            McpServerResource = McpServerResource,
         };
     }
 }

--- a/src/ModelContextProtocol.Core/Protocol/ResourcesCapability.cs
+++ b/src/ModelContextProtocol.Core/Protocol/ResourcesCapability.cs
@@ -21,8 +21,8 @@ public sealed class ResourcesCapability
     /// Gets or sets whether this server supports notifications for changes to the resource list.
     /// </summary>
     /// <remarks>
-    /// When set to <see langword="true"/>, the server will send notifications using 
-    /// <see cref="NotificationMethods.ResourceListChangedNotification"/> when resources are added, 
+    /// When set to <see langword="true"/>, the server will send notifications using
+    /// <see cref="NotificationMethods.ResourceListChangedNotification"/> when resources are added,
     /// removed, or modified. Clients can register handlers for these notifications to
     /// refresh their resource cache.
     /// </remarks>
@@ -39,7 +39,7 @@ public sealed class ResourcesCapability
     /// allowing clients to discover available resource types and their access patterns.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>? ListResourceTemplatesHandler { get; set; }
+    public McpRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>? ListResourceTemplatesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesList"/> requests.
@@ -49,7 +49,7 @@ public sealed class ResourcesCapability
     /// The implementation should return a <see cref="ListResourcesResult"/> with the matching resources.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>? ListResourcesHandler { get; set; }
+    public McpRequestHandler<ListResourcesRequestParams, ListResourcesResult>? ListResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesRead"/> requests.
@@ -61,7 +61,7 @@ public sealed class ResourcesCapability
     /// its contents in a ReadResourceResult object.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>? ReadResourceHandler { get; set; }
+    public McpRequestHandler<ReadResourceRequestParams, ReadResourceResult>? ReadResourceHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesSubscribe"/> requests.
@@ -74,7 +74,7 @@ public sealed class ResourcesCapability
     /// requiring polling.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>? SubscribeToResourcesHandler { get; set; }
+    public McpRequestHandler<SubscribeRequestParams, EmptyResult>? SubscribeToResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesUnsubscribe"/> requests.
@@ -85,7 +85,7 @@ public sealed class ResourcesCapability
     /// about the specified resource.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>? UnsubscribeFromResourcesHandler { get; set; }
+    public McpRequestHandler<UnsubscribeRequestParams, EmptyResult>? UnsubscribeFromResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets a collection of resources served by the server.

--- a/src/ModelContextProtocol.Core/Protocol/Tool.cs
+++ b/src/ModelContextProtocol.Core/Protocol/Tool.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
 
 namespace ModelContextProtocol.Protocol;
 
@@ -43,7 +44,7 @@ public sealed class Tool : IBaseMetadata
     /// if an invalid schema is provided.
     /// </para>
     /// <para>
-    /// The schema typically defines the properties (parameters) that the tool accepts, 
+    /// The schema typically defines the properties (parameters) that the tool accepts,
     /// their types, and which ones are required. This helps AI models understand
     /// how to structure their calls to the tool.
     /// </para>
@@ -52,9 +53,9 @@ public sealed class Tool : IBaseMetadata
     /// </para>
     /// </remarks>
     [JsonPropertyName("inputSchema")]
-    public JsonElement InputSchema  
-    { 
-        get => field; 
+    public JsonElement InputSchema
+    {
+        get => field;
         set
         {
             if (!McpJsonUtilities.IsValidMcpToolSchema(value))
@@ -114,4 +115,10 @@ public sealed class Tool : IBaseMetadata
     /// </remarks>
     [JsonPropertyName("_meta")]
     public JsonObject? Meta { get; set; }
+
+    /// <summary>
+    /// Gets or sets the callable server tool corresponding to this metadata if any.
+    /// </summary>
+    [JsonIgnore]
+    public McpServerTool? McpServerTool { get; set; }
 }

--- a/src/ModelContextProtocol.Core/Protocol/ToolsCapability.cs
+++ b/src/ModelContextProtocol.Core/Protocol/ToolsCapability.cs
@@ -13,10 +13,10 @@ public sealed class ToolsCapability
     /// Gets or sets whether this server supports notifications for changes to the tool list.
     /// </summary>
     /// <remarks>
-    /// When set to <see langword="true"/>, the server will send notifications using 
-    /// <see cref="NotificationMethods.ToolListChangedNotification"/> when tools are added, 
+    /// When set to <see langword="true"/>, the server will send notifications using
+    /// <see cref="NotificationMethods.ToolListChangedNotification"/> when tools are added,
     /// removed, or modified. Clients can register handlers for these notifications to
-    /// refresh their tool cache. This capability enables clients to stay synchronized with server-side 
+    /// refresh their tool cache. This capability enables clients to stay synchronized with server-side
     /// changes to available tools.
     /// </remarks>
     [JsonPropertyName("listChanged")]
@@ -33,19 +33,19 @@ public sealed class ToolsCapability
     /// and the tools from the collection will be combined to form the complete list of available tools.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>? ListToolsHandler { get; set; }
+    public McpRequestHandler<ListToolsRequestParams, ListToolsResult>? ListToolsHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ToolsCall"/> requests.
     /// </summary>
     /// <remarks>
     /// This handler is invoked when a client makes a call to a tool that isn't found in the <see cref="ToolCollection"/>.
-    /// The handler should implement logic to execute the requested tool and return appropriate results. 
-    /// It receives a <see cref="RequestContext{CallToolRequestParams}"/> containing information about the tool 
+    /// The handler should implement logic to execute the requested tool and return appropriate results.
+    /// It receives a <see cref="RequestContext{CallToolRequestParams}"/> containing information about the tool
     /// being called and its arguments, and should return a <see cref="CallToolResult"/> with the execution results.
     /// </remarks>
     [JsonIgnore]
-    public Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>>? CallToolHandler { get; set; }
+    public McpRequestHandler<CallToolRequestParams, CallToolResult>? CallToolHandler { get; set; }
 
     /// <summary>
     /// Gets or sets a collection of tools served by the server.

--- a/src/ModelContextProtocol.Core/RequestHandlers.cs
+++ b/src/ModelContextProtocol.Core/RequestHandlers.cs
@@ -23,13 +23,13 @@ internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, 
     /// deserialized request parameters.
     /// </para>
     /// <para>
-    /// The handler function receives the deserialized request object and a cancellation token, and should return
-    /// a response object that will be serialized back to the client.
+    /// The handler function receives the deserialized request object, the full JSON-RPC request, and a cancellation token,
+    /// and should return a response object that will be serialized back to the client.
     /// </para>
     /// </remarks>
     public void Set<TRequest, TResponse>(
         string method,
-        Func<TRequest?, ITransport?, CancellationToken, ValueTask<TResponse>> handler,
+        Func<TRequest?, JsonRpcRequest, CancellationToken, ValueTask<TResponse>> handler,
         JsonTypeInfo<TRequest> requestTypeInfo,
         JsonTypeInfo<TResponse> responseTypeInfo)
     {
@@ -41,7 +41,7 @@ internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, 
         this[method] = async (request, cancellationToken) =>
         {
             TRequest? typedRequest = JsonSerializer.Deserialize(request.Params, requestTypeInfo);
-            object? result = await handler(typedRequest, request.RelatedTransport, cancellationToken).ConfigureAwait(false);
+            object? result = await handler(typedRequest, request, cancellationToken).ConfigureAwait(false);
             return JsonSerializer.SerializeToNode(result, responseTypeInfo);
         };
     }

--- a/src/ModelContextProtocol.Core/RequestHandlers.cs
+++ b/src/ModelContextProtocol.Core/RequestHandlers.cs
@@ -10,8 +10,8 @@ internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, 
     /// <summary>
     /// Registers a handler for incoming requests of a specific method in the MCP protocol.
     /// </summary>
-    /// <typeparam name="TRequest">Type of request payload that will be deserialized from incoming JSON</typeparam>
-    /// <typeparam name="TResponse">Type of response payload that will be serialized to JSON (not full RPC response)</typeparam>
+    /// <typeparam name="TParams">Type of request payload that will be deserialized from incoming JSON</typeparam>
+    /// <typeparam name="TResult">Type of response payload that will be serialized to JSON (not full RPC response)</typeparam>
     /// <param name="method">Method identifier to register for (e.g., "tools/list", "logging/setLevel")</param>
     /// <param name="handler">Handler function to be called when a request with the specified method identifier is received</param>
     /// <param name="requestTypeInfo">The JSON contract governing request parameter deserialization</param>
@@ -27,11 +27,11 @@ internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, 
     /// and should return a response object that will be serialized back to the client.
     /// </para>
     /// </remarks>
-    public void Set<TRequest, TResponse>(
+    public void Set<TParams, TResult>(
         string method,
-        Func<TRequest?, JsonRpcRequest, CancellationToken, ValueTask<TResponse>> handler,
-        JsonTypeInfo<TRequest> requestTypeInfo,
-        JsonTypeInfo<TResponse> responseTypeInfo)
+        Func<TParams?, JsonRpcRequest, CancellationToken, ValueTask<TResult>> handler,
+        JsonTypeInfo<TParams> requestTypeInfo,
+        JsonTypeInfo<TResult> responseTypeInfo)
     {
         Throw.IfNull(method);
         Throw.IfNull(handler);
@@ -40,7 +40,7 @@ internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, 
 
         this[method] = async (request, cancellationToken) =>
         {
-            TRequest? typedRequest = JsonSerializer.Deserialize(request.Params, requestTypeInfo);
+            TParams? typedRequest = JsonSerializer.Deserialize(request.Params, requestTypeInfo);
             object? result = await handler(typedRequest, request, cancellationToken).ConfigureAwait(false);
             return JsonSerializer.SerializeToNode(result, responseTypeInfo);
         };

--- a/src/ModelContextProtocol.Core/Server/DestinationBoundMcpServer.cs
+++ b/src/ModelContextProtocol.Core/Server/DestinationBoundMcpServer.cs
@@ -22,15 +22,25 @@ internal sealed class DestinationBoundMcpServer(McpServer server, ITransport? tr
 
     public Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
     {
-        Debug.Assert(message.RelatedTransport is null);
-        message.RelatedTransport = transport;
+        if (message.Context is not null)
+        {
+            throw new ArgumentException("Only transports can provide a JsonRpcMessageContext.");
+        }
+
+        message.Context = new JsonRpcMessageContext();
+        message.Context.RelatedTransport = transport;
         return server.SendMessageAsync(message, cancellationToken);
     }
 
     public Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken = default)
     {
-        Debug.Assert(request.RelatedTransport is null);
-        request.RelatedTransport = transport;
+        if (request.Context is not null)
+        {
+            throw new ArgumentException("Only transports can provide a JsonRpcMessageContext.");
+        }
+
+        request.Context = new JsonRpcMessageContext();
+        request.Context.RelatedTransport = transport;
         return server.SendRequestAsync(request, cancellationToken);
     }
 }

--- a/src/ModelContextProtocol.Core/Server/IMcpServerPrimitive.cs
+++ b/src/ModelContextProtocol.Core/Server/IMcpServerPrimitive.cs
@@ -7,4 +7,13 @@ public interface IMcpServerPrimitive
 {
     /// <summary>Gets the unique identifier of the primitive.</summary>
     string Id { get; }
+
+    /// <summary>
+    /// Gets the metadata for this primitive instance.
+    /// </summary>
+    /// <remarks>
+    /// Contains attributes from the associated MethodInfo and declaring class (if any),
+    /// with class-level attributes appearing before method-level attributes.
+    /// </remarks>
+    IReadOnlyList<object> Metadata { get; }
 }

--- a/src/ModelContextProtocol.Core/Server/McpRequestFilter.cs
+++ b/src/ModelContextProtocol.Core/Server/McpRequestFilter.cs
@@ -1,0 +1,11 @@
+namespace ModelContextProtocol.Server;
+
+/// <summary>
+/// Delegate type for applying filters to incoming MCP requests with specific parameter and result types.
+/// </summary>
+/// <typeparam name="TParams">The type of the parameters sent with the request.</typeparam>
+/// <typeparam name="TResult">The type of the response returned by the handler.</typeparam>
+/// <param name="next">The next request handler in the pipeline.</param>
+/// <returns>The next request handler wrapped with the filter.</returns>
+public delegate McpRequestHandler<TParams, TResult> McpRequestFilter<TParams, TResult>(
+    McpRequestHandler<TParams, TResult> next);

--- a/src/ModelContextProtocol.Core/Server/McpRequestHandler.cs
+++ b/src/ModelContextProtocol.Core/Server/McpRequestHandler.cs
@@ -1,0 +1,13 @@
+namespace ModelContextProtocol.Server;
+
+/// <summary>
+/// Delegate type for handling incoming MCP requests with specific parameter and result types.
+/// </summary>
+/// <typeparam name="TParams">The type of the parameters sent with the request.</typeparam>
+/// <typeparam name="TResult">The type of the response returned by the handler.</typeparam>
+/// <param name="request">The request context containing the parameters and other metadata.</param>
+/// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+/// <returns>A task representing the asynchronous operation, with the result of the handler.</returns>
+public delegate ValueTask<TResult> McpRequestHandler<TParams, TResult>(
+    RequestContext<TParams> request,
+    CancellationToken cancellationToken);

--- a/src/ModelContextProtocol.Core/Server/McpServer.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServer.cs
@@ -667,18 +667,22 @@ internal sealed partial class McpServer : McpEndpoint, IMcpServer
         McpRequestFilter<TParams, TResult>? finalHandler = null)
     {
         var current = baseHandler;
+
         if (finalHandler is not null)
         {
             current = finalHandler(current);
         }
+
         for (int i = filters.Count - 1; i >= 0; i--)
         {
             current = filters[i](current);
         }
+
         if (initialHandler is not null)
         {
             current = initialHandler(current);
         }
+
         return current;
     }
 

--- a/src/ModelContextProtocol.Core/Server/McpServerFilters.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerFilters.cs
@@ -1,0 +1,161 @@
+using ModelContextProtocol.Protocol;
+
+namespace ModelContextProtocol.Server;
+
+/// <summary>
+/// Provides filter collections for MCP server handlers.
+/// </summary>
+/// <remarks>
+/// This class contains collections of filters that can be applied to various MCP server handlers.
+/// This allows for middleware-style composition where filters can perform actions before and after the inner handler.
+/// </remarks>
+public sealed class McpServerFilters
+{
+    /// <summary>
+    /// Gets the filters for the list tools handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These filters wrap handlers that return a list of available tools when requested by a client.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ToolsList"/> requests. It supports pagination through the cursor mechanism,
+    /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more tools.
+    /// </para>
+    /// <para>
+    /// These filters work alongside any tools defined in the <see cref="McpServerTool"/> collection.
+    /// Tools from both sources will be combined when returning results to clients.
+    /// </para>
+    /// </remarks>
+    public List<Func<Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>, Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>>> ListToolsFilters { get; } = new();
+
+    /// <summary>
+    /// Gets the filters for the call tool handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// These filters wrap handlers that are invoked when a client makes a call to a tool that isn't found in the <see cref="McpServerTool"/> collection.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ToolsCall"/> requests. The handler should implement logic to execute the requested tool and return appropriate results.
+    /// </remarks>
+    public List<Func<Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>>, Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>>>> CallToolFilters { get; } = new();
+
+    /// <summary>
+    /// Gets the filters for the list prompts handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These filters wrap handlers that return a list of available prompts when requested by a client.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.PromptsList"/> requests. It supports pagination through the cursor mechanism,
+    /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more prompts.
+    /// </para>
+    /// <para>
+    /// These filters work alongside any prompts defined in the <see cref="McpServerPrompt"/> collection.
+    /// Prompts from both sources will be combined when returning results to clients.
+    /// </para>
+    /// </remarks>
+    public List<Func<Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>, Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>>> ListPromptsFilters { get; } = new();
+
+    /// <summary>
+    /// Gets the filters for the get prompt handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// These filters wrap handlers that are invoked when a client requests details for a specific prompt that isn't found in the <see cref="McpServerPrompt"/> collection.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.PromptsGet"/> requests. The handler should implement logic to fetch or generate the requested prompt and return appropriate results.
+    /// </remarks>
+    public List<Func<Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>, Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>>> GetPromptFilters { get; } = new();
+
+    /// <summary>
+    /// Gets the filters for the list resource templates handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// These filters wrap handlers that return a list of available resource templates when requested by a client.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ResourcesTemplatesList"/> requests. It supports pagination through the cursor mechanism,
+    /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more resource templates.
+    /// </remarks>
+    public List<Func<Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>, Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>>> ListResourceTemplatesFilters { get; } = new();
+
+    /// <summary>
+    /// Gets the filters for the list resources handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// These filters wrap handlers that return a list of available resources when requested by a client.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ResourcesList"/> requests. It supports pagination through the cursor mechanism,
+    /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more resources.
+    /// </remarks>
+    public List<Func<Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>, Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>>> ListResourcesFilters { get; } = new();
+
+    /// <summary>
+    /// Gets the filters for the read resource handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// These filters wrap handlers that are invoked when a client requests the content of a specific resource identified by its URI.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ResourcesRead"/> requests. The handler should implement logic to locate and retrieve the requested resource.
+    /// </remarks>
+    public List<Func<Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>, Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>>> ReadResourceFilters { get; } = new();
+
+    /// <summary>
+    /// Gets the filters for the complete handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// These filters wrap handlers that provide auto-completion suggestions for prompt arguments or resource references in the Model Context Protocol.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.CompletionComplete"/> requests. The handler processes auto-completion requests, returning a list of suggestions based on the
+    /// reference type and current argument value.
+    /// </remarks>
+    public List<Func<Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>, Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>>> CompleteFilters { get; } = new();
+
+    /// <summary>
+    /// Gets the filters for the subscribe to resources handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These filters wrap handlers that are invoked when a client wants to receive notifications about changes to specific resources or resource patterns.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ResourcesSubscribe"/> requests. The handler should implement logic to register the client's interest in the specified resources
+    /// and set up the necessary infrastructure to send notifications when those resources change.
+    /// </para>
+    /// <para>
+    /// After a successful subscription, the server should send resource change notifications to the client
+    /// whenever a relevant resource is created, updated, or deleted.
+    /// </para>
+    /// </remarks>
+    public List<Func<Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>>> SubscribeToResourcesFilters { get; } = new();
+
+    /// <summary>
+    /// Gets the filters for the unsubscribe from resources handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These filters wrap handlers that are invoked when a client wants to stop receiving notifications about previously subscribed resources.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ResourcesUnsubscribe"/> requests. The handler should implement logic to remove the client's subscriptions to the specified resources
+    /// and clean up any associated resources.
+    /// </para>
+    /// <para>
+    /// After a successful unsubscription, the server should no longer send resource change notifications
+    /// to the client for the specified resources.
+    /// </para>
+    /// </remarks>
+    public List<Func<Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>>> UnsubscribeFromResourcesFilters { get; } = new();
+
+    /// <summary>
+    /// Gets the filters for the set logging level handler pipeline.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These filters wrap handlers that process <see cref="RequestMethods.LoggingSetLevel"/> requests from clients. When set, it enables
+    /// clients to control which log messages they receive by specifying a minimum severity threshold.
+    /// The filters can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.LoggingSetLevel"/> requests.
+    /// </para>
+    /// <para>
+    /// After handling a level change request, the server typically begins sending log messages
+    /// at or above the specified level to the client as notifications/message notifications.
+    /// </para>
+    /// </remarks>
+    public List<Func<Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>>> SetLoggingLevelFilters { get; } = new();
+}

--- a/src/ModelContextProtocol.Core/Server/McpServerFilters.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerFilters.cs
@@ -26,7 +26,7 @@ public sealed class McpServerFilters
     /// Tools from both sources will be combined when returning results to clients.
     /// </para>
     /// </remarks>
-    public List<Func<Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>, Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>>> ListToolsFilters { get; } = new();
+    public List<McpRequestFilter<ListToolsRequestParams, ListToolsResult>> ListToolsFilters { get; } = new();
 
     /// <summary>
     /// Gets the filters for the call tool handler pipeline.
@@ -36,7 +36,7 @@ public sealed class McpServerFilters
     /// The filters can modify, log, or perform additional operations on requests and responses for
     /// <see cref="RequestMethods.ToolsCall"/> requests. The handler should implement logic to execute the requested tool and return appropriate results.
     /// </remarks>
-    public List<Func<Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>>, Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>>>> CallToolFilters { get; } = new();
+    public List<McpRequestFilter<CallToolRequestParams, CallToolResult>> CallToolFilters { get; } = new();
 
     /// <summary>
     /// Gets the filters for the list prompts handler pipeline.
@@ -53,7 +53,7 @@ public sealed class McpServerFilters
     /// Prompts from both sources will be combined when returning results to clients.
     /// </para>
     /// </remarks>
-    public List<Func<Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>, Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>>> ListPromptsFilters { get; } = new();
+    public List<McpRequestFilter<ListPromptsRequestParams, ListPromptsResult>> ListPromptsFilters { get; } = new();
 
     /// <summary>
     /// Gets the filters for the get prompt handler pipeline.
@@ -63,7 +63,7 @@ public sealed class McpServerFilters
     /// The filters can modify, log, or perform additional operations on requests and responses for
     /// <see cref="RequestMethods.PromptsGet"/> requests. The handler should implement logic to fetch or generate the requested prompt and return appropriate results.
     /// </remarks>
-    public List<Func<Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>, Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>>> GetPromptFilters { get; } = new();
+    public List<McpRequestFilter<GetPromptRequestParams, GetPromptResult>> GetPromptFilters { get; } = new();
 
     /// <summary>
     /// Gets the filters for the list resource templates handler pipeline.
@@ -74,7 +74,7 @@ public sealed class McpServerFilters
     /// <see cref="RequestMethods.ResourcesTemplatesList"/> requests. It supports pagination through the cursor mechanism,
     /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more resource templates.
     /// </remarks>
-    public List<Func<Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>, Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>>> ListResourceTemplatesFilters { get; } = new();
+    public List<McpRequestFilter<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>> ListResourceTemplatesFilters { get; } = new();
 
     /// <summary>
     /// Gets the filters for the list resources handler pipeline.
@@ -85,7 +85,7 @@ public sealed class McpServerFilters
     /// <see cref="RequestMethods.ResourcesList"/> requests. It supports pagination through the cursor mechanism,
     /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more resources.
     /// </remarks>
-    public List<Func<Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>, Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>>> ListResourcesFilters { get; } = new();
+    public List<McpRequestFilter<ListResourcesRequestParams, ListResourcesResult>> ListResourcesFilters { get; } = new();
 
     /// <summary>
     /// Gets the filters for the read resource handler pipeline.
@@ -95,7 +95,7 @@ public sealed class McpServerFilters
     /// The filters can modify, log, or perform additional operations on requests and responses for
     /// <see cref="RequestMethods.ResourcesRead"/> requests. The handler should implement logic to locate and retrieve the requested resource.
     /// </remarks>
-    public List<Func<Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>, Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>>> ReadResourceFilters { get; } = new();
+    public List<McpRequestFilter<ReadResourceRequestParams, ReadResourceResult>> ReadResourceFilters { get; } = new();
 
     /// <summary>
     /// Gets the filters for the complete handler pipeline.
@@ -106,7 +106,7 @@ public sealed class McpServerFilters
     /// <see cref="RequestMethods.CompletionComplete"/> requests. The handler processes auto-completion requests, returning a list of suggestions based on the
     /// reference type and current argument value.
     /// </remarks>
-    public List<Func<Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>, Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>>> CompleteFilters { get; } = new();
+    public List<McpRequestFilter<CompleteRequestParams, CompleteResult>> CompleteFilters { get; } = new();
 
     /// <summary>
     /// Gets the filters for the subscribe to resources handler pipeline.
@@ -123,7 +123,7 @@ public sealed class McpServerFilters
     /// whenever a relevant resource is created, updated, or deleted.
     /// </para>
     /// </remarks>
-    public List<Func<Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>>> SubscribeToResourcesFilters { get; } = new();
+    public List<McpRequestFilter<SubscribeRequestParams, EmptyResult>> SubscribeToResourcesFilters { get; } = new();
 
     /// <summary>
     /// Gets the filters for the unsubscribe from resources handler pipeline.
@@ -140,7 +140,7 @@ public sealed class McpServerFilters
     /// to the client for the specified resources.
     /// </para>
     /// </remarks>
-    public List<Func<Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>>> UnsubscribeFromResourcesFilters { get; } = new();
+    public List<McpRequestFilter<UnsubscribeRequestParams, EmptyResult>> UnsubscribeFromResourcesFilters { get; } = new();
 
     /// <summary>
     /// Gets the filters for the set logging level handler pipeline.
@@ -157,5 +157,5 @@ public sealed class McpServerFilters
     /// at or above the specified level to the client as notifications/message notifications.
     /// </para>
     /// </remarks>
-    public List<Func<Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>>> SetLoggingLevelFilters { get; } = new();
+    public List<McpRequestFilter<SetLevelRequestParams, EmptyResult>> SetLoggingLevelFilters { get; } = new();
 }

--- a/src/ModelContextProtocol.Core/Server/McpServerOptions.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerOptions.cs
@@ -79,4 +79,14 @@ public sealed class McpServerOptions
     /// </para>
     /// </remarks>
     public Implementation? KnownClientInfo { get; set; }
+
+    /// <summary>
+    /// Gets the filter collections for MCP server handlers.
+    /// </summary>
+    /// <remarks>
+    /// This property provides access to filter collections that can be used to modify the behavior 
+    /// of various MCP server handlers. Filters are applied in reverse order, so the last filter 
+    /// added will be the outermost (first to execute).
+    /// </remarks>
+    public McpServerFilters Filters { get; } = new();
 }

--- a/src/ModelContextProtocol.Core/Server/McpServerPrompt.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerPrompt.cs
@@ -20,7 +20,7 @@ namespace ModelContextProtocol.Server;
 /// </para>
 /// <para>
 /// Most commonly, <see cref="McpServerPrompt"/> instances are created using the static <see cref="M:McpServerPrompt.Create"/> methods.
-/// These methods enable creating an <see cref="McpServerPrompt"/> for a method, specified via a <see cref="Delegate"/> or 
+/// These methods enable creating an <see cref="McpServerPrompt"/> for a method, specified via a <see cref="Delegate"/> or
 /// <see cref="MethodInfo"/>, and are what are used implicitly by WithPromptsFromAssembly and WithPrompts. The <see cref="M:McpServerPrompt.Create"/> methods
 /// create <see cref="McpServerPrompt"/> instances capable of working with a large variety of .NET method signatures, automatically handling
 /// how parameters are marshaled into the method from the JSON received from the MCP client, and how the return value is marshaled back
@@ -61,15 +61,15 @@ namespace ModelContextProtocol.Server;
 ///   </item>
 ///   <item>
 ///     <description>
-///       When the <see cref="McpServerPrompt"/> is constructed, it may be passed an <see cref="IServiceProvider"/> via 
+///       When the <see cref="McpServerPrompt"/> is constructed, it may be passed an <see cref="IServiceProvider"/> via
 ///       <see cref="McpServerPromptCreateOptions.Services"/>. Any parameter that can be satisfied by that <see cref="IServiceProvider"/>
-///       according to <see cref="IServiceProviderIsService"/> will be resolved from the <see cref="IServiceProvider"/> provided to 
+///       according to <see cref="IServiceProviderIsService"/> will be resolved from the <see cref="IServiceProvider"/> provided to
 ///       <see cref="GetAsync"/> rather than from the argument collection.
 ///     </description>
 ///   </item>
 ///   <item>
 ///     <description>
-///       Any parameter attributed with <see cref="FromKeyedServicesAttribute"/> will similarly be resolved from the 
+///       Any parameter attributed with <see cref="FromKeyedServicesAttribute"/> will similarly be resolved from the
 ///       <see cref="IServiceProvider"/> provided to <see cref="GetAsync"/> rather than from the argument collection.
 ///     </description>
 ///   </item>
@@ -80,7 +80,7 @@ namespace ModelContextProtocol.Server;
 /// </para>
 /// <para>
 /// In general, the data supplied via the <see cref="GetPromptRequestParams.Arguments"/>'s dictionary is passed along from the caller and
-/// should thus be considered unvalidated and untrusted. To provide validated and trusted data to the invocation of the prompt, consider having 
+/// should thus be considered unvalidated and untrusted. To provide validated and trusted data to the invocation of the prompt, consider having
 /// the prompt be an instance method, referring to data stored in the instance, or using an instance or parameters resolved from the <see cref="IServiceProvider"/>
 /// to provide data to the method.
 /// </para>
@@ -129,6 +129,15 @@ public abstract class McpServerPrompt : IMcpServerPrimitive
     public abstract Prompt ProtocolPrompt { get; }
 
     /// <summary>
+    /// Gets the metadata for this prompt instance.
+    /// </summary>
+    /// <remarks>
+    /// Contains attributes from the associated MethodInfo and declaring class (if any),
+    /// with class-level attributes appearing before method-level attributes.
+    /// </remarks>
+    public abstract IReadOnlyList<object> Metadata { get; }
+
+    /// <summary>
     /// Gets the prompt, rendering it with the provided request parameters and returning the prompt result.
     /// </summary>
     /// <param name="request">
@@ -170,7 +179,7 @@ public abstract class McpServerPrompt : IMcpServerPrimitive
     /// <exception cref="ArgumentNullException"><paramref name="method"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="method"/> is an instance method but <paramref name="target"/> is <see langword="null"/>.</exception>
     public static McpServerPrompt Create(
-        MethodInfo method, 
+        MethodInfo method,
         object? target = null,
         McpServerPromptCreateOptions? options = null) =>
         AIFunctionMcpServerPrompt.Create(method, target, options);

--- a/src/ModelContextProtocol.Core/Server/McpServerPromptCreateOptions.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerPromptCreateOptions.cs
@@ -69,6 +69,15 @@ public sealed class McpServerPromptCreateOptions
     public AIJsonSchemaCreateOptions? SchemaCreateOptions { get; set; }
 
     /// <summary>
+    /// Gets or sets the metadata associated with the prompt.
+    /// </summary>
+    /// <remarks>
+    /// Metadata includes information such as the attributes extracted from the method and its declaring class.
+    /// If not provided, metadata will be automatically generated for methods created via reflection.
+    /// </remarks>
+    public IReadOnlyList<object>? Metadata { get; set; }
+
+    /// <summary>
     /// Creates a shallow clone of the current <see cref="McpServerPromptCreateOptions"/> instance.
     /// </summary>
     internal McpServerPromptCreateOptions Clone() =>
@@ -80,5 +89,6 @@ public sealed class McpServerPromptCreateOptions
             Description = Description,
             SerializerOptions = SerializerOptions,
             SchemaCreateOptions = SchemaCreateOptions,
+            Metadata = Metadata,
         };
 }

--- a/src/ModelContextProtocol.Core/Server/McpServerResource.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerResource.cs
@@ -11,13 +11,13 @@ namespace ModelContextProtocol.Server;
 /// <remarks>
 /// <para>
 /// <see cref="McpServerResource"/> is an abstract base class that represents an MCP resource for use in the server (as opposed
-/// to <see cref="Resource"/> or <see cref="ResourceTemplate"/>, which provide the protocol representations of a resource). Instances of 
+/// to <see cref="Resource"/> or <see cref="ResourceTemplate"/>, which provide the protocol representations of a resource). Instances of
 /// <see cref="McpServerResource"/> can be added into a <see cref="IServiceCollection"/> to be picked up automatically when
 /// <see cref="McpServerFactory"/> is used to create an <see cref="IMcpServer"/>, or added into a <see cref="McpServerPrimitiveCollection{McpServerResource}"/>.
 /// </para>
 /// <para>
 /// Most commonly, <see cref="McpServerResource"/> instances are created using the static <see cref="M:McpServerResource.Create"/> methods.
-/// These methods enable creating an <see cref="McpServerResource"/> for a method, specified via a <see cref="Delegate"/> or 
+/// These methods enable creating an <see cref="McpServerResource"/> for a method, specified via a <see cref="Delegate"/> or
 /// <see cref="MethodInfo"/>, and are what are used implicitly by WithResourcesFromAssembly and
 /// <see cref="M:McpServerBuilderExtensions.WithResources"/>. The <see cref="M:McpServerResource.Create"/> methods
 /// create <see cref="McpServerResource"/> instances capable of working with a large variety of .NET method signatures, automatically handling
@@ -62,15 +62,15 @@ namespace ModelContextProtocol.Server;
 ///   </item>
 ///   <item>
 ///     <description>
-///       When the <see cref="McpServerResource"/> is constructed, it may be passed an <see cref="IServiceProvider"/> via 
+///       When the <see cref="McpServerResource"/> is constructed, it may be passed an <see cref="IServiceProvider"/> via
 ///       <see cref="McpServerResourceCreateOptions.Services"/>. Any parameter that can be satisfied by that <see cref="IServiceProvider"/>
-///       according to <see cref="IServiceProviderIsService"/> will be resolved from the <see cref="IServiceProvider"/> provided to the 
+///       according to <see cref="IServiceProviderIsService"/> will be resolved from the <see cref="IServiceProvider"/> provided to the
 ///       resource invocation rather than from the argument collection.
 ///     </description>
 ///   </item>
 ///   <item>
 ///     <description>
-///       Any parameter attributed with <see cref="FromKeyedServicesAttribute"/> will similarly be resolved from the 
+///       Any parameter attributed with <see cref="FromKeyedServicesAttribute"/> will similarly be resolved from the
 ///       <see cref="IServiceProvider"/> provided to the resource invocation rather than from the argument collection.
 ///     </description>
 ///   </item>
@@ -150,6 +150,15 @@ public abstract class McpServerResource : IMcpServerPrimitive
     public virtual Resource? ProtocolResource => ProtocolResourceTemplate.AsResource();
 
     /// <summary>
+    /// Gets the metadata for this resource instance.
+    /// </summary>
+    /// <remarks>
+    /// Contains attributes from the associated MethodInfo and declaring class (if any),
+    /// with class-level attributes appearing before method-level attributes.
+    /// </remarks>
+    public abstract IReadOnlyList<object> Metadata { get; }
+
+    /// <summary>
     /// Gets the resource, rendering it with the provided request parameters and returning the resource result.
     /// </summary>
     /// <param name="request">
@@ -192,7 +201,7 @@ public abstract class McpServerResource : IMcpServerPrimitive
     /// <exception cref="ArgumentNullException"><paramref name="method"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="method"/> is an instance method but <paramref name="target"/> is <see langword="null"/>.</exception>
     public static McpServerResource Create(
-        MethodInfo method, 
+        MethodInfo method,
         object? target = null,
         McpServerResourceCreateOptions? options = null) =>
         AIFunctionMcpServerResource.Create(method, target, options);

--- a/src/ModelContextProtocol.Core/Server/McpServerResourceCreateOptions.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerResourceCreateOptions.cs
@@ -84,6 +84,15 @@ public sealed class McpServerResourceCreateOptions
     public AIJsonSchemaCreateOptions? SchemaCreateOptions { get; set; }
 
     /// <summary>
+    /// Gets or sets the metadata associated with the resource.
+    /// </summary>
+    /// <remarks>
+    /// Metadata includes information such as attributes extracted from the method and its declaring class.
+    /// If not provided, metadata will be automatically generated for methods created via reflection.
+    /// </remarks>
+    public IReadOnlyList<object>? Metadata { get; set; }
+
+    /// <summary>
     /// Creates a shallow clone of the current <see cref="McpServerResourceCreateOptions"/> instance.
     /// </summary>
     internal McpServerResourceCreateOptions Clone() =>
@@ -97,5 +106,6 @@ public sealed class McpServerResourceCreateOptions
             MimeType = MimeType,
             SerializerOptions = SerializerOptions,
             SchemaCreateOptions = SchemaCreateOptions,
+            Metadata = Metadata,
         };
 }

--- a/src/ModelContextProtocol.Core/Server/McpServerTool.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerTool.cs
@@ -20,7 +20,7 @@ namespace ModelContextProtocol.Server;
 /// </para>
 /// <para>
 /// Most commonly, <see cref="McpServerTool"/> instances are created using the static <see cref="M:McpServerTool.Create"/> methods.
-/// These methods enable creating an <see cref="McpServerTool"/> for a method, specified via a <see cref="Delegate"/> or 
+/// These methods enable creating an <see cref="McpServerTool"/> for a method, specified via a <see cref="Delegate"/> or
 /// <see cref="MethodInfo"/>, and are what are used implicitly by WithToolsFromAssembly and WithTools. The <see cref="M:McpServerTool.Create"/> methods
 /// create <see cref="McpServerTool"/> instances capable of working with a large variety of .NET method signatures, automatically handling
 /// how parameters are marshaled into the method from the JSON received from the MCP client, and how the return value is marshaled back
@@ -56,22 +56,22 @@ namespace ModelContextProtocol.Server;
 ///     <description>
 ///       <see cref="IProgress{ProgressNotificationValue}"/> parameters accepting <see cref="ProgressNotificationValue"/> values
 ///       are not included in the JSON schema and are bound to an <see cref="IProgress{ProgressNotificationValue}"/> instance manufactured
-///       to forward progress notifications from the tool to the client. If the client included a <see cref="ProgressToken"/> in their request, 
+///       to forward progress notifications from the tool to the client. If the client included a <see cref="ProgressToken"/> in their request,
 ///       progress reports issued to this instance will propagate to the client as <see cref="NotificationMethods.ProgressNotification"/> notifications with
 ///       that token. If the client did not include a <see cref="ProgressToken"/>, the instance will ignore any progress reports issued to it.
 ///     </description>
 ///   </item>
 ///   <item>
 ///     <description>
-///       When the <see cref="McpServerTool"/> is constructed, it may be passed an <see cref="IServiceProvider"/> via 
+///       When the <see cref="McpServerTool"/> is constructed, it may be passed an <see cref="IServiceProvider"/> via
 ///       <see cref="McpServerToolCreateOptions.Services"/>. Any parameter that can be satisfied by that <see cref="IServiceProvider"/>
-///       according to <see cref="IServiceProviderIsService"/> will not be included in the generated JSON schema and will be resolved 
+///       according to <see cref="IServiceProviderIsService"/> will not be included in the generated JSON schema and will be resolved
 ///       from the <see cref="IServiceProvider"/> provided to <see cref="InvokeAsync"/> rather than from the argument collection.
 ///     </description>
 ///   </item>
 ///   <item>
 ///     <description>
-///       Any parameter attributed with <see cref="FromKeyedServicesAttribute"/> will similarly be resolved from the 
+///       Any parameter attributed with <see cref="FromKeyedServicesAttribute"/> will similarly be resolved from the
 ///       <see cref="IServiceProvider"/> provided to <see cref="InvokeAsync"/> rather than from the argument
 ///       collection, and will not be included in the generated JSON schema.
 ///     </description>
@@ -79,13 +79,13 @@ namespace ModelContextProtocol.Server;
 /// </list>
 /// </para>
 /// <para>
-/// All other parameters are deserialized from the <see cref="JsonElement"/>s in the <see cref="CallToolRequestParams.Arguments"/> dictionary, 
-/// using the <see cref="JsonSerializerOptions"/> supplied in <see cref="McpServerToolCreateOptions.SerializerOptions"/>, or if none was provided, 
+/// All other parameters are deserialized from the <see cref="JsonElement"/>s in the <see cref="CallToolRequestParams.Arguments"/> dictionary,
+/// using the <see cref="JsonSerializerOptions"/> supplied in <see cref="McpServerToolCreateOptions.SerializerOptions"/>, or if none was provided,
 /// using <see cref="McpJsonUtilities.DefaultOptions"/>.
 /// </para>
 /// <para>
 /// In general, the data supplied via the <see cref="CallToolRequestParams.Arguments"/>'s dictionary is passed along from the caller and
-/// should thus be considered unvalidated and untrusted. To provide validated and trusted data to the invocation of the tool, consider having 
+/// should thus be considered unvalidated and untrusted. To provide validated and trusted data to the invocation of the tool, consider having
 /// the tool be an instance method, referring to data stored in the instance, or using an instance or parameters resolved from the <see cref="IServiceProvider"/>
 /// to provide data to the method.
 /// </para>
@@ -141,6 +141,15 @@ public abstract class McpServerTool : IMcpServerPrimitive
     /// <summary>Gets the protocol <see cref="Tool"/> type for this instance.</summary>
     public abstract Tool ProtocolTool { get; }
 
+    /// <summary>
+    /// Gets the metadata for this tool instance.
+    /// </summary>
+    /// <remarks>
+    /// Contains attributes from the associated MethodInfo and declaring class (if any),
+    /// with class-level attributes appearing before method-level attributes.
+    /// </remarks>
+    public abstract IReadOnlyList<object> Metadata { get; }
+
     /// <summary>Invokes the <see cref="McpServerTool"/>.</summary>
     /// <param name="request">The request information resulting in the invocation of this tool.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
@@ -172,7 +181,7 @@ public abstract class McpServerTool : IMcpServerPrimitive
     /// <exception cref="ArgumentNullException"><paramref name="method"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="method"/> is an instance method but <paramref name="target"/> is <see langword="null"/>.</exception>
     public static McpServerTool Create(
-        MethodInfo method, 
+        MethodInfo method,
         object? target = null,
         McpServerToolCreateOptions? options = null) =>
         AIFunctionMcpServerTool.Create(method, target, options);

--- a/src/ModelContextProtocol.Core/Server/McpServerToolCreateOptions.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerToolCreateOptions.cs
@@ -80,7 +80,7 @@ public sealed class McpServerToolCreateOptions
     public bool? Destructive { get; set; }
 
     /// <summary>
-    /// Gets or sets whether calling the tool repeatedly with the same arguments 
+    /// Gets or sets whether calling the tool repeatedly with the same arguments
     /// will have no additional effect on its environment.
     /// </summary>
     /// <remarks>
@@ -156,6 +156,15 @@ public sealed class McpServerToolCreateOptions
     public AIJsonSchemaCreateOptions? SchemaCreateOptions { get; set; }
 
     /// <summary>
+    /// Gets or sets the metadata associated with the tool.
+    /// </summary>
+    /// <remarks>
+    /// Metadata includes information such as attributes extracted from the method and its declaring class.
+    /// If not provided, metadata will be automatically generated for methods created via reflection.
+    /// </remarks>
+    public IReadOnlyList<object>? Metadata { get; set; }
+
+    /// <summary>
     /// Creates a shallow clone of the current <see cref="McpServerToolCreateOptions"/> instance.
     /// </summary>
     internal McpServerToolCreateOptions Clone() =>
@@ -172,5 +181,6 @@ public sealed class McpServerToolCreateOptions
             UseStructuredContent = UseStructuredContent,
             SerializerOptions = SerializerOptions,
             SchemaCreateOptions = SchemaCreateOptions,
+            Metadata = Metadata,
         };
 }

--- a/src/ModelContextProtocol.Core/Server/RequestContext.cs
+++ b/src/ModelContextProtocol.Core/Server/RequestContext.cs
@@ -1,3 +1,6 @@
+using System.Security.Claims;
+using ModelContextProtocol.Protocol;
+
 namespace ModelContextProtocol.Server;
 
 /// <summary>
@@ -15,19 +18,23 @@ public sealed class RequestContext<TParams>
     private IMcpServer _server;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="RequestContext{TParams}"/> class with the specified server.
+    /// Initializes a new instance of the <see cref="RequestContext{TParams}"/> class with the specified server and JSON-RPC request.
     /// </summary>
     /// <param name="server">The server with which this instance is associated.</param>
-    public RequestContext(IMcpServer server)
+    /// <param name="jsonRpcRequest">The JSON-RPC request associated with this context.</param>
+    public RequestContext(IMcpServer server, JsonRpcRequest jsonRpcRequest)
     {
         Throw.IfNull(server);
+        Throw.IfNull(jsonRpcRequest);
 
         _server = server;
+        JsonRpcRequest = jsonRpcRequest;
         Services = server.Services;
+        User = jsonRpcRequest.Context?.User;
     }
 
     /// <summary>Gets or sets the server with which this instance is associated.</summary>
-    public IMcpServer Server 
+    public IMcpServer Server
     {
         get => _server;
         set
@@ -46,6 +53,23 @@ public sealed class RequestContext<TParams>
     /// </remarks>
     public IServiceProvider? Services { get; set; }
 
+    /// <summary>Gets or sets the user associated with this request.</summary>
+    public ClaimsPrincipal? User { get; set; }
+
     /// <summary>Gets or sets the parameters associated with this request.</summary>
     public TParams? Params { get; set; }
+
+    /// <summary>
+    /// Gets or sets the primitive that matched the request.
+    /// </summary>
+    public IMcpServerPrimitive? MatchedPrimitive { get; set; }
+
+    /// <summary>
+    /// Gets the JSON-RPC request associated with this context.
+    /// </summary>
+    /// <remarks>
+    /// This property provides access to the complete JSON-RPC request that initiated this handler invocation,
+    /// including the method name, parameters, request ID, and associated transport and user information.
+    /// </remarks>
+    public JsonRpcRequest JsonRpcRequest { get; }
 }

--- a/src/ModelContextProtocol.Core/Server/RequestContext.cs
+++ b/src/ModelContextProtocol.Core/Server/RequestContext.cs
@@ -17,6 +17,8 @@ public sealed class RequestContext<TParams>
     /// <summary>The server with which this instance is associated.</summary>
     private IMcpServer _server;
 
+    private IDictionary<string, object?>? _items;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RequestContext{TParams}"/> class with the specified server and JSON-RPC request.
     /// </summary>
@@ -41,6 +43,21 @@ public sealed class RequestContext<TParams>
         {
             Throw.IfNull(value);
             _server = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a key/value collection that can be used to share data within the scope of this request.
+    /// </summary>
+    public IDictionary<string, object?> Items
+    {
+        get
+        {
+            return _items ??= new Dictionary<string, object?>();
+        }
+        set
+        {
+            _items = value;
         }
     }
 

--- a/src/ModelContextProtocol.Core/Server/SseWriter.cs
+++ b/src/ModelContextProtocol.Core/Server/SseWriter.cs
@@ -26,6 +26,8 @@ internal sealed class SseWriter(string? messageEndpoint = null, BoundedChannelOp
 
     public Task WriteAllAsync(Stream sseResponseStream, CancellationToken cancellationToken)
     {
+        Throw.IfNull(sseResponseStream);
+
         // When messageEndpoint is set, the very first SSE event isn't really an IJsonRpcMessage, but there's no API to write a single
         // item of a different type, so we fib and special-case the "endpoint" event type in the formatter.
         if (messageEndpoint is not null && !_messages.Writer.TryWrite(new SseItem<JsonRpcMessage?>(null, "endpoint")))

--- a/src/ModelContextProtocol.Core/Server/StreamableHttpPostTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamableHttpPostTransport.cs
@@ -1,7 +1,9 @@
 ﻿using ModelContextProtocol.Protocol;
+using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net.ServerSentEvents;
 using System.Runtime.CompilerServices;
+using System.Security.Claims;
 using System.Text.Json;
 using System.Threading.Channels;
 
@@ -9,14 +11,14 @@ namespace ModelContextProtocol.Server;
 
 /// <summary>
 /// Handles processing the request/response body pairs for the Streamable HTTP transport.
-/// This is typically used via <see cref="JsonRpcMessage.RelatedTransport"/>.
+/// This is typically used via <see cref="JsonRpcMessageContext.RelatedTransport"/>.
 /// </summary>
-internal sealed class StreamableHttpPostTransport(StreamableHttpServerTransport parentTransport, IDuplexPipe httpBodies) : ITransport
+internal sealed class StreamableHttpPostTransport(StreamableHttpServerTransport parentTransport, Stream responseStream) : ITransport
 {
     private readonly SseWriter _sseWriter = new();
     private RequestId _pendingRequest;
 
-    public ChannelReader<JsonRpcMessage> MessageReader => throw new NotSupportedException("JsonRpcMessage.RelatedTransport should only be used for sending messages.");
+    public ChannelReader<JsonRpcMessage> MessageReader => throw new NotSupportedException("JsonRpcMessage.Context.RelatedTransport should only be used for sending messages.");
 
     string? ITransport.SessionId => parentTransport.SessionId;
 
@@ -25,11 +27,31 @@ internal sealed class StreamableHttpPostTransport(StreamableHttpServerTransport 
     /// False, if nothing was written because the request body did not contain any <see cref="JsonRpcRequest"/> messages to respond to.
     /// The HTTP application should typically respond with an empty "202 Accepted" response in this scenario.
     /// </returns>
-    public async ValueTask<bool> RunAsync(CancellationToken cancellationToken)
+    public async ValueTask<bool> HandlePostAsync(JsonRpcMessage message, CancellationToken cancellationToken)
     {
-        var message = await JsonSerializer.DeserializeAsync(httpBodies.Input.AsStream(),
-            McpJsonUtilities.JsonContext.Default.JsonRpcMessage, cancellationToken).ConfigureAwait(false);
-        await OnMessageReceivedAsync(message, cancellationToken).ConfigureAwait(false);
+        Debug.Assert(_pendingRequest.Id is null);
+
+        if (message is JsonRpcRequest request)
+        {
+            _pendingRequest = request.Id;
+
+            // Invoke the initialize request callback if applicable.
+            if (parentTransport.OnInitRequestReceived is { } onInitRequest && request.Method == RequestMethods.Initialize)
+            {
+                var initializeRequest = JsonSerializer.Deserialize(request.Params, McpJsonUtilities.JsonContext.Default.InitializeRequestParams);
+                await onInitRequest(initializeRequest).ConfigureAwait(false);
+            }
+        }
+
+        message.Context ??= new JsonRpcMessageContext();
+        message.Context.RelatedTransport = this;
+
+        if (parentTransport.FlowExecutionContextFromRequests)
+        {
+            message.Context.ExecutionContext = ExecutionContext.Capture();
+        }
+
+        await parentTransport.MessageWriter.WriteAsync(message, cancellationToken).ConfigureAwait(false);
 
         if (_pendingRequest.Id is null)
         {
@@ -37,12 +59,14 @@ internal sealed class StreamableHttpPostTransport(StreamableHttpServerTransport 
         }
 
         _sseWriter.MessageFilter = StopOnFinalResponseFilter;
-        await _sseWriter.WriteAllAsync(httpBodies.Output.AsStream(), cancellationToken).ConfigureAwait(false);
+        await _sseWriter.WriteAllAsync(responseStream, cancellationToken).ConfigureAwait(false);
         return true;
     }
 
     public async Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
     {
+        Throw.IfNull(message);
+
         if (parentTransport.Stateless && message is JsonRpcRequest)
         {
             throw new InvalidOperationException("Server to client requests are not supported in stateless mode.");
@@ -68,34 +92,5 @@ internal sealed class StreamableHttpPostTransport(StreamableHttpServerTransport 
                 break;
             }
         }
-    }
-
-    private async ValueTask OnMessageReceivedAsync(JsonRpcMessage? message, CancellationToken cancellationToken)
-    {
-        if (message is null)
-        {
-            throw new InvalidOperationException("Received invalid null message.");
-        }
-
-        if (message is JsonRpcRequest request)
-        {
-            _pendingRequest = request.Id;
-
-            // Invoke the initialize request callback if applicable.
-            if (parentTransport.OnInitRequestReceived is { } onInitRequest && request.Method == RequestMethods.Initialize)
-            {
-                var initializeRequest = JsonSerializer.Deserialize(request.Params, McpJsonUtilities.JsonContext.Default.InitializeRequestParams);
-                await onInitRequest(initializeRequest).ConfigureAwait(false);
-            }
-        }
-
-        message.RelatedTransport = this;
-
-        if (parentTransport.FlowExecutionContextFromRequests)
-        {
-            message.ExecutionContext = ExecutionContext.Capture();
-        }
-
-        await parentTransport.MessageWriter.WriteAsync(message, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
@@ -1,5 +1,6 @@
 using ModelContextProtocol.Protocol;
 using System.IO.Pipelines;
+using System.Security.Claims;
 using System.Threading.Channels;
 
 namespace ModelContextProtocol.Server;
@@ -49,8 +50,8 @@ public sealed class StreamableHttpServerTransport : ITransport
     public bool Stateless { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether the execution context should flow from the calls to <see cref="HandlePostRequest(IDuplexPipe, CancellationToken)"/>
-    /// to the corresponding <see cref="JsonRpcMessage.ExecutionContext"/> emitted by the <see cref="MessageReader"/>.
+    /// Gets a value indicating whether the execution context should flow from the calls to <see cref="HandlePostRequest(JsonRpcMessage, Stream, CancellationToken)"/>
+    /// to the corresponding <see cref="JsonRpcMessageContext.ExecutionContext"/> property contained in the <see cref="JsonRpcMessage"/> instances returned by the <see cref="MessageReader"/>.
     /// </summary>
     /// <remarks>
     /// Defaults to <see langword="false"/>.
@@ -75,8 +76,10 @@ public sealed class StreamableHttpServerTransport : ITransport
     /// <param name="sseResponseStream">The response stream to write MCP JSON-RPC messages as SSE events to.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task representing the send loop that writes JSON-RPC messages to the SSE response stream.</returns>
-    public async Task HandleGetRequest(Stream sseResponseStream, CancellationToken cancellationToken)
+    public async Task HandleGetRequest(Stream sseResponseStream, CancellationToken cancellationToken = default)
     {
+        Throw.IfNull(sseResponseStream);
+
         if (Stateless)
         {
             throw new InvalidOperationException("GET requests are not supported in stateless mode.");
@@ -96,23 +99,33 @@ public sealed class StreamableHttpServerTransport : ITransport
     /// <see cref="JsonRpcResponse"/> and other correlated messages are sent back to the client directly in response
     /// to the <see cref="JsonRpcRequest"/> that initiated the message.
     /// </summary>
-    /// <param name="httpBodies">The duplex pipe facilitates the reading and writing of HTTP request and response data.</param>
-    /// <param name="cancellationToken">This token allows for the operation to be canceled if needed.</param>
+    /// <param name="message">The JSON-RPC message received from the client via the POST request body.</param>
+    /// <param name="cancellationToken">This token allows for the operation to be canceled if needed. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <param name="responseStream">The POST response body to write MCP JSON-RPC messages to.</param>
     /// <returns>
     /// True, if data was written to the response body.
     /// False, if nothing was written because the request body did not contain any <see cref="JsonRpcRequest"/> messages to respond to.
     /// The HTTP application should typically respond with an empty "202 Accepted" response in this scenario.
     /// </returns>
-    public async Task<bool> HandlePostRequest(IDuplexPipe httpBodies, CancellationToken cancellationToken)
+    /// <para>
+    /// If 's an authenticated <see cref="ClaimsPrincipal"/> sent the message, that can be included in the <see cref="JsonRpcMessage.Context"/>.
+    /// No other part of the context should be set.
+    /// </para>
+    public async Task<bool> HandlePostRequest(JsonRpcMessage message, Stream responseStream, CancellationToken cancellationToken = default)
     {
+        Throw.IfNull(message);
+        Throw.IfNull(responseStream);
+
         using var postCts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, cancellationToken);
-        await using var postTransport = new StreamableHttpPostTransport(this, httpBodies);
-        return await postTransport.RunAsync(postCts.Token).ConfigureAwait(false);
+        await using var postTransport = new StreamableHttpPostTransport(this, responseStream);
+        return await postTransport.HandlePostAsync(message, postCts.Token).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
     {
+        Throw.IfNull(message);
+
         if (Stateless)
         {
             throw new InvalidOperationException("Unsolicited server to client messages are not supported in stateless mode.");
@@ -126,6 +139,7 @@ public sealed class StreamableHttpServerTransport : ITransport
     {
         try
         {
+            _incomingChannel.Writer.TryComplete();
             await _disposeCts.CancelAsync();
         }
         finally

--- a/src/ModelContextProtocol/McpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol/McpServerBuilderExtensions.cs
@@ -707,6 +707,278 @@ public static partial class McpServerBuilderExtensions
     }
     #endregion
 
+    #region Filters
+    /// <summary>
+    /// Adds a filter to the list resource templates handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that return a list of available resource templates when requested by a client.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ResourcesTemplatesList"/> requests. It supports pagination through the cursor mechanism,
+    /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more resource templates.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddListResourceTemplatesFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>, Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.ListResourceTemplatesFilters.Add(filter));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a filter to the list tools handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that return a list of available tools when requested by a client.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ToolsList"/> requests. It supports pagination through the cursor mechanism,
+    /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more tools.
+    /// </para>
+    /// <para>
+    /// This filter works alongside any tools defined in the <see cref="McpServerTool"/> collection.
+    /// Tools from both sources will be combined when returning results to clients.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddListToolsFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>, Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.ListToolsFilters.Add(filter));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a filter to the call tool handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that are invoked when a client makes a call to a tool that isn't found in the <see cref="McpServerTool"/> collection.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ToolsCall"/> requests. The handler should implement logic to execute the requested tool and return appropriate results.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddCallToolFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>>, Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.CallToolFilters.Add(filter));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a filter to the list prompts handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that return a list of available prompts when requested by a client.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.PromptsList"/> requests. It supports pagination through the cursor mechanism,
+    /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more prompts.
+    /// </para>
+    /// <para>
+    /// This filter works alongside any prompts defined in the <see cref="McpServerPrompt"/> collection.
+    /// Prompts from both sources will be combined when returning results to clients.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddListPromptsFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>, Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.ListPromptsFilters.Add(filter));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a filter to the get prompt handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that are invoked when a client requests details for a specific prompt that isn't found in the <see cref="McpServerPrompt"/> collection.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.PromptsGet"/> requests. The handler should implement logic to fetch or generate the requested prompt and return appropriate results.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddGetPromptFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>, Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.GetPromptFilters.Add(filter));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a filter to the list resources handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that return a list of available resources when requested by a client.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ResourcesList"/> requests. It supports pagination through the cursor mechanism,
+    /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more resources.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddListResourcesFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>, Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.ListResourcesFilters.Add(filter));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a filter to the read resource handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that are invoked when a client requests the content of a specific resource identified by its URI.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ResourcesRead"/> requests. The handler should implement logic to locate and retrieve the requested resource.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddReadResourceFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>, Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.ReadResourceFilters.Add(filter));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a filter to the complete handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that provide auto-completion suggestions for prompt arguments or resource references in the Model Context Protocol.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.CompletionComplete"/> requests. The handler processes auto-completion requests, returning a list of suggestions based on the
+    /// reference type and current argument value.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddCompleteFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>, Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.CompleteFilters.Add(filter));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a filter to the subscribe to resources handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that are invoked when a client wants to receive notifications about changes to specific resources or resource patterns.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ResourcesSubscribe"/> requests. The handler should implement logic to register the client's interest in the specified resources
+    /// and set up the necessary infrastructure to send notifications when those resources change.
+    /// </para>
+    /// <para>
+    /// After a successful subscription, the server should send resource change notifications to the client
+    /// whenever a relevant resource is created, updated, or deleted.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddSubscribeToResourcesFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.SubscribeToResourcesFilters.Add(filter));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a filter to the unsubscribe from resources handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that are invoked when a client wants to stop receiving notifications about previously subscribed resources.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.ResourcesUnsubscribe"/> requests. The handler should implement logic to remove the client's subscriptions to the specified resources
+    /// and clean up any associated resources.
+    /// </para>
+    /// <para>
+    /// After a successful unsubscription, the server should no longer send resource change notifications
+    /// to the client for the specified resources.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddUnsubscribeFromResourcesFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.UnsubscribeFromResourcesFilters.Add(filter));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a filter to the set logging level handler pipeline.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="filter">The filter function that wraps the handler.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This filter wraps handlers that process <see cref="RequestMethods.LoggingSetLevel"/> requests from clients. When set, it enables
+    /// clients to control which log messages they receive by specifying a minimum severity threshold.
+    /// The filter can modify, log, or perform additional operations on requests and responses for
+    /// <see cref="RequestMethods.LoggingSetLevel"/> requests.
+    /// </para>
+    /// <para>
+    /// After handling a level change request, the server typically begins sending log messages
+    /// at or above the specified level to the client as notifications/message notifications.
+    /// </para>
+    /// </remarks>
+    public static IMcpServerBuilder AddSetLoggingLevelFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>> filter)
+    {
+        Throw.IfNull(builder);
+
+        builder.Services.Configure<McpServerOptions>(options => options.Filters.SetLoggingLevelFilters.Add(filter));
+        return builder;
+    }
+    #endregion
+
     #region Transports
     /// <summary>
     /// Adds a server transport that uses standard input (stdin) and standard output (stdout) for communication.

--- a/src/ModelContextProtocol/McpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol/McpServerBuilderExtensions.cs
@@ -91,7 +91,7 @@ public static partial class McpServerBuilderExtensions
             if (toolMethod.GetCustomAttribute<McpServerToolAttribute>() is not null)
             {
                 builder.Services.AddSingleton(services => McpServerTool.Create(
-                    toolMethod, 
+                    toolMethod,
                     toolMethod.IsStatic ? null : target,
                     new() { Services = services, SerializerOptions = serializerOptions }));
             }
@@ -585,7 +585,7 @@ public static partial class McpServerBuilderExtensions
     /// resource system where templates define the URI patterns and the read handler provides the actual content.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithListResourceTemplatesHandler(this IMcpServerBuilder builder, Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>> handler)
+    public static IMcpServerBuilder WithListResourceTemplatesHandler(this IMcpServerBuilder builder, McpRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -618,7 +618,7 @@ public static partial class McpServerBuilderExtensions
     /// executes them when invoked by clients.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithListToolsHandler(this IMcpServerBuilder builder, Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>> handler)
+    public static IMcpServerBuilder WithListToolsHandler(this IMcpServerBuilder builder, McpRequestHandler<ListToolsRequestParams, ListToolsResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -638,7 +638,7 @@ public static partial class McpServerBuilderExtensions
     /// This method is typically paired with <see cref="WithListToolsHandler"/> to provide a complete tools implementation,
     /// where <see cref="WithListToolsHandler"/> advertises available tools and this handler executes them.
     /// </remarks>
-    public static IMcpServerBuilder WithCallToolHandler(this IMcpServerBuilder builder, Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>> handler)
+    public static IMcpServerBuilder WithCallToolHandler(this IMcpServerBuilder builder, McpRequestHandler<CallToolRequestParams, CallToolResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -671,7 +671,7 @@ public static partial class McpServerBuilderExtensions
     /// produces them when invoked by clients.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithListPromptsHandler(this IMcpServerBuilder builder, Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>> handler)
+    public static IMcpServerBuilder WithListPromptsHandler(this IMcpServerBuilder builder, McpRequestHandler<ListPromptsRequestParams, ListPromptsResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -686,7 +686,7 @@ public static partial class McpServerBuilderExtensions
     /// <param name="handler">The handler function that processes prompt requests.</param>
     /// <returns>The builder provided in <paramref name="builder"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
-    public static IMcpServerBuilder WithGetPromptHandler(this IMcpServerBuilder builder, Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>> handler)
+    public static IMcpServerBuilder WithGetPromptHandler(this IMcpServerBuilder builder, McpRequestHandler<GetPromptRequestParams, GetPromptResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -707,7 +707,7 @@ public static partial class McpServerBuilderExtensions
     /// where this handler advertises available resources and the read handler provides their content when requested.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithListResourcesHandler(this IMcpServerBuilder builder, Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>> handler)
+    public static IMcpServerBuilder WithListResourcesHandler(this IMcpServerBuilder builder, McpRequestHandler<ListResourcesRequestParams, ListResourcesResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -726,7 +726,7 @@ public static partial class McpServerBuilderExtensions
     /// This handler is typically paired with <see cref="WithListResourcesHandler"/> to provide a complete resources implementation,
     /// where the list handler advertises available resources and the read handler provides their content when requested.
     /// </remarks>
-    public static IMcpServerBuilder WithReadResourceHandler(this IMcpServerBuilder builder, Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>> handler)
+    public static IMcpServerBuilder WithReadResourceHandler(this IMcpServerBuilder builder, McpRequestHandler<ReadResourceRequestParams, ReadResourceResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -745,7 +745,7 @@ public static partial class McpServerBuilderExtensions
     /// The completion handler is invoked when clients request suggestions for argument values.
     /// This enables auto-complete functionality for both prompt arguments and resource references.
     /// </remarks>
-    public static IMcpServerBuilder WithCompleteHandler(this IMcpServerBuilder builder, Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>> handler)
+    public static IMcpServerBuilder WithCompleteHandler(this IMcpServerBuilder builder, McpRequestHandler<CompleteRequestParams, CompleteResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -775,7 +775,7 @@ public static partial class McpServerBuilderExtensions
     /// resources and to send appropriate notifications through the connection when resources change.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithSubscribeToResourcesHandler(this IMcpServerBuilder builder, Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>> handler)
+    public static IMcpServerBuilder WithSubscribeToResourcesHandler(this IMcpServerBuilder builder, McpRequestHandler<SubscribeRequestParams, EmptyResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -805,7 +805,7 @@ public static partial class McpServerBuilderExtensions
     /// to the specified resource.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithUnsubscribeFromResourcesHandler(this IMcpServerBuilder builder, Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>> handler)
+    public static IMcpServerBuilder WithUnsubscribeFromResourcesHandler(this IMcpServerBuilder builder, McpRequestHandler<UnsubscribeRequestParams, EmptyResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -832,7 +832,7 @@ public static partial class McpServerBuilderExtensions
     /// most recently set level.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder WithSetLoggingLevelHandler(this IMcpServerBuilder builder, Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>> handler)
+    public static IMcpServerBuilder WithSetLoggingLevelHandler(this IMcpServerBuilder builder, McpRequestHandler<SetLevelRequestParams, EmptyResult> handler)
     {
         Throw.IfNull(builder);
 
@@ -857,7 +857,7 @@ public static partial class McpServerBuilderExtensions
     /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more resource templates.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddListResourceTemplatesFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>, Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>> filter)
+    public static IMcpServerBuilder AddListResourceTemplatesFilter(this IMcpServerBuilder builder, McpRequestFilter<ListResourceTemplatesRequestParams, ListResourceTemplatesResult> filter)
     {
         Throw.IfNull(builder);
 
@@ -884,7 +884,7 @@ public static partial class McpServerBuilderExtensions
     /// Tools from both sources will be combined when returning results to clients.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddListToolsFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>, Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>> filter)
+    public static IMcpServerBuilder AddListToolsFilter(this IMcpServerBuilder builder, McpRequestFilter<ListToolsRequestParams, ListToolsResult> filter)
     {
         Throw.IfNull(builder);
 
@@ -906,7 +906,7 @@ public static partial class McpServerBuilderExtensions
     /// <see cref="RequestMethods.ToolsCall"/> requests. The handler should implement logic to execute the requested tool and return appropriate results.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddCallToolFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>>, Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>>> filter)
+    public static IMcpServerBuilder AddCallToolFilter(this IMcpServerBuilder builder, McpRequestFilter<CallToolRequestParams, CallToolResult> filter)
     {
         Throw.IfNull(builder);
 
@@ -933,7 +933,7 @@ public static partial class McpServerBuilderExtensions
     /// Prompts from both sources will be combined when returning results to clients.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddListPromptsFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>, Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>> filter)
+    public static IMcpServerBuilder AddListPromptsFilter(this IMcpServerBuilder builder, McpRequestFilter<ListPromptsRequestParams, ListPromptsResult> filter)
     {
         Throw.IfNull(builder);
 
@@ -955,7 +955,7 @@ public static partial class McpServerBuilderExtensions
     /// <see cref="RequestMethods.PromptsGet"/> requests. The handler should implement logic to fetch or generate the requested prompt and return appropriate results.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddGetPromptFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>, Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>> filter)
+    public static IMcpServerBuilder AddGetPromptFilter(this IMcpServerBuilder builder, McpRequestFilter<GetPromptRequestParams, GetPromptResult> filter)
     {
         Throw.IfNull(builder);
 
@@ -978,7 +978,7 @@ public static partial class McpServerBuilderExtensions
     /// where the client can make repeated calls with the cursor returned by the previous call to retrieve more resources.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddListResourcesFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>, Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>> filter)
+    public static IMcpServerBuilder AddListResourcesFilter(this IMcpServerBuilder builder, McpRequestFilter<ListResourcesRequestParams, ListResourcesResult> filter)
     {
         Throw.IfNull(builder);
 
@@ -1000,7 +1000,7 @@ public static partial class McpServerBuilderExtensions
     /// <see cref="RequestMethods.ResourcesRead"/> requests. The handler should implement logic to locate and retrieve the requested resource.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddReadResourceFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>, Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>> filter)
+    public static IMcpServerBuilder AddReadResourceFilter(this IMcpServerBuilder builder, McpRequestFilter<ReadResourceRequestParams, ReadResourceResult> filter)
     {
         Throw.IfNull(builder);
 
@@ -1023,7 +1023,7 @@ public static partial class McpServerBuilderExtensions
     /// reference type and current argument value.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddCompleteFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>, Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>> filter)
+    public static IMcpServerBuilder AddCompleteFilter(this IMcpServerBuilder builder, McpRequestFilter<CompleteRequestParams, CompleteResult> filter)
     {
         Throw.IfNull(builder);
 
@@ -1050,7 +1050,7 @@ public static partial class McpServerBuilderExtensions
     /// whenever a relevant resource is created, updated, or deleted.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddSubscribeToResourcesFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>> filter)
+    public static IMcpServerBuilder AddSubscribeToResourcesFilter(this IMcpServerBuilder builder, McpRequestFilter<SubscribeRequestParams, EmptyResult> filter)
     {
         Throw.IfNull(builder);
 
@@ -1077,7 +1077,7 @@ public static partial class McpServerBuilderExtensions
     /// to the client for the specified resources.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddUnsubscribeFromResourcesFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>> filter)
+    public static IMcpServerBuilder AddUnsubscribeFromResourcesFilter(this IMcpServerBuilder builder, McpRequestFilter<UnsubscribeRequestParams, EmptyResult> filter)
     {
         Throw.IfNull(builder);
 
@@ -1104,7 +1104,7 @@ public static partial class McpServerBuilderExtensions
     /// at or above the specified level to the client as notifications/message notifications.
     /// </para>
     /// </remarks>
-    public static IMcpServerBuilder AddSetLoggingLevelFilter(this IMcpServerBuilder builder, Func<Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>, Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>> filter)
+    public static IMcpServerBuilder AddSetLoggingLevelFilter(this IMcpServerBuilder builder, McpRequestFilter<SetLevelRequestParams, EmptyResult> filter)
     {
         Throw.IfNull(builder);
 

--- a/src/ModelContextProtocol/McpServerHandlers.cs
+++ b/src/ModelContextProtocol/McpServerHandlers.cs
@@ -40,7 +40,7 @@ public sealed class McpServerHandlers
     /// Tools from both sources will be combined when returning results to clients.
     /// </para>
     /// </remarks>
-    public Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>>? ListToolsHandler { get; set; }
+    public McpRequestHandler<ListToolsRequestParams, ListToolsResult>? ListToolsHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ToolsCall"/> requests.
@@ -49,7 +49,7 @@ public sealed class McpServerHandlers
     /// This handler is invoked when a client makes a call to a tool that isn't found in the <see cref="McpServerTool"/> collection.
     /// The handler should implement logic to execute the requested tool and return appropriate results.
     /// </remarks>
-    public Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>>? CallToolHandler { get; set; }
+    public McpRequestHandler<CallToolRequestParams, CallToolResult>? CallToolHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.PromptsList"/> requests.
@@ -65,7 +65,7 @@ public sealed class McpServerHandlers
     /// Prompts from both sources will be combined when returning results to clients.
     /// </para>
     /// </remarks>
-    public Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>>? ListPromptsHandler { get; set; }
+    public McpRequestHandler<ListPromptsRequestParams, ListPromptsResult>? ListPromptsHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.PromptsGet"/> requests.
@@ -74,7 +74,7 @@ public sealed class McpServerHandlers
     /// This handler is invoked when a client requests details for a specific prompt that isn't found in the <see cref="McpServerPrompt"/> collection.
     /// The handler should implement logic to fetch or generate the requested prompt and return appropriate results.
     /// </remarks>
-    public Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>>? GetPromptHandler { get; set; }
+    public McpRequestHandler<GetPromptRequestParams, GetPromptResult>? GetPromptHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesTemplatesList"/> requests.
@@ -84,7 +84,7 @@ public sealed class McpServerHandlers
     /// It supports pagination through the cursor mechanism, where the client can make
     /// repeated calls with the cursor returned by the previous call to retrieve more resource templates.
     /// </remarks>
-    public Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>>? ListResourceTemplatesHandler { get; set; }
+    public McpRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult>? ListResourceTemplatesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesList"/> requests.
@@ -94,7 +94,7 @@ public sealed class McpServerHandlers
     /// It supports pagination through the cursor mechanism, where the client can make
     /// repeated calls with the cursor returned by the previous call to retrieve more resources.
     /// </remarks>
-    public Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>>? ListResourcesHandler { get; set; }
+    public McpRequestHandler<ListResourcesRequestParams, ListResourcesResult>? ListResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesRead"/> requests.
@@ -103,17 +103,17 @@ public sealed class McpServerHandlers
     /// This handler is invoked when a client requests the content of a specific resource identified by its URI.
     /// The handler should implement logic to locate and retrieve the requested resource.
     /// </remarks>
-    public Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>>? ReadResourceHandler { get; set; }
+    public McpRequestHandler<ReadResourceRequestParams, ReadResourceResult>? ReadResourceHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.CompletionComplete"/> requests.
     /// </summary>
     /// <remarks>
     /// This handler provides auto-completion suggestions for prompt arguments or resource references in the Model Context Protocol.
-    /// The handler processes auto-completion requests, returning a list of suggestions based on the 
+    /// The handler processes auto-completion requests, returning a list of suggestions based on the
     /// reference type and current argument value.
     /// </remarks>
-    public Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>>? CompleteHandler { get; set; }
+    public McpRequestHandler<CompleteRequestParams, CompleteResult>? CompleteHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesSubscribe"/> requests.
@@ -129,7 +129,7 @@ public sealed class McpServerHandlers
     /// whenever a relevant resource is created, updated, or deleted.
     /// </para>
     /// </remarks>
-    public Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>? SubscribeToResourcesHandler { get; set; }
+    public McpRequestHandler<SubscribeRequestParams, EmptyResult>? SubscribeToResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.ResourcesUnsubscribe"/> requests.
@@ -145,7 +145,7 @@ public sealed class McpServerHandlers
     /// to the client for the specified resources.
     /// </para>
     /// </remarks>
-    public Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>>? UnsubscribeFromResourcesHandler { get; set; }
+    public McpRequestHandler<UnsubscribeRequestParams, EmptyResult>? UnsubscribeFromResourcesHandler { get; set; }
 
     /// <summary>
     /// Gets or sets the handler for <see cref="RequestMethods.LoggingSetLevel"/> requests.
@@ -160,7 +160,7 @@ public sealed class McpServerHandlers
     /// at or above the specified level to the client as notifications/message notifications.
     /// </para>
     /// </remarks>
-    public Func<RequestContext<SetLevelRequestParams>, CancellationToken, ValueTask<EmptyResult>>? SetLoggingLevelHandler { get; set; }
+    public McpRequestHandler<SetLevelRequestParams, EmptyResult>? SetLoggingLevelHandler { get; set; }
 
     /// <summary>
     /// Overwrite any handlers in McpServerOptions with non-null handlers from this instance.

--- a/tests/ModelContextProtocol.AspNetCore.Tests/AuthorizeAttributeTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/AuthorizeAttributeTests.cs
@@ -1,0 +1,374 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.AspNetCore.Tests.Utils;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Security.Claims;
+
+namespace ModelContextProtocol.AspNetCore.Tests;
+
+/// <summary>
+/// Tests for MCP authorization functionality with [Authorize], [AllowAnonymous] and role-based authorization.
+/// </summary>
+public class AuthorizeAttributeTests(ITestOutputHelper testOutputHelper) : KestrelInMemoryTest(testOutputHelper)
+{
+    private async Task<IMcpClient> ConnectAsync()
+    {
+        await using var transport = new SseClientTransport(new SseClientTransportOptions
+        {
+            Endpoint = new("http://localhost:5000"),
+        }, HttpClient, LoggerFactory);
+
+        return await McpClientFactory.CreateAsync(transport, cancellationToken: TestContext.Current.CancellationToken, loggerFactory: LoggerFactory);
+    }
+
+    [Fact]
+    public async Task Authorize_Tool_RequiresAuthentication()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithTools<AuthorizationTestTools>());
+
+        var client = await ConnectAsync();
+        var result = await client.CallToolAsync(
+            "authorized_tool",
+            new Dictionary<string, object?> { ["message"] = "test" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Should return error because tool requires authorization but user is anonymous
+        Assert.True(result.IsError ?? false);
+        var content = Assert.Single(result.Content.OfType<TextContentBlock>());
+        Assert.Equal("Access forbidden: This tool requires authorization.", content.Text);
+    }
+
+    [Fact]
+    public async Task ClassLevelAuthorize_Tool_RequiresAuthentication()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithTools<AllowAnonymousTestTools>());
+
+        var client = await ConnectAsync();
+        var result = await client.CallToolAsync(
+            "anonymous_tool",
+            new Dictionary<string, object?> { ["message"] = "test" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError ?? false);
+        var content = Assert.Single(result.Content.OfType<TextContentBlock>());
+        Assert.Equal("Anonymous: test", content.Text);
+    }
+
+    [Fact]
+    public async Task AllowAnonymous_Tool_AllowsAnonymousAccess()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithTools<AllowAnonymousTestTools>());
+
+        var client = await ConnectAsync();
+        var result = await client.CallToolAsync(
+            "anonymous_tool",
+            new Dictionary<string, object?> { ["message"] = "test" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError ?? false);
+        var content = Assert.Single(result.Content.OfType<TextContentBlock>());
+        Assert.Equal("Anonymous: test", content.Text);
+    }
+
+    [Fact]
+    public async Task Authorize_Tool_AllowsAuthenticatedUser()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithTools<AuthorizationTestTools>(), "TestUser");
+
+        var client = await ConnectAsync();
+        var result = await client.CallToolAsync(
+            "authorized_tool",
+            new Dictionary<string, object?> { ["message"] = "test" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError ?? false);
+        var content = Assert.Single(result.Content.OfType<TextContentBlock>());
+        Assert.Equal("Authorized: test", content.Text);
+    }
+
+    [Fact]
+    public async Task AuthorizeWithRoles_Tool_RequiresAdminRole()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithTools<AuthorizationTestTools>(), "TestUser", "User");
+
+        var client = await ConnectAsync();
+        var result = await client.CallToolAsync(
+            "admin_tool",
+            new Dictionary<string, object?> { ["message"] = "test" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Should return error because tool requires Admin role but user only has User role
+        Assert.True(result.IsError ?? false);
+        var content = Assert.Single(result.Content.OfType<TextContentBlock>());
+        Assert.Equal("Access forbidden: This tool requires authorization.", content.Text);
+    }
+
+    [Fact]
+    public async Task AuthorizeWithRoles_Tool_AllowsAdminUser()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithTools<AuthorizationTestTools>(), "AdminUser", "Admin");
+
+        var client = await ConnectAsync();
+        var result = await client.CallToolAsync(
+            "admin_tool",
+            new Dictionary<string, object?> { ["message"] = "test" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError ?? false);
+        var content = Assert.Single(result.Content.OfType<TextContentBlock>());
+        Assert.Equal("Admin: test", content.Text);
+    }
+
+    [Fact]
+    public async Task ListTools_Anonymous_OnlyReturnsAnonymousTools()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithTools<AuthorizationTestTools>());
+
+        var client = await ConnectAsync();
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Single(tools);
+        Assert.Equal("anonymous_tool", tools[0].Name);
+    }
+
+    [Fact]
+    public async Task ListTools_AuthenticatedUser_ReturnsAuthorizedTools()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithTools<AuthorizationTestTools>(), "TestUser");
+
+        var client = await ConnectAsync();
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Authenticated user should see anonymous and basic authorized tools, but not admin-only tools
+        Assert.Equal(2, tools.Count);
+        var toolNames = tools.Select(t => t.Name).OrderBy(n => n).ToList();
+        Assert.Equal(["anonymous_tool", "authorized_tool"], toolNames);
+    }
+
+    [Fact]
+    public async Task ListTools_AdminUser_ReturnsAllTools()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithTools<AuthorizationTestTools>(), "AdminUser", "Admin");
+
+        var client = await ConnectAsync();
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Admin user should see all tools
+        Assert.Equal(3, tools.Count);
+        var toolNames = tools.Select(t => t.Name).OrderBy(n => n).ToList();
+        Assert.Equal(["admin_tool", "anonymous_tool", "authorized_tool"], toolNames);
+    }
+
+    [Fact]
+    public async Task ListTools_UserRole_DoesNotReturnAdminTools()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithTools<AuthorizationTestTools>(), "TestUser", "User");
+
+        var client = await ConnectAsync();
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // User with User role should not see admin-only tools
+        Assert.Equal(2, tools.Count);
+        var toolNames = tools.Select(t => t.Name).OrderBy(n => n).ToList();
+        Assert.Equal(["anonymous_tool", "authorized_tool"], toolNames);
+    }
+
+    [Fact]
+    public async Task Authorize_Prompt_RequiresAuthentication()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithPrompts<AuthorizationTestPrompts>());
+
+        var client = await ConnectAsync();
+
+        var exception = await Assert.ThrowsAsync<McpException>(async () =>
+            await client.GetPromptAsync(
+                "authorized_prompt",
+                new Dictionary<string, object?> { ["message"] = "test" },
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal("Request failed (remote): Access forbidden: This prompt requires authorization.", exception.Message);
+        Assert.Equal(McpErrorCode.InvalidRequest, exception.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Authorize_Prompt_AllowsAuthenticatedUser()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithPrompts<AuthorizationTestPrompts>(), "TestUser");
+
+        var client = await ConnectAsync();
+        var result = await client.GetPromptAsync(
+            "authorized_prompt",
+            new Dictionary<string, object?> { ["message"] = "test" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var message = Assert.Single(result.Messages);
+        Assert.Equal(Role.User, message.Role);
+        var content = Assert.IsType<TextContentBlock>(message.Content);
+        Assert.Equal("Authorized prompt: test", content.Text);
+    }
+
+    [Fact]
+    public async Task ListPrompts_Anonymous_OnlyReturnsAnonymousPrompts()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithPrompts<AuthorizationTestPrompts>());
+
+        var client = await ConnectAsync();
+        var prompts = await client.ListPromptsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Anonymous user should only see prompts marked with [AllowAnonymous]
+        Assert.Single(prompts);
+        Assert.Equal("anonymous_prompt", prompts[0].Name);
+    }
+
+    [Fact]
+    public async Task Authorize_Resource_RequiresAuthentication()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithResources<AuthorizationTestResources>());
+
+        var client = await ConnectAsync();
+
+        var exception = await Assert.ThrowsAsync<McpException>(async () =>
+            await client.ReadResourceAsync(
+                "resource://authorized",
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal("Request failed (remote): Access forbidden: This resource requires authorization.", exception.Message);
+        Assert.Equal(McpErrorCode.InvalidRequest, exception.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Authorize_Resource_AllowsAuthenticatedUser()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithResources<AuthorizationTestResources>(), "TestUser");
+
+        var client = await ConnectAsync();
+        var result = await client.ReadResourceAsync(
+            "resource://authorized",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var content = Assert.Single(result.Contents.OfType<TextResourceContents>());
+        Assert.Equal("Authorized resource content", content.Text);
+    }
+
+    [Fact]
+    public async Task ListResources_Anonymous_OnlyReturnsAnonymousResources()
+    {
+        await using var app = await StartServerWithAuth(builder => builder.WithResources<AuthorizationTestResources>());
+
+        var client = await ConnectAsync();
+        var resources = await client.ListResourcesAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Single(resources);
+        Assert.Equal("resource://anonymous", resources[0].Uri);
+    }
+
+    private async Task<WebApplication> StartServerWithAuth(Action<IMcpServerBuilder> configure, string? userName = null, params string[] roles)
+    {
+        var builder = Builder.Services.AddMcpServer().WithHttpTransport();
+        configure(builder);
+        Builder.Services.AddAuthorization();
+
+        var app = Builder.Build();
+
+        if (userName is not null)
+        {
+            app.Use(next =>
+            {
+                return async context =>
+                {
+                    context.User = CreateUser(userName, roles);
+                    await next(context);
+                };
+            });
+        }
+
+        app.MapMcp();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+        return app;
+    }
+
+    private ClaimsPrincipal CreateUser(string name, params string[] roles)
+        => new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim("name", name), new Claim(ClaimTypes.NameIdentifier, name), ..roles.Select(role => new Claim("role", role))],
+            "TestAuthType", "name", "role"));
+
+    [McpServerToolType]
+    private class AuthorizationTestTools
+    {
+        [McpServerTool, Description("A tool that allows anonymous access.")]
+        public static string AnonymousTool(string message)
+        {
+            return $"Anonymous: {message}";
+        }
+
+        [McpServerTool, Description("A tool that requires authorization.")]
+        [Authorize]
+        public static string AuthorizedTool(string message)
+        {
+            return $"Authorized: {message}";
+        }
+
+        [McpServerTool, Description("A tool that requires Admin role.")]
+        [Authorize(Roles = "Admin")]
+        public static string AdminTool(string message)
+        {
+            return $"Admin: {message}";
+        }
+    }
+
+    [McpServerToolType]
+    [Authorize]
+    private class AllowAnonymousTestTools
+    {
+        [McpServerTool, Description("A tool that allows anonymous access.")]
+        [AllowAnonymous]
+        public static string AnonymousTool(string message)
+        {
+            return $"Anonymous: {message}";
+        }
+
+        [McpServerTool, Description("A tool that requires authorization.")]
+        public static string AuthorizedTool(string message)
+        {
+            return $"Authorized: {message}";
+        }
+    }
+
+    [McpServerPromptType]
+    private class AuthorizationTestPrompts
+    {
+        [McpServerPrompt, Description("A prompt that allows anonymous access.")]
+        public static string AnonymousPrompt(string message)
+        {
+            return $"Anonymous prompt: {message}";
+        }
+
+        [McpServerPrompt, Description("A prompt that requires authorization.")]
+        [Authorize]
+        public static string AuthorizedPrompt(string message)
+        {
+            return $"Authorized prompt: {message}";
+        }
+    }
+
+    [McpServerResourceType]
+    private class AuthorizationTestResources
+    {
+        [McpServerResource(UriTemplate = "resource://anonymous"), Description("A resource that allows anonymous access.")]
+        public static string AnonymousResource()
+        {
+            return "Anonymous resource content";
+        }
+
+        [McpServerResource(UriTemplate = "resource://authorized"), Description("A resource that requires authorization.")]
+        [Authorize]
+        public static string AuthorizedResource()
+        {
+            return "Authorized resource content";
+        }
+    }
+}

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpSseTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpSseTests.cs
@@ -13,7 +13,7 @@ public class MapMcpSseTests(ITestOutputHelper outputHelper) : MapMcpTests(output
     [InlineData("/mcp/secondary")]
     public async Task Allows_Customizing_Route(string pattern)
     {
-        Builder.Services.AddMcpServer().WithHttpTransport(ConfigureStateless);
+        Builder.Services.AddMcpServer().WithHttpTransport();
         await using var app = Builder.Build();
 
         app.MapMcp(pattern);

--- a/tests/ModelContextProtocol.TestServer/Program.cs
+++ b/tests/ModelContextProtocol.TestServer/Program.cs
@@ -491,7 +491,7 @@ internal static class Program
             {"temperature", ["0", "0.5", "0.7", "1.0"]},
         };
 
-        Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>> handler = async (request, cancellationToken) =>
+        McpRequestHandler<CompleteRequestParams, CompleteResult> handler = async (request, cancellationToken) =>
         {
             string[]? values;
             switch (request.Params?.Ref)

--- a/tests/ModelContextProtocol.Tests/ClientServerTestBase.cs
+++ b/tests/ModelContextProtocol.Tests/ClientServerTestBase.cs
@@ -20,7 +20,8 @@ public abstract class ClientServerTestBase : LoggedTest, IAsyncDisposable
         : base(testOutputHelper)
     {
         ServiceCollection sc = new();
-        sc.AddSingleton(LoggerFactory);
+        sc.AddLogging();
+        sc.AddSingleton(XunitLoggerProvider);
         _builder = sc
             .AddMcpServer()
             .WithStreamServerTransport(_clientToServerPipe.Reader.AsStream(), _serverToClientPipe.Writer.AsStream());

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsFilterTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsFilterTests.cs
@@ -1,0 +1,314 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Tests.Utils;
+
+namespace ModelContextProtocol.Tests.Configuration;
+
+public class McpServerBuilderExtensionsFilterTests : ClientServerTestBase
+{
+    public McpServerBuilderExtensionsFilterTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    private MockLoggerProvider _mockLoggerProvider = new();
+
+    private static ILogger GetLogger(IServiceProvider? services, string categoryName)
+    {
+        var loggerFactory = services?.GetRequiredService<ILoggerFactory>() ?? throw new InvalidOperationException("LoggerFactory not available");
+        return loggerFactory.CreateLogger(categoryName);
+    }
+
+    protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
+    {
+        mcpServerBuilder
+            .AddListResourceTemplatesFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "ListResourceTemplatesFilter");
+                logger.LogInformation("ListResourceTemplatesFilter executed");
+                return await next(request, cancellationToken);
+            })
+            .AddListToolsFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "ListToolsFilter");
+                logger.LogInformation("ListToolsFilter executed");
+                return await next(request, cancellationToken);
+            })
+            .AddListToolsFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "ListToolsOrder1");
+                logger.LogInformation("ListToolsOrder1 before");
+                var result = await next(request, cancellationToken);
+                logger.LogInformation("ListToolsOrder1 after");
+                return result;
+            })
+            .AddListToolsFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "ListToolsOrder2");
+                logger.LogInformation("ListToolsOrder2 before");
+                var result = await next(request, cancellationToken);
+                logger.LogInformation("ListToolsOrder2 after");
+                return result;
+            })
+            .AddCallToolFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "CallToolFilter");
+                var primitiveId = request.MatchedPrimitive?.Id ?? "unknown";
+                logger.LogInformation($"CallToolFilter executed for tool: {primitiveId}");
+                return await next(request, cancellationToken);
+            })
+            .AddListPromptsFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "ListPromptsFilter");
+                logger.LogInformation("ListPromptsFilter executed");
+                return await next(request, cancellationToken);
+            })
+            .AddGetPromptFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "GetPromptFilter");
+                var primitiveId = request.MatchedPrimitive?.Id ?? "unknown";
+                logger.LogInformation($"GetPromptFilter executed for prompt: {primitiveId}");
+                return await next(request, cancellationToken);
+            })
+            .AddListResourcesFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "ListResourcesFilter");
+                logger.LogInformation("ListResourcesFilter executed");
+                return await next(request, cancellationToken);
+            })
+            .AddReadResourceFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "ReadResourceFilter");
+                var primitiveId = request.MatchedPrimitive?.Id ?? "unknown";
+                logger.LogInformation($"ReadResourceFilter executed for resource: {primitiveId}");
+                return await next(request, cancellationToken);
+            })
+            .AddCompleteFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "CompleteFilter");
+                logger.LogInformation("CompleteFilter executed");
+                return await next(request, cancellationToken);
+            })
+            .AddSubscribeToResourcesFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "SubscribeToResourcesFilter");
+                logger.LogInformation("SubscribeToResourcesFilter executed");
+                return await next(request, cancellationToken);
+            })
+            .AddUnsubscribeFromResourcesFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "UnsubscribeFromResourcesFilter");
+                logger.LogInformation("UnsubscribeFromResourcesFilter executed");
+                return await next(request, cancellationToken);
+            })
+            .AddSetLoggingLevelFilter((next) => async (request, cancellationToken) =>
+            {
+                var logger = GetLogger(request.Services, "SetLoggingLevelFilter");
+                logger.LogInformation("SetLoggingLevelFilter executed");
+                return await next(request, cancellationToken);
+            })
+            .WithTools<TestTool>()
+            .WithPrompts<TestPrompt>()
+            .WithResources<TestResource>()
+            .WithSetLoggingLevelHandler(async (request, cancellationToken) => new EmptyResult())
+            .WithListResourceTemplatesHandler(async (request, cancellationToken) => new ListResourceTemplatesResult
+            {
+                ResourceTemplates = [new() { Name = "test", UriTemplate = "test://resource/{id}" }]
+            })
+            .WithCompleteHandler(async (request, cancellationToken) => new CompleteResult
+            {
+                Completion = new() { Values = ["test"] }
+            });
+
+        services.AddSingleton<ILoggerProvider>(_mockLoggerProvider);
+    }
+
+    [Fact]
+    public async Task AddListResourceTemplatesFilter_Logs_When_ListResourceTemplates_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.ListResourceTemplatesAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "ListResourceTemplatesFilter executed");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("ListResourceTemplatesFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddListToolsFilter_Logs_When_ListTools_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "ListToolsFilter executed");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("ListToolsFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddCallToolFilter_Logs_When_CallTool_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.CallToolAsync("test_tool_method", cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "CallToolFilter executed for tool: test_tool_method");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("CallToolFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddListPromptsFilter_Logs_When_ListPrompts_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.ListPromptsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "ListPromptsFilter executed");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("ListPromptsFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddGetPromptFilter_Logs_When_GetPrompt_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.GetPromptAsync("test_prompt_method", cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "GetPromptFilter executed for prompt: test_prompt_method");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("GetPromptFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddListResourcesFilter_Logs_When_ListResources_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.ListResourcesAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "ListResourcesFilter executed");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("ListResourcesFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddReadResourceFilter_Logs_When_ReadResource_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.ReadResourceAsync("test://resource/123", cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "ReadResourceFilter executed for resource: test://resource/{id}");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("ReadResourceFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddCompleteFilter_Logs_When_Complete_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        var reference = new PromptReference { Name = "test_prompt_method" };
+        await client.CompleteAsync(reference, "argument", "value", cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "CompleteFilter executed");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("CompleteFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddSubscribeToResourcesFilter_Logs_When_SubscribeToResources_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.SubscribeToResourceAsync("test://resource/123", cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "SubscribeToResourcesFilter executed");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("SubscribeToResourcesFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddUnsubscribeFromResourcesFilter_Logs_When_UnsubscribeFromResources_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.UnsubscribeFromResourceAsync("test://resource/123", cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "UnsubscribeFromResourcesFilter executed");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("UnsubscribeFromResourcesFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddSetLoggingLevelFilter_Logs_When_SetLoggingLevel_Called()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.SetLoggingLevel(LoggingLevel.Info, cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessage = Assert.Single(_mockLoggerProvider.LogMessages, m => m.Message == "SetLoggingLevelFilter executed");
+        Assert.Equal(LogLevel.Information, logMessage.LogLevel);
+        Assert.Equal("SetLoggingLevelFilter", logMessage.Category);
+    }
+
+    [Fact]
+    public async Task AddListToolsFilter_Multiple_Filters_Log_In_Expected_Order()
+    {
+        await using IMcpClient client = await CreateMcpClientForServer();
+
+        await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var logMessages = _mockLoggerProvider.LogMessages
+            .Where(m => m.Category.StartsWith("ListToolsOrder"))
+            .Select(m => m.Message);
+
+        Assert.Collection(logMessages,
+            m => Assert.Equal("ListToolsOrder1 before", m),
+            m => Assert.Equal("ListToolsOrder2 before", m),
+            m => Assert.Equal("ListToolsOrder2 after", m),
+            m => Assert.Equal("ListToolsOrder1 after", m)
+        );
+    }
+
+    [McpServerToolType]
+    public sealed class TestTool
+    {
+        [McpServerTool]
+        public static string TestToolMethod()
+        {
+            return "test result";
+        }
+    }
+
+    [McpServerPromptType]
+    public sealed class TestPrompt
+    {
+        [McpServerPrompt]
+        public static Task<GetPromptResult> TestPromptMethod()
+        {
+            return Task.FromResult(new GetPromptResult
+            {
+                Description = "Test prompt",
+                Messages = [new() { Role = Role.User, Content = new TextContentBlock { Text = "Test" } }]
+            });
+        }
+    }
+
+    [McpServerResourceType]
+    public sealed class TestResource
+    {
+        [McpServerResource(UriTemplate = "test://resource/{id}")]
+        public static string TestResourceMethod(string id)
+        {
+            return $"Test resource for ID: {id}";
+        }
+    }
+}

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsHandlerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsHandlerTests.cs
@@ -21,7 +21,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithListToolsHandler_Sets_Handler()
     {
-        Func<RequestContext<ListToolsRequestParams>, CancellationToken, ValueTask<ListToolsResult>> handler = async (context, token) => new ListToolsResult();
+        McpRequestHandler<ListToolsRequestParams, ListToolsResult> handler = async (context, token) => new ListToolsResult();
 
         _builder.Object.WithListToolsHandler(handler);
 
@@ -34,7 +34,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithCallToolHandler_Sets_Handler()
     {
-        Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>> handler = async (context, token) => new CallToolResult();
+        McpRequestHandler<CallToolRequestParams, CallToolResult> handler = async (context, token) => new CallToolResult();
 
         _builder.Object.WithCallToolHandler(handler);
 
@@ -47,7 +47,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithListPromptsHandler_Sets_Handler()
     {
-        Func<RequestContext<ListPromptsRequestParams>, CancellationToken, ValueTask<ListPromptsResult>> handler = async (context, token) => new ListPromptsResult();
+        McpRequestHandler<ListPromptsRequestParams, ListPromptsResult> handler = async (context, token) => new ListPromptsResult();
 
         _builder.Object.WithListPromptsHandler(handler);
 
@@ -60,7 +60,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithGetPromptHandler_Sets_Handler()
     {
-        Func<RequestContext<GetPromptRequestParams>, CancellationToken, ValueTask<GetPromptResult>> handler = async (context, token) => new GetPromptResult();
+        McpRequestHandler<GetPromptRequestParams, GetPromptResult> handler = async (context, token) => new GetPromptResult();
 
         _builder.Object.WithGetPromptHandler(handler);
 
@@ -73,7 +73,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithListResourceTemplatesHandler_Sets_Handler()
     {
-        Func<RequestContext<ListResourceTemplatesRequestParams>, CancellationToken, ValueTask<ListResourceTemplatesResult>> handler = async (context, token) => new ListResourceTemplatesResult();
+        McpRequestHandler<ListResourceTemplatesRequestParams, ListResourceTemplatesResult> handler = async (context, token) => new ListResourceTemplatesResult();
 
         _builder.Object.WithListResourceTemplatesHandler(handler);
 
@@ -86,7 +86,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithListResourcesHandler_Sets_Handler()
     {
-        Func<RequestContext<ListResourcesRequestParams>, CancellationToken, ValueTask<ListResourcesResult>> handler = async (context, token) => new ListResourcesResult();
+        McpRequestHandler<ListResourcesRequestParams, ListResourcesResult> handler = async (context, token) => new ListResourcesResult();
 
         _builder.Object.WithListResourcesHandler(handler);
 
@@ -99,7 +99,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithReadResourceHandler_Sets_Handler()
     {
-        Func<RequestContext<ReadResourceRequestParams>, CancellationToken, ValueTask<ReadResourceResult>> handler = async (context, token) => new ReadResourceResult();
+        McpRequestHandler<ReadResourceRequestParams, ReadResourceResult> handler = async (context, token) => new ReadResourceResult();
 
         _builder.Object.WithReadResourceHandler(handler);
 
@@ -112,7 +112,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithCompleteHandler_Sets_Handler()
     {
-        Func<RequestContext<CompleteRequestParams>, CancellationToken, ValueTask<CompleteResult>> handler = async (context, token) => new CompleteResult();
+        McpRequestHandler<CompleteRequestParams, CompleteResult> handler = async (context, token) => new CompleteResult();
 
         _builder.Object.WithCompleteHandler(handler);
 
@@ -125,7 +125,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithSubscribeToResourcesHandler_Sets_Handler()
     {
-        Func<RequestContext<SubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>> handler = async (context, token) => new EmptyResult();
+        McpRequestHandler<SubscribeRequestParams, EmptyResult> handler = async (context, token) => new EmptyResult();
 
         _builder.Object.WithSubscribeToResourcesHandler(handler);
 
@@ -138,7 +138,7 @@ public class McpServerBuilderExtensionsHandlerTests
     [Fact]
     public void WithUnsubscribeFromResourcesHandler_Sets_Handler()
     {
-        Func<RequestContext<UnsubscribeRequestParams>, CancellationToken, ValueTask<EmptyResult>> handler = async (context, token) => new EmptyResult();
+        McpRequestHandler<UnsubscribeRequestParams, EmptyResult> handler = async (context, token) => new EmptyResult();
 
         _builder.Object.WithUnsubscribeFromResourcesHandler(handler);
 

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsPromptsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsPromptsTests.cs
@@ -238,7 +238,7 @@ public partial class McpServerBuilderExtensionsPromptsTests : ClientServerTestBa
         sc.AddMcpServer().WithPrompts(target);
 
         McpServerPrompt prompt = sc.BuildServiceProvider().GetServices<McpServerPrompt>().First(t => t.ProtocolPrompt.Name == "returns_string");
-        var result = await prompt.GetAsync(new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object)
+        var result = await prompt.GetAsync(new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, new JsonRpcRequest { Method = "test", Id = new RequestId("1") })
         {
             Params = new GetPromptRequestParams
             {

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsResourcesTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsResourcesTests.cs
@@ -265,7 +265,7 @@ public partial class McpServerBuilderExtensionsResourcesTests : ClientServerTest
         sc.AddMcpServer().WithResources(target);
 
         McpServerResource resource = sc.BuildServiceProvider().GetServices<McpServerResource>().First(t => t.ProtocolResource?.Name == "returns_string");
-        var result = await resource.ReadAsync(new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object)
+        var result = await resource.ReadAsync(new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object, new JsonRpcRequest { Method = "test", Id = new RequestId("1") })
         {
             Params = new()
             {

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
@@ -525,7 +525,7 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         sc.AddMcpServer().WithTools(target, BuilderToolsJsonContext.Default.Options);
 
         McpServerTool tool = sc.BuildServiceProvider().GetServices<McpServerTool>().First(t => t.ProtocolTool.Name == "get_ctor_parameter");
-        var result = await tool.InvokeAsync(new RequestContext<CallToolRequestParams>(new Mock<IMcpServer>().Object), TestContext.Current.CancellationToken);
+        var result = await tool.InvokeAsync(new RequestContext<CallToolRequestParams>(new Mock<IMcpServer>().Object, new JsonRpcRequest { Method = "test", Id = new RequestId("1") }), TestContext.Current.CancellationToken);
 
         Assert.Equal(target.GetCtorParameter(), (result.Content[0] as TextContentBlock)?.Text);
     }

--- a/tests/ModelContextProtocol.Tests/Server/McpServerPromptTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerPromptTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 using ModelContextProtocol.Protocol;
@@ -15,6 +15,16 @@ namespace ModelContextProtocol.Tests.Server;
 
 public class McpServerPromptTests
 {
+    private static JsonRpcRequest CreateTestJsonRpcRequest()
+    {
+        return new JsonRpcRequest
+        {
+            Id = new RequestId("test-id"),
+            Method = "test/method",
+            Params = null
+        };
+    }
+
     public McpServerPromptTests()
     {
 #if !NET
@@ -46,7 +56,7 @@ public class McpServerPromptTests
         Assert.DoesNotContain("server", prompt.ProtocolPrompt.Arguments?.Select(a => a.Name) ?? []);
 
         var result = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(mockServer.Object),
+            new RequestContext<GetPromptRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.NotNull(result.Messages);
@@ -75,7 +85,7 @@ public class McpServerPromptTests
         }, new() { Services = services });
 
         var result = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(mockServer.Object),
+            new RequestContext<GetPromptRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.NotNull(result.Messages);
@@ -125,11 +135,11 @@ public class McpServerPromptTests
         Assert.DoesNotContain("actualMyService", prompt.ProtocolPrompt.Arguments?.Select(a => a.Name) ?? []);
 
         await Assert.ThrowsAnyAsync<ArgumentException>(async () => await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken));
 
         var result = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object) { Services = services },
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()) { Services = services },
             TestContext.Current.CancellationToken);
         Assert.Equal("Hello", Assert.IsType<TextContentBlock>(result.Messages[0].Content).Text);
     }
@@ -150,7 +160,7 @@ public class McpServerPromptTests
         }, new() { Services = services });
 
         var result = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
         Assert.Equal("Hello", Assert.IsType<TextContentBlock>(result.Messages[0].Content).Text);
     }
@@ -163,7 +173,7 @@ public class McpServerPromptTests
             _ => new DisposablePromptType());
 
         var result = await prompt1.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
         Assert.Equal("disposals:1", Assert.IsType<TextContentBlock>(result.Messages[0].Content).Text);
     }
@@ -176,7 +186,7 @@ public class McpServerPromptTests
             _ => new AsyncDisposablePromptType());
 
         var result = await prompt1.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
         Assert.Equal("asyncDisposals:1", Assert.IsType<TextContentBlock>(result.Messages[0].Content).Text);
     }
@@ -189,7 +199,7 @@ public class McpServerPromptTests
             _ => new AsyncDisposableAndDisposablePromptType());
 
         var result = await prompt1.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
         Assert.Equal("disposals:0, asyncDisposals:1", Assert.IsType<TextContentBlock>(result.Messages[0].Content).Text);
     }
@@ -205,7 +215,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
 
         Assert.Same(expected, actual);
@@ -222,7 +232,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(actual);
@@ -248,7 +258,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(actual);
@@ -260,7 +270,7 @@ public class McpServerPromptTests
     [Fact]
     public async Task CanReturnPromptMessages()
     {
-        IList<PromptMessage> expected = 
+        IList<PromptMessage> expected =
         [
             new()
             {
@@ -280,7 +290,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(actual);
@@ -307,7 +317,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(actual);
@@ -339,7 +349,7 @@ public class McpServerPromptTests
         });
 
         var actual = await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(actual);
@@ -360,7 +370,7 @@ public class McpServerPromptTests
         });
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken));
     }
 
@@ -373,7 +383,7 @@ public class McpServerPromptTests
         });
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await prompt.GetAsync(
-            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object),
+            new RequestContext<GetPromptRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()),
             TestContext.Current.CancellationToken));
     }
 

--- a/tests/ModelContextProtocol.Tests/Server/McpServerResourceTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerResourceTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -11,6 +11,16 @@ namespace ModelContextProtocol.Tests.Server;
 
 public partial class McpServerResourceTests
 {
+    private static JsonRpcRequest CreateTestJsonRpcRequest()
+    {
+        return new JsonRpcRequest
+        {
+            Id = new RequestId("test-id"),
+            Method = "test/method",
+            Params = null
+        };
+    }
+
     public McpServerResourceTests()
     {
 #if !NET
@@ -138,7 +148,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create(() => "42", new() { Name = Name });
         Assert.Equal("resource://mcp/Hello", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = "resource://mcp/Hello" } }, 
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Hello" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
@@ -146,7 +156,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((IMcpServer server) => "42", new() { Name = Name });
         Assert.Equal("resource://mcp/Hello", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = "resource://mcp/Hello" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Hello" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
@@ -154,7 +164,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((string arg1) => arg1, new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?arg1}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?arg1=wOrLd" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?arg1=wOrLd" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("wOrLd", ((TextResourceContents)result.Contents[0]).Text);
@@ -162,7 +172,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((string arg1, string? arg2 = null) => arg1 + arg2, new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?arg1,arg2}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?arg1=wo&arg2=rld" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?arg1=wo&arg2=rld" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("world", ((TextResourceContents)result.Contents[0]).Text);
@@ -170,7 +180,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((object a1, bool a2, char a3, byte a4, sbyte a5) => a1.ToString() + a2 + a3 + a4 + a5, new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a1=hi&a2=true&a3=s&a4=12&a5=34" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a1=hi&a2=true&a3=s&a4=12&a5=34" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("hiTrues1234", ((TextResourceContents)result.Contents[0]).Text);
@@ -178,7 +188,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((ushort a1, short a2, uint a3, int a4, ulong a5) => (a1 + a2 + a3 + a4 + (long)a5).ToString(), new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a1=10&a2=20&a3=30&a4=40&a5=50" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a1=10&a2=20&a3=30&a4=40&a5=50" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("150", ((TextResourceContents)result.Contents[0]).Text);
@@ -186,7 +196,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((long a1, float a2, double a3, decimal a4, TimeSpan a5) => a5.ToString(), new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a1=1&a2=2&a3=3&a4=4&a5=5" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a1=1&a2=2&a3=3&a4=4&a5=5" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("5.00:00:00", ((TextResourceContents)result.Contents[0]).Text);
@@ -194,7 +204,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((DateTime a1, DateTimeOffset a2, Uri a3, Guid a4, Version a5) => a4.ToString("N") + a5, new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a1={DateTime.UtcNow:r}&a2={DateTimeOffset.UtcNow:r}&a3=http%3A%2F%2Ftest&a4=14e5f43d-0d41-47d6-8207-8249cf669e41&a5=1.2.3.4" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a1={DateTime.UtcNow:r}&a2={DateTimeOffset.UtcNow:r}&a3=http%3A%2F%2Ftest&a4=14e5f43d-0d41-47d6-8207-8249cf669e41&a5=1.2.3.4" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("14e5f43d0d4147d682078249cf669e411.2.3.4", ((TextResourceContents)result.Contents[0]).Text);
@@ -203,7 +213,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((Half a2, Int128 a3, UInt128 a4, IntPtr a5) => (a3 + (Int128)a4 + a5).ToString(), new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a2=1.0&a3=3&a4=4&a5=5" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a2=1.0&a3=3&a4=4&a5=5" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("12", ((TextResourceContents)result.Contents[0]).Text);
@@ -211,7 +221,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((UIntPtr a1, DateOnly a2, TimeOnly a3) => a1.ToString(), new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a1,a2,a3}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a1=123&a2=0001-02-03&a3=01%3A02%3A03" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a1=123&a2=0001-02-03&a3=01%3A02%3A03" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("123", ((TextResourceContents)result.Contents[0]).Text);
@@ -220,7 +230,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((bool? a2, char? a3, byte? a4, sbyte? a5) => a2?.ToString() + a3 + a4 + a5, new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a2=true&a3=s&a4=12&a5=34" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a2=true&a3=s&a4=12&a5=34" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("Trues1234", ((TextResourceContents)result.Contents[0]).Text);
@@ -228,7 +238,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((ushort? a1, short? a2, uint? a3, int? a4, ulong? a5) => (a1 + a2 + a3 + a4 + (long?)a5).ToString(), new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a1=10&a2=20&a3=30&a4=40&a5=50" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a1=10&a2=20&a3=30&a4=40&a5=50" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("150", ((TextResourceContents)result.Contents[0]).Text);
@@ -236,7 +246,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((long? a1, float? a2, double? a3, decimal? a4, TimeSpan? a5) => a5?.ToString(), new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a1,a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a1=1&a2=2&a3=3&a4=4&a5=5" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a1=1&a2=2&a3=3&a4=4&a5=5" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("5.00:00:00", ((TextResourceContents)result.Contents[0]).Text);
@@ -244,7 +254,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((DateTime? a1, DateTimeOffset? a2, Guid? a4) => a4?.ToString("N"), new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a1,a2,a4}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a1={DateTime.UtcNow:r}&a2={DateTimeOffset.UtcNow:r}&a4=14e5f43d-0d41-47d6-8207-8249cf669e41" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a1={DateTime.UtcNow:r}&a2={DateTimeOffset.UtcNow:r}&a4=14e5f43d-0d41-47d6-8207-8249cf669e41" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("14e5f43d0d4147d682078249cf669e41", ((TextResourceContents)result.Contents[0]).Text);
@@ -253,7 +263,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((Half? a2, Int128? a3, UInt128? a4, IntPtr? a5) => (a3 + (Int128?)a4 + a5).ToString(), new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a2,a3,a4,a5}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a2=1.0&a3=3&a4=4&a5=5" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a2=1.0&a3=3&a4=4&a5=5" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("12", ((TextResourceContents)result.Contents[0]).Text);
@@ -261,7 +271,7 @@ public partial class McpServerResourceTests
         t = McpServerResource.Create((UIntPtr? a1, DateOnly? a2, TimeOnly? a3) => a1?.ToString(), new() { Name = Name });
         Assert.Equal($"resource://mcp/Hello{{?a1,a2,a3}}", t.ProtocolResourceTemplate.UriTemplate);
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(server) { Params = new() { Uri = $"resource://mcp/Hello?a1=123&a2=0001-02-03&a3=01%3A02%3A03" } },
+            new RequestContext<ReadResourceRequestParams>(server, CreateTestJsonRpcRequest()) { Params = new() { Uri = $"resource://mcp/Hello?a1=123&a2=0001-02-03&a3=01%3A02%3A03" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("123", ((TextResourceContents)result.Contents[0]).Text);
@@ -277,7 +287,7 @@ public partial class McpServerResourceTests
         McpServerResource t = McpServerResource.Create((string arg1) => arg1, new() { Name = "Hello" });
         Assert.Equal("resource://mcp/Hello{?arg1}", t.ProtocolResourceTemplate.UriTemplate);
         Assert.Null(await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = uri } },
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = uri } },
             TestContext.Current.CancellationToken));
     }
 
@@ -288,7 +298,7 @@ public partial class McpServerResourceTests
     {
         McpServerResource t = McpServerResource.Create(() => "resource", new() { UriTemplate = actualUri });
         Assert.NotNull(await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = queriedUri } },
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = queriedUri } },
             TestContext.Current.CancellationToken));
     }
 
@@ -317,7 +327,7 @@ public partial class McpServerResourceTests
         McpServerResource t = McpServerResource.Create((string arg1, int arg2) => arg1, new() { Name = "Hello" });
         Assert.Equal("resource://mcp/Hello{?arg1,arg2}", t.ProtocolResourceTemplate.UriTemplate);
         await Assert.ThrowsAsync<ArgumentException>(async () => await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = uri } },
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = uri } },
             TestContext.Current.CancellationToken));
     }
 
@@ -330,25 +340,25 @@ public partial class McpServerResourceTests
         ReadResourceResult? result;
 
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = "resource://mcp/Hello" } },
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Hello" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("", ((TextResourceContents)result.Contents[0]).Text);
 
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = "resource://mcp/Hello?arg1=first" } },
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Hello?arg1=first" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("first", ((TextResourceContents)result.Contents[0]).Text);
 
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = "resource://mcp/Hello?arg2=42" } },
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Hello?arg2=42" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
 
         result = await t.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = "resource://mcp/Hello?arg1=first&arg2=42" } },
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Hello?arg1=first&arg2=42" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("first42", ((TextResourceContents)result.Contents[0]).Text);
@@ -366,7 +376,7 @@ public partial class McpServerResourceTests
         }, new() { Name = "Test" });
 
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
@@ -393,7 +403,7 @@ public partial class McpServerResourceTests
         }, new() { Services = services });
 
         var result = await tool.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "https://something" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "https://something" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.NotNull(result.Contents);
@@ -470,11 +480,11 @@ public partial class McpServerResourceTests
         Mock<IMcpServer> mockServer = new();
 
         await Assert.ThrowsAnyAsync<ArgumentException>(async () => await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken));
 
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Services = services, Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Services = services, Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
@@ -496,7 +506,7 @@ public partial class McpServerResourceTests
         }, new() { Services = services, Name = "Test" });
 
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("42", ((TextResourceContents)result.Contents[0]).Text);
@@ -512,7 +522,7 @@ public partial class McpServerResourceTests
             _ => new DisposableResourceType());
 
         var result = await resource1.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object) { Params = new() { Uri = "test://static/resource/instanceMethod" } },
+            new RequestContext<ReadResourceRequestParams>(new Mock<IMcpServer>().Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "test://static/resource/instanceMethod" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal("0", ((TextResourceContents)result.Contents[0]).Text);
@@ -530,7 +540,7 @@ public partial class McpServerResourceTests
             return new ReadResourceResult { Contents = new List<ResourceContents> { new TextResourceContents { Text = "hello" } } };
         }, new() { Name = "Test" });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Single(result.Contents);
@@ -547,7 +557,7 @@ public partial class McpServerResourceTests
             return new TextResourceContents { Text = "hello" };
         }, new() { Name = "Test", SerializerOptions = JsonContext6.Default.Options });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Single(result.Contents);
@@ -568,7 +578,7 @@ public partial class McpServerResourceTests
             ];
         }, new() { Name = "Test" });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal(2, result.Contents.Count);
@@ -586,7 +596,7 @@ public partial class McpServerResourceTests
             return "42";
         }, new() { Name = "Test" });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Single(result.Contents);
@@ -603,7 +613,7 @@ public partial class McpServerResourceTests
             return new List<string> { "42", "43" };
         }, new() { Name = "Test", SerializerOptions = JsonContext6.Default.Options });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal(2, result.Contents.Count);
@@ -621,7 +631,7 @@ public partial class McpServerResourceTests
             return new DataContent(new byte[] { 0, 1, 2 }, "application/octet-stream");
         }, new() { Name = "Test" });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Single(result.Contents);
@@ -643,7 +653,7 @@ public partial class McpServerResourceTests
             };
         }, new() { Name = "Test", SerializerOptions = JsonContext6.Default.Options });
         var result = await resource.ReadAsync(
-            new RequestContext<ReadResourceRequestParams>(mockServer.Object) { Params = new() { Uri = "resource://mcp/Test" } },
+            new RequestContext<ReadResourceRequestParams>(mockServer.Object, CreateTestJsonRpcRequest()) { Params = new() { Uri = "resource://mcp/Test" } },
             TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal(2, result.Contents.Count);


### PR DESCRIPTION
# MCP Server Handler Filters

For each handler type in the MCP Server, there are corresponding `AddXXXFilter` methods in `McpServerBuilderExtensions.cs` that allow you to add filters to the handler pipeline. The filters are stored in `McpServerOptions.Filters` and applied during server configuration.

## Available Filter Methods

The following filter methods are available:

- `AddListResourceTemplatesFilter` - Filter for list resource templates handlers
- `AddListToolsFilter` - Filter for list tools handlers
- `AddCallToolFilter` - Filter for call tool handlers
- `AddListPromptsFilter` - Filter for list prompts handlers
- `AddGetPromptFilter` - Filter for get prompt handlers
- `AddListResourcesFilter` - Filter for list resources handlers
- `AddReadResourceFilter` - Filter for read resource handlers
- `AddCompleteFilter` - Filter for completion handlers
- `AddSubscribeToResourcesFilter` - Filter for resource subscription handlers
- `AddUnsubscribeFromResourcesFilter` - Filter for resource unsubscription handlers
- `AddSetLoggingLevelFilter` - Filter for logging level handlers

## Usage

Filters are functions that take a handler and return a new handler, allowing you to wrap the original handler with additional functionality:

```csharp
services.AddMcpServer()
    .WithListToolsHandler(async (context, cancellationToken) =>
    {
        // Your base handler logic
        return new ListToolsResult { Tools = GetTools() };
    })
    .AddListToolsFilter(next => async (context, cancellationToken) =>
    {
        // Pre-processing logic
        Console.WriteLine("Before handler execution");

        var result = await next(context, cancellationToken);

        // Post-processing logic
        Console.WriteLine("After handler execution");
        return result;
    });
```

## Filter Execution Order

```csharp
services.AddMcpServer()
    .WithListToolsHandler(baseHandler)
    .AddListToolsFilter(filter1)  // Executes first (outermost)
    .AddListToolsFilter(filter2)  // Executes second
    .AddListToolsFilter(filter3); // Executes third (closest to handler)
```

Execution flow: `filter1 -> filter2 -> filter3 -> baseHandler -> filter3 -> filter2 -> filter1`

## [Authorize] attribute support

When using the ASP.NET Core integration (`ModelContextProtocol.AspNetCore`), authorization filters are automatically configured by `WithHttpTransport()` that support `[Authorize]` and `[AllowAnonymous]` attributes on MCP server tools, prompts, and resources. Some of the attributes the MCP server automatically respects after this change include:

- **`[Authorize]`** - Requires authentication for access
- **`[Authorize(Roles = "RoleName")]`** - Requires specific roles
- **`[Authorize(Policy = "PolicyName")]`** - Requires specific authorization policies
- **`[AllowAnonymous]`** - Explicitly allows anonymous access (overrides `[Authorize]`)

### Tool Authorization

Tools can be decorated with authorization attributes to control access:

```csharp
[McpServerToolType]
public class WeatherTools
{
    [McpServerTool, Description("Gets public weather data")]
    public static string GetWeather(string location)
    {
        return $"Weather for {location}: Sunny, 25°C";
    }

    [McpServerTool, Description("Gets detailed weather forecast")]
    [Authorize] // Requires authentication
    public static string GetDetailedForecast(string location)
    {
        return $"Detailed forecast for {location}: ...";
    }

    [McpServerTool, Description("Manages weather alerts")]
    [Authorize(Roles = "Admin")] // Requires Admin role
    public static string ManageWeatherAlerts(string alertType)
    {
        return $"Managing alert: {alertType}";
    }
}
```

### Class-Level Authorization

You can apply authorization at the class level, which affects all tools in the class:

```csharp
[McpServerToolType]
[Authorize] // All tools require authentication
public class RestrictedTools
{
    [McpServerTool, Description("Restricted tool accessible to authenticated users")]
    public static string RestrictedOperation()
    {
        return "Restricted operation completed";
    }

    [McpServerTool, Description("Public tool accessible to anonymous users")]
    [AllowAnonymous] // Overrides class-level [Authorize]
    public static string PublicOperation()
    {
        return "Public operation completed";
    }
}
```

### How Authorization Filters Work

The authorization filters work differently for list operations versus individual operations:

#### List Operations (ListTools, ListPrompts, ListResources)
For list operations, the filters automatically remove unauthorized items from the results. Users only see tools, prompts, or resources they have permission to access.

#### Individual Operations (CallTool, GetPrompt, ReadResource)
For individual operations, the filters return authorization errors when access is denied:

- **Tools**: Returns a `CallToolResult` with `IsError = true` and an error message
- **Prompts**: Throws an `McpException` with "Access forbidden" message
- **Resources**: Throws an `McpException` with "Access forbidden" message

### Setup Requirements

To use authorization features, you must configure authentication and authorization in your ASP.NET Core application:

```csharp
var builder = WebApplication.CreateBuilder(args);

builder.Services.AddAuthentication("Bearer")
    .AddJwtBearer(options => { /* JWT configuration */ })
    .AddMcp(options => { /* Resource metadata configuration */ });
builder.Services.AddAuthorization();

builder.Services.AddMcpServer()
    .WithHttpTransport()
    .WithTools<WeatherTools>()
    .AddCallToolFilter(next => async (context, cancellationToken) =>
    {
        // Custom call tool logic
        return await next(context, cancellationToken);
    });

var app = builder.Build();
app.MapMcp();
app.Run();
```

### Custom Authorization Filters

You can also create custom authorization filters using the filter methods:

```csharp
.AddCallToolFilter(next => async (context, cancellationToken) =>
{
    // Custom authorization logic
    if (context.User?.Identity?.IsAuthenticated != true)
    {
        return new CallToolResult
        {
            Content = [new TextContent { Text = "Custom: Authentication required" }],
            IsError = true
        };
    }

    return await next(context, cancellationToken);
});
```

### RequestContext

Within filters, you have access to:

- `context.User` - The current user's `ClaimsPrincipal`
- `context.Services` - The request's service provider for resolving authorization services
- `context.MatchedPrimitive` - The matched tool/prompt/resource with its metadata including authorization attributes

