### PR TITLE
Correct 'McpTool' to 'McpServerTool' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ var response = await chatClient.GetResponseAsync(
 Here is an example of how to create an MCP server and register all tools from the current application.
 It includes a simple echo tool as an example (this is included in the same file here for easy of copy and paste, but it needn't be in the same file...
 the employed overload of `WithTools` examines the current assembly for classes with the `McpServerToolType` attribute, and registers all methods with the
-`McpTool` attribute as tools.)
+`McpServerTool` attribute as tools.)
 
 ```
 dotnet add package ModelContextProtocol --prerelease


### PR DESCRIPTION
Fix README to say McpServerTool, not McpTool to match the code.

## Motivation and Context
doc bug

## How Has This Been Tested?
n/a

## Breaking Changes
n/a

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
