### PR TITLE
Update .NET version in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,8 @@ jobs:
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
+            10.0.x
             9.0.x
-            8.0.x
 
       - name: Pack
         run: dotnet pack
@@ -139,11 +139,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
-        with:
-          dotnet-version: 9.0.x
 
       - name: Download build artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1


### PR DESCRIPTION
Updated .NET version in release workflow to 10.0.x and removed older versions. This is a follow up to #822.

You can see from https://github.com/modelcontextprotocol/csharp-sdk/actions/runs/18327180276/job/52194615796 that the build-package job is missing the .NET 10 SDK.
