### PR TITLE
Revert "Pin global.json to rc.1 SDK"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.100-rc.1.25451.107",
-    "rollForward": "disable",
+    "version": "10.0.100-rc.1",
+    "rollForward": "minor",
     "allowPrerelease": true
   }
 }


### PR DESCRIPTION
Reverts modelcontextprotocol/csharp-sdk#869

This broke the repo, as it looks like this particular SDK isn't installed. These changes must not have been used for that PR?