### PR TITLE
Update download-artifact path reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Publish to GitHub NuGet package registry
         run: dotnet nuget push
-            ${{github.workspace}}/build-artifacts/packages/*.nupkg
+            ${{github.workspace}}/packages/*.nupkg
             --source "github"
             --api-key ${{ secrets.GITHUB_TOKEN }}
             --skip-duplicate
@@ -145,7 +145,7 @@ jobs:
 
       - name: Upload release asset
         run: gh release upload ${{ github.event.release.tag_name }}
-          ${{ github.workspace }}/build-artifacts/packages/*.*nupkg
+          ${{ github.workspace }}/packages/*.*nupkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -170,7 +170,7 @@ jobs:
 
       - name: Publish to NuGet.org (Releases only)
         run: dotnet nuget push
-            ${{github.workspace}}/build-artifacts/packages/*.nupkg
+            ${{github.workspace}}/packages/*.nupkg
             --source https://api.nuget.org/v3/index.json
             --api-key ${{ secrets.NUGET_KEY_MODELCONTEXTPROTOCOL }}
             --skip-duplicate


### PR DESCRIPTION
Compensates for the breaking change in https://github.com/actions/download-artifact/releases/tag/v5.0.0, as I've interpreted how it applies to our usage.