### PR TITLE
Fix tests in Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,5 +19,5 @@
 			}
 		}
 	},
-	"postCreateCommand": "dotnet --list-sdks && echo 'Available .NET SDKs installed successfully!'"
+	"postCreateCommand": "dotnet dev-certs https --trust && dotnet --list-sdks && echo 'Available .NET SDKs installed successfully!'"
 }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryTest.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryTest.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModelContextProtocol.Tests.Utils;
 
 namespace ModelContextProtocol.AspNetCore.Tests.Utils;
@@ -11,11 +11,11 @@ public class KestrelInMemoryTest : LoggedTest
     public KestrelInMemoryTest(ITestOutputHelper testOutputHelper)
         : base(testOutputHelper)
     {
-        // Use SlimBuilder instead of EmptyBuilder to avoid having to call UseRouting() and UseEndpoints(_ => { })
-        // or a helper that does the same every test. But clear out the existing socket transport to avoid potential port conflicts.
-        Builder = WebApplication.CreateSlimBuilder();
-        Builder.Services.RemoveAll<IConnectionListenerFactory>();
+        Builder = WebApplication.CreateEmptyBuilder(new());
         Builder.Services.AddSingleton<IConnectionListenerFactory>(KestrelInMemoryTransport);
+        Builder.WebHost.UseKestrelCore();
+        Builder.Services.AddRoutingCore();
+        Builder.Services.AddLogging();
         Builder.Services.AddSingleton(XunitLoggerProvider);
 
         SocketsHttpHandler.ConnectCallback = (context, token) =>

--- a/tests/ModelContextProtocol.TestOAuthServer/Program.cs
+++ b/tests/ModelContextProtocol.TestOAuthServer/Program.cs
@@ -96,9 +96,6 @@ public sealed class Program
 
         var app = builder.Build();
 
-        app.UseRouting();
-        app.UseEndpoints(_ => { });
-
         // Set up the demo client
         var clientId = "demo-client";
         var clientSecret = "demo-secret";

--- a/tests/ModelContextProtocol.TestSseServer/Program.cs
+++ b/tests/ModelContextProtocol.TestSseServer/Program.cs
@@ -424,8 +424,6 @@ public class Program
             .WithHttpTransport();
 
         var app = builder.Build();
-        app.UseRouting();
-        app.UseEndpoints(_ => { });
 
         // Handle the /stateless endpoint if no other endpoints have been matched by the call to UseRouting above.
         HandleStatelessMcp(app);


### PR DESCRIPTION
Before this PR, tests in classes deriving from `KestrelInMemoryTest` would fail using the Dev Container configured by this project's devcontainer.json based on `mcr.microsoft.com/devcontainers/dotnet:1-8.0-jammy`. The `HttpClient` would timeout trying to connect to Kestrel using the in-memory test transport. Some investigation uncovered this was caused by the [Dockerfile setting a non-default `ASPNETCORE_HTTP_PORTS` environment variable](https://github.com/dotnet/dotnet-docker/blob/a4996523cfca71eb1623bfae84a1c4fe2c9aceb6/src/runtime-deps/8.0/jammy/amd64/Dockerfile#L6-L7) of `8080` instead of the normal default port of 5000 used by default by the test.

I noticed that the tests using `SseServerIntegrationTestFixture` still passed on the Dev Container while `KestrelInMemoryTest` wouldn't, and this is because `ModelContextProtocol.TestSseServer` referenced by the test fixture uses `WebApplication.CreateEmptyBuilder()` which doesn't read environment variables as configuration instead of `WebApplication.CreateSlimBuilder()` which does. I could have fixed the default port issue by explicitly calling something like `ListenLocalhost(5000)` which would override configuration, but I discovered that `CreateEmptyBuilder()` actually will automatically add the routing middleware if you don't add it manually just like the other builders despite what I claimed in the comment I deleted. Had I known that to begin with, I would have used `CreateEmptyBuilder()` all along for simplicity and avoiding potential environmental issues like this.

I also updated the Dev Container's "postCreateCommand" to install and trust a developer certificate. Technically, only the installation is necessary, since the tests use `RemoteCertificateValidationCallback = (_, _, _, _) => true`, but I think trusting makes sense for running samples. Currently, only the `TestOAuthServer` uses HTTPS. This wouldn't be necessary if we updated the tests and `ProtectedMCPServer` sample to set [RequireHttpsMetadata](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.jwtbeareroptions.requirehttpsmetadata?view=aspnetcore-1.1#microsoft-aspnetcore-builder-jwtbeareroptions-requirehttpsmetadata) to false. But for the sample in particular, I'd rather not do this.

