### PR TITLE
Call Regex.IsMatch when Match is not needed

### DIFF
--- a/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerResource.cs
+++ b/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerResource.cs
@@ -317,15 +317,21 @@ internal sealed class AIFunctionMcpServerResource : McpServerResource
     public override bool IsMatch(string uri)
     {
         Throw.IfNull(uri);
-        return TryMatch(uri, out _);
-    }
 
-    private bool TryMatch(string uri, out Match? match)
-    {
         // For templates, use the Regex to parse. For static resources, we can just compare the URIs.
         if (_uriParser is null)
         {
             // This resource is not templated.
+            return UriTemplate.UriTemplateComparer.Instance.Equals(uri, ProtocolResourceTemplate.UriTemplate);
+        }
+
+        return _uriParser.IsMatch(uri);
+    }
+
+    private bool TryMatch(string uri, out Match? match)
+    {
+        if (_uriParser is null)
+        {
             match = null;
             return UriTemplate.UriTemplateComparer.Instance.Equals(uri, ProtocolResourceTemplate.UriTemplate);
         }


### PR DESCRIPTION
This should address @stephentoub's feedback in https://github.com/modelcontextprotocol/csharp-sdk/pull/897#discussion_r2441537588 which I hastily misinterpreted to be about naming earlier.