### PR TITLE
Remove problematic System.Net.Http package reference from tests

### DIFF
--- a/tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj
+++ b/tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj
@@ -53,7 +53,6 @@
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="System.Linq.AsyncEnumerable" />
-    <PackageReference Include="System.Net.Http" />
     <PackageReference Include="JsonSchema.Net" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">


### PR DESCRIPTION
It's started producing a warning-as-error about not getting pruned.