### PR TITLE
Fix support for sending server notifications with request-specific McpServer instances used outside their original scope.

### DIFF
--- a/src/ModelContextProtocol.Core/Server/SseResponseStreamTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/SseResponseStreamTransport.cs
@@ -66,6 +66,7 @@ public sealed class SseResponseStreamTransport(Stream sseResponseStream, string?
     public async Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
     {
         Throw.IfNull(message);
+        // If the underlying writer has been disposed, just drop the message.
         await _sseWriter.SendMessageAsync(message, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/ModelContextProtocol.Core/Server/SseWriter.cs
+++ b/src/ModelContextProtocol.Core/Server/SseWriter.cs
@@ -47,7 +47,7 @@ internal sealed class SseWriter(string? messageEndpoint = null, BoundedChannelOp
         return _writeTask;
     }
 
-    public async Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
+    public async Task<bool> SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
     {
         Throw.IfNull(message);
 
@@ -55,14 +55,14 @@ internal sealed class SseWriter(string? messageEndpoint = null, BoundedChannelOp
 
         if (_disposed)
         {
-            // Don't throw an ODE, because this is disposed internally when the transport disconnects due to an abort
-            // or sending all the responses for the a give given Streamable HTTP POST request, so the user might not be at fault.
-            // There's precedence for no-oping here similar to writing to the response body of an aborted request in ASP.NET Core.
-            return;
+            // Don't throw ObjectDisposedException here; just return false to indicate the message wasn't sent.
+            // The calling tranport can determine what to do in this case (drop the message, or fallback to another transport).
+            return false;
         }
 
         // Emit redundant "event: message" lines for better compatibility with other SDKs.
         await _messages.Writer.WriteAsync(new SseItem<JsonRpcMessage?>(message, SseParser.EventTypeDefault), cancellationToken).ConfigureAwait(false);
+        return true;
     }
 
     public async ValueTask DisposeAsync()

--- a/src/ModelContextProtocol.Core/Server/SseWriter.cs
+++ b/src/ModelContextProtocol.Core/Server/SseWriter.cs
@@ -56,7 +56,7 @@ internal sealed class SseWriter(string? messageEndpoint = null, BoundedChannelOp
         if (_disposed)
         {
             // Don't throw ObjectDisposedException here; just return false to indicate the message wasn't sent.
-            // The calling tranport can determine what to do in this case (drop the message, or fallback to another transport).
+            // The calling transport can determine what to do in this case (drop the message, or fallback to another transport).
             return false;
         }
 

--- a/src/ModelContextProtocol.Core/Server/SseWriter.cs
+++ b/src/ModelContextProtocol.Core/Server/SseWriter.cs
@@ -56,7 +56,7 @@ internal sealed class SseWriter(string? messageEndpoint = null, BoundedChannelOp
         if (_disposed)
         {
             // Don't throw ObjectDisposedException here; just return false to indicate the message wasn't sent.
-            // The calling transport can determine what to do in this case (drop the message, or fallback to another transport).
+            // The calling transport can determine what to do in this case (drop the message, or fall back to another transport).
             return false;
         }
 

--- a/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
@@ -131,6 +131,7 @@ public sealed class StreamableHttpServerTransport : ITransport
             throw new InvalidOperationException("Unsolicited server to client messages are not supported in stateless mode.");
         }
 
+        // If the underlying writer has been disposed, just drop the message.
         await _sseWriter.SendMessageAsync(message, cancellationToken).ConfigureAwait(false);
     }
 


### PR DESCRIPTION
Fix #693.