### PR TITLE
Add unit test for ElicitAsync<T> with no `SerializationOptions` #798

### DIFF
--- a/tests/ModelContextProtocol.Tests/Protocol/ElicitationTypedTests.cs
+++ b/tests/ModelContextProtocol.Tests/Protocol/ElicitationTypedTests.cs
@@ -211,6 +211,11 @@ public partial class ElicitationTypedTests : ClientServerTestBase
     [Fact]
     public async Task Can_Elicit_Typed_Information_No_SerializationOptions()
     {
+        if (JsonSerializer.IsReflectionEnabledByDefault is false)
+        {
+            Assert.Skip("Reflection is disabled by default. This test requires reflection to be enabled.");
+        }
+
         await using McpClient client = await CreateMcpClientForServer(new McpClientOptions
         {
             Capabilities = new()
@@ -230,33 +235,33 @@ public partial class ElicitationTypedTests : ClientServerTestBase
                             var value = entry.Value;
                             switch (key)
                             {
-                                case nameof(SampleForm.Name):
+                                case "name":
                                     var stringSchema = Assert.IsType<ElicitRequestParams.StringSchema>(value);
                                     Assert.Equal("string", stringSchema.Type);
                                     break;
 
-                                case nameof(SampleForm.Age):
+                                case "age":
                                     var intSchema = Assert.IsType<ElicitRequestParams.NumberSchema>(value);
                                     Assert.Equal("integer", intSchema.Type);
                                     break;
 
-                                case nameof(SampleForm.Active):
+                                case "active":
                                     var boolSchema = Assert.IsType<ElicitRequestParams.BooleanSchema>(value);
                                     Assert.Equal("boolean", boolSchema.Type);
                                     break;
 
-                                case nameof(SampleForm.Role):
+                                case "role":
                                     var enumSchema = Assert.IsType<ElicitRequestParams.EnumSchema>(value);
                                     Assert.Equal("string", enumSchema.Type);
                                     Assert.Equal([nameof(SampleRole.User), nameof(SampleRole.Admin)], enumSchema.Enum);
                                     break;
 
-                                case nameof(SampleForm.Score):
+                                case "score":
                                     var numSchema = Assert.IsType<ElicitRequestParams.NumberSchema>(value);
                                     Assert.Equal("number", numSchema.Type);
                                     break;
 
-                                case nameof(SampleForm.Created):
+                                case "created":
                                     var dateTimeSchema = Assert.IsType<ElicitRequestParams.StringSchema>(value);
                                     Assert.Equal("string", dateTimeSchema.Type);
                                     Assert.Equal("date-time", dateTimeSchema.Format);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
