### PR TITLE
Tokens can be cached beyond the lifetime of the (http) transport.

### DIFF
--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthOptions.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthOptions.cs
@@ -86,4 +86,10 @@ public sealed class ClientOAuthOptions
     /// </para>
     /// </remarks>
     public IDictionary<string, string> AdditionalAuthorizationParameters { get; set; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets or sets the token cache to use for storing and retrieving tokens beyond the lifetime of the transport.
+    /// If none is provided, tokens will be cached with the transport.
+    /// </summary>
+    public ITokenCache? TokenCache { get; set; }
 }

--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
@@ -40,7 +40,7 @@ internal sealed partial class ClientOAuthProvider
     private string? _clientId;
     private string? _clientSecret;
 
-    private TokenContainer? _token;
+    private ITokenCache _tokenCache;
     private AuthorizationServerMetadata? _authServerMetadata;
 
     /// <summary>
@@ -82,6 +82,7 @@ internal sealed partial class ClientOAuthProvider
         _dcrClientUri = options.DynamicClientRegistration?.ClientUri;
         _dcrInitialAccessToken = options.DynamicClientRegistration?.InitialAccessToken;
         _dcrResponseDelegate = options.DynamicClientRegistration?.ResponseDelegate;
+        _tokenCache = options.TokenCache ?? new InMemoryTokenCache();
     }
 
     /// <summary>
@@ -135,20 +136,22 @@ internal sealed partial class ClientOAuthProvider
     {
         ThrowIfNotBearerScheme(scheme);
 
+        var token = await _tokenCache.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+
         // Return the token if it's valid
-        if (_token != null && _token.ExpiresAt > DateTimeOffset.UtcNow.AddMinutes(5))
+        if (token != null && token.ExpiresAt > DateTimeOffset.UtcNow.AddMinutes(5))
         {
-            return _token.AccessToken;
+            return token.AccessToken;
         }
 
         // Try to refresh the token if we have a refresh token
-        if (_token?.RefreshToken != null && _authServerMetadata != null)
+        if (token?.RefreshToken != null && _authServerMetadata != null)
         {
-            var newToken = await RefreshTokenAsync(_token.RefreshToken, resourceUri, _authServerMetadata, cancellationToken).ConfigureAwait(false);
+            var newToken = await RefreshTokenAsync(token.RefreshToken, resourceUri, _authServerMetadata, cancellationToken).ConfigureAwait(false);
             if (newToken != null)
             {
-                _token = newToken;
-                return _token.AccessToken;
+                await _tokenCache.StoreTokenAsync(newToken, cancellationToken).ConfigureAwait(false);
+                return newToken.AccessToken;
             }
         }
 
@@ -234,7 +237,7 @@ internal sealed partial class ClientOAuthProvider
             ThrowFailedToHandleUnauthorizedResponse($"The {nameof(AuthorizationRedirectDelegate)} returned a null or empty token.");
         }
 
-        _token = token;
+        await _tokenCache.StoreTokenAsync(token, cancellationToken).ConfigureAwait(false);
         LogOAuthAuthorizationCompleted();
     }
 

--- a/src/ModelContextProtocol.Core/Authentication/ITokenCache.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ITokenCache.cs
@@ -1,0 +1,17 @@
+namespace ModelContextProtocol.Authentication;
+
+/// <summary>
+/// Allows the client to cache access tokens beyond the lifetime of the transport.
+/// </summary>
+public interface ITokenCache
+{
+    /// <summary>
+    /// Cache the token.
+    /// </summary>
+    Task StoreTokenAsync(TokenContainer token, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get the cached token.
+    /// </summary>
+    Task<TokenContainer?> GetTokenAsync(CancellationToken cancellationToken);
+}

--- a/src/ModelContextProtocol.Core/Authentication/InMemoryTokenCache.cs
+++ b/src/ModelContextProtocol.Core/Authentication/InMemoryTokenCache.cs
@@ -1,0 +1,27 @@
+
+namespace ModelContextProtocol.Authentication;
+
+/// <summary>
+/// Caches the token in-memory within this instance.
+/// </summary>
+internal class InMemoryTokenCache : ITokenCache
+{
+    private TokenContainer? _token;
+
+    /// <summary>
+    /// Cache the token.
+    /// </summary>
+    public Task StoreTokenAsync(TokenContainer token, CancellationToken cancellationToken)
+    {
+        _token = token;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Get the cached token.
+    /// </summary>
+    public Task<TokenContainer?> GetTokenAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_token);
+    }
+}

--- a/src/ModelContextProtocol.Core/Authentication/TokenContainer.cs
+++ b/src/ModelContextProtocol.Core/Authentication/TokenContainer.cs
@@ -5,7 +5,7 @@ namespace ModelContextProtocol.Authentication;
 /// <summary>
 /// Represents a token response from the OAuth server.
 /// </summary>
-internal sealed class TokenContainer
+public sealed class TokenContainer
 {
     /// <summary>
     /// Gets or sets the access token.
@@ -46,7 +46,7 @@ internal sealed class TokenContainer
     /// <summary>
     /// Gets or sets the timestamp when the token was obtained.
     /// </summary>
-    [JsonIgnore]
+    [JsonPropertyName("obtained_at")]
     public DateTimeOffset ObtainedAt { get; set; }
 
     /// <summary>


### PR DESCRIPTION
I added the possibility to plugin a token cache, so that the client can be made to reuse its access token beyond the lifetime of the transport. By default tokens are only cached for the lifetime of the transport.

## Motivation and Context
When the client acquires an access token and a refresh token, it should be able to utilze them to make authenticated requests to the server even after it was restarted. The client should not need to go through the OAuth dance again and again every time it is initialised (unless the access token is no longer valid and no refresh token was acquired or the refresh token was revoked).

## How Has This Been Tested?
I tested it via a [proof of concept application](https://github.com/halllo/McpExperiments/blob/8f856563a8c74e09700bea41cd61171c937bf0f6/MyMCPClient.Console/Program.cs#L38C3-L38C55) without a token cache (using the default `InMemoryTokenCache`) and with a custom implementation of a [file-based token cache](https://github.com/halllo/McpExperiments/blob/main/MyMCPClient.Console/TokenCacheFile.cs).

## Breaking Changes
The introduction of the `ITokenCache` is backwards compatible. If no custom token cache is provided, it falls back to an `InMemoryTokenCache` with the same lifetime as the (oauth enabled http) transport (like before).

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
- I made `TokenContainer` public, so that it can be passed into custom token caches.
- I also made its `ObtainedAt` property serialisable, because it needs to remember when it was obtained after serialization to calculate the expiration.
These two changes seemed more reasonable than introducing another token type for cache serialization only. I didn't find usages that could be disrupted by this.