### PR TITLE
Pin global.json to rc.1 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.100-rc.1",
-    "rollForward": "minor",
+    "version": "10.0.100-rc.1.25451.107",
+    "rollForward": "disable",
     "allowPrerelease": true
   }
 }


### PR DESCRIPTION
This is an attempt to work around an apparent bug in either the .NET 10 rc2 SDK or xUnit v3. There's some initial discussion about similar "Catastrophic failures" in https://github.com/xunit/xunit/issues/3413, but we might have to file an issue against the SDK. I'm not sure what the root cause is.