### PR TITLE
Remove TODOs related to AllowOutOfOrderMetadataProperty workarounds.

### DIFF
--- a/src/ModelContextProtocol.Core/Protocol/ContentBlock.cs
+++ b/src/ModelContextProtocol.Core/Protocol/ContentBlock.cs
@@ -25,7 +25,7 @@ namespace ModelContextProtocol.Protocol;
 /// See the <see href="https://github.com/modelcontextprotocol/specification/blob/main/schema/">schema</see> for more details.
 /// </para>
 /// </remarks>
-[JsonConverter(typeof(Converter))] // TODO: This converter exists due to the lack of downlevel support for AllowOutOfOrderMetadataProperties.
+[JsonConverter(typeof(Converter))]
 public abstract class ContentBlock
 {
     /// <summary>Prevent external derivations.</summary>
@@ -55,6 +55,8 @@ public abstract class ContentBlock
     /// <summary>
     /// Provides a <see cref="JsonConverter"/> for <see cref="ContentBlock"/>.
     /// </summary>
+    /// Provides a polymorphic converter for the <see cref="ContentBlock"/> class that doesn't  require
+    /// setting <see cref="JsonSerializerOptions.AllowOutOfOrderMetadataProperties"/> explicitly.
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class Converter : JsonConverter<ContentBlock>
     {

--- a/src/ModelContextProtocol.Core/Protocol/ElicitRequestParams.cs
+++ b/src/ModelContextProtocol.Core/Protocol/ElicitRequestParams.cs
@@ -61,7 +61,7 @@ public sealed class ElicitRequestParams
     /// Represents restricted subset of JSON Schema: 
     /// <see cref="StringSchema"/>, <see cref="NumberSchema"/>, <see cref="BooleanSchema"/>, or <see cref="EnumSchema"/>.
     /// </summary>
-    [JsonConverter(typeof(Converter))] // TODO: This converter exists due to the lack of downlevel support for AllowOutOfOrderMetadataProperties.
+    [JsonConverter(typeof(Converter))]
     public abstract class PrimitiveSchemaDefinition
     {
         /// <summary>Prevent external derivations.</summary>
@@ -84,6 +84,8 @@ public sealed class ElicitRequestParams
         /// <summary>
         /// Provides a <see cref="JsonConverter"/> for <see cref="ResourceContents"/>.
         /// </summary>
+        /// Provides a polymorphic converter for the <see cref="PrimitiveSchemaDefinition"/> class that doesn't  require
+        /// setting <see cref="JsonSerializerOptions.AllowOutOfOrderMetadataProperties"/> explicitly.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public class Converter : JsonConverter<PrimitiveSchemaDefinition>
         {

--- a/src/ModelContextProtocol.Core/Protocol/Reference.cs
+++ b/src/ModelContextProtocol.Core/Protocol/Reference.cs
@@ -39,6 +39,10 @@ public abstract class Reference
     /// <summary>
     /// Provides a <see cref="JsonConverter"/> for <see cref="Reference"/>.
     /// </summary>
+    /// <remarks>
+    /// Provides a polymorphic converter for the <see cref="Reference"/> class that doesn't  require
+    /// setting <see cref="JsonSerializerOptions.AllowOutOfOrderMetadataProperties"/> explicitly.
+    /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class Converter : JsonConverter<Reference>
     {
@@ -94,8 +98,6 @@ public abstract class Reference
                         break;
                 }
             }
-
-            // TODO: This converter exists due to the lack of downlevel support for AllowOutOfOrderMetadataProperties.
 
             switch (type)
             {


### PR DESCRIPTION
Even though we've now updated the STJ baseline to v10, we have decided to keep the `AllowOutOfOrderMetadataProperty` workarounds since removing those would require that users always set that value to true when working with the MCP sdk.