### PR TITLE
fixed donet version from 10.0.100-rc.1.25451.107 to 10.0.100-rc.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
         with:
           dotnet-version: |
-            10.0.100-rc.2
+            10.0.x
             9.0.x
 
       - name: Pack


### PR DESCRIPTION
Updated the release.yml to include dotnet 10 rc 2. After merging the change to global.json with the same version it seems to have broken the release.

## Motivation and Context
Broken workflow

## How Has This Been Tested?
Can't test the workflow in my fork.

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ x] My code follows the repository's style guidelines
- [ x] New and existing tests pass locally
- [ n/a] I have added appropriate error handling
- [ n/a] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
