### PR TITLE
Include docs samples in solution build

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -18,6 +18,7 @@ on:
       - "src/**"
       - "tests/**"
       - "samples/**"
+      - "docs/**"
 
 permissions:
   contents: read

--- a/ModelContextProtocol.slnx
+++ b/ModelContextProtocol.slnx
@@ -8,6 +8,32 @@
     <File Path=".github/workflows/release.md" />
     <File Path=".github/workflows/release.yml" />
   </Folder>
+  <Folder Name="/docs/" />
+  <Folder Name="/docs/concepts/" />
+  <Folder Name="/docs/concepts/elicitation/" />
+  <Folder Name="/docs/concepts/elicitation/samples/" />
+  <Folder Name="/docs/concepts/elicitation/samples/client/">
+    <Project Path="docs/concepts/elicitation/samples/client/ElicitationClient.csproj" />
+  </Folder>
+  <Folder Name="/docs/concepts/elicitation/samples/server/">
+    <Project Path="docs/concepts/elicitation/samples/server/Elicitation.csproj" />
+  </Folder>
+  <Folder Name="/docs/concepts/logging/" />
+  <Folder Name="/docs/concepts/logging/samples/" />
+  <Folder Name="/docs/concepts/logging/samples/client/">
+    <Project Path="docs/concepts/logging/samples/client/LoggingClient.csproj" />
+  </Folder>
+  <Folder Name="/docs/concepts/logging/samples/server/">
+    <Project Path="docs/concepts/logging/samples/server/Logging.csproj" />
+  </Folder>
+  <Folder Name="/docs/concepts/progress/" />
+  <Folder Name="/docs/concepts/progress/samples/" />
+  <Folder Name="/docs/concepts/progress/samples/client/">
+    <Project Path="docs/concepts/progress/samples/client/ProgressClient.csproj" />
+  </Folder>
+  <Folder Name="/docs/concepts/progress/samples/server/">
+    <Project Path="docs/concepts/progress/samples/server/Progress.csproj" />
+  </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/AspNetCoreMcpServer/AspNetCoreMcpServer.csproj" />
     <Project Path="samples/ChatWithTools/ChatWithTools.csproj" />

--- a/docs/concepts/elicitation/samples/client/ElicitationClient.csproj
+++ b/docs/concepts/elicitation/samples/client/ElicitationClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol.Core" Version="0.3.0-preview.3" />
+    <ProjectReference Include="../../../../../src/ModelContextProtocol.Core/ModelContextProtocol.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/concepts/elicitation/samples/client/Program.cs
+++ b/docs/concepts/elicitation/samples/client/Program.cs
@@ -56,13 +56,13 @@ foreach (var block in result.Content)
 async ValueTask<ElicitResult> HandleElicitationAsync(ElicitRequestParams? requestParams, CancellationToken token)
 {
     // Bail out if the requestParams is null or if the requested schema has no properties
-    if (requestParams?.RequestedSchema?.Properties == null)
+    if (requestParams is null || requestParams.RequestedSchema?.Properties is null)
     {
         return new ElicitResult();
     }
 
     // Process the elicitation request
-    if (requestParams?.Message is not null)
+    if (requestParams.Message is not null)
     {
         Console.WriteLine(requestParams.Message);
     }

--- a/docs/concepts/elicitation/samples/server/Elicitation.csproj
+++ b/docs/concepts/elicitation/samples/server/Elicitation.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.3" />
+    <ProjectReference Include="../../../../../src/ModelContextProtocol.AspNetCore/ModelContextProtocol.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/concepts/logging/samples/client/LoggingClient.csproj
+++ b/docs/concepts/logging/samples/client/LoggingClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol.Core" Version="0.3.0-preview.3" />
+    <ProjectReference Include="../../../../../src/ModelContextProtocol.Core/ModelContextProtocol.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/concepts/logging/samples/server/Logging.csproj
+++ b/docs/concepts/logging/samples/server/Logging.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.3" />
+    <ProjectReference Include="../../../../../src/ModelContextProtocol.AspNetCore/ModelContextProtocol.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/concepts/progress/samples/client/ProgressClient.csproj
+++ b/docs/concepts/progress/samples/client/ProgressClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol.Core" Version="0.3.0-preview.3" />
+    <ProjectReference Include="../../../../../src/ModelContextProtocol.Core/ModelContextProtocol.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/concepts/progress/samples/server/Progress.csproj
+++ b/docs/concepts/progress/samples/server/Progress.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.3" />
+    <ProjectReference Include="../../../../../src/ModelContextProtocol.AspNetCore/ModelContextProtocol.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds the docs samples into the solution so they will be built as part of CI, which should flag when PRs cause the samples to break. 