### PR TITLE
Bump to 0.4.0-preview.1 for releasing breaking changes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,8 +5,8 @@
     <PackageProjectUrl>https://github.com/modelcontextprotocol/csharp-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/modelcontextprotocol/csharp-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>preview.5</VersionSuffix>
+    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
     <Authors>ModelContextProtocolOfficial</Authors>
     <Copyright>© Anthropic and Contributors.</Copyright>
     <PackageTags>ModelContextProtocol;mcp;ai;llm</PackageTags>


### PR DESCRIPTION
We have breaking API changes queued up in main that we will be releasing. This bumps the version to `0.4.0-preview.1` to reflect the notable differences.