### PR TITLE
Refactor HandlePostRequest to return IAsyncEnumerable of JsonRpcMessage

### DIFF
--- a/src/ModelContextProtocol.Core/Protocol/JsonRpcMessage.cs
+++ b/src/ModelContextProtocol.Core/Protocol/JsonRpcMessage.cs
@@ -40,7 +40,7 @@ public abstract class JsonRpcMessage
     /// <remarks>
     /// This property should only be set when implementing a custom <see cref="ITransport"/>
     /// that needs to pass additional per-message context or to pass a <see cref="JsonRpcMessageContext.User"/>
-    /// to <see cref="StreamableHttpServerTransport.HandlePostRequest(JsonRpcMessage, Stream, CancellationToken)"/>
+    /// to <see cref="StreamableHttpServerTransport.HandlePostRequest(JsonRpcMessage, CancellationToken)"/>
     /// or <see cref="SseResponseStreamTransport.OnMessageReceivedAsync(JsonRpcMessage, CancellationToken)"/> .
     /// </remarks>
     [JsonIgnore]

--- a/src/ModelContextProtocol.Core/Server/SseWriter.cs
+++ b/src/ModelContextProtocol.Core/Server/SseWriter.cs
@@ -47,6 +47,16 @@ internal sealed class SseWriter(string? messageEndpoint = null, BoundedChannelOp
         return _writeTask;
     }
 
+    public IAsyncEnumerable<SseItem<JsonRpcMessage?>> ReadMessagesAsync(CancellationToken cancellationToken)
+    {
+        var messages = _messages.Reader.ReadAllAsync(cancellationToken);
+        if (MessageFilter is not null)
+        {
+            messages = MessageFilter(messages, cancellationToken);
+        }
+        return messages;
+    }
+
     public async Task<bool> SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
     {
         Throw.IfNull(message);


### PR DESCRIPTION
This PR changes the signature of HandlePostRequest in StreamableHttpServerTransport from:

```csharp
public async Task<bool> HandlePostRequest(JsonRpcMessage message, Stream responseStream, CancellationToken cancellationToken = default)
```

 to:

```
public async IAsyncEnumerable<JsonRpcMessage> HandlePostRequest(JsonRpcMessage message, [EnumeratorCancellation] CancellationToken cancellationToken = default)
```

