### PR TITLE
Make `JsonRpcMessageWithId.RequestId` non-required

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -250,7 +250,6 @@ internal sealed class StreamableHttpHandler(
     {
         var jsonRpcError = new JsonRpcError
         {
-            Id = default,
             Error = new()
             {
                 Code = errorCode,

--- a/src/ModelContextProtocol.Core/Protocol/JsonRpcMessageWithId.cs
+++ b/src/ModelContextProtocol.Core/Protocol/JsonRpcMessageWithId.cs
@@ -26,5 +26,5 @@ public abstract class JsonRpcMessageWithId : JsonRpcMessage
     /// Each ID is expected to be unique within the context of a given session.
     /// </remarks>
     [JsonPropertyName("id")]
-    public required RequestId Id { get; set; }
+    public RequestId Id { get; set; }
 }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/StatelessServerTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/StatelessServerTests.cs
@@ -203,7 +203,6 @@ public class StatelessServerTests(ITestOutputHelper outputHelper) : KestrelInMem
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => server.SendRequestAsync(new JsonRpcRequest
         {
-            Id = default,
             Method = RequestMethods.SamplingCreateMessage
         }));
         return ex.Message;
@@ -222,7 +221,6 @@ public class StatelessServerTests(ITestOutputHelper outputHelper) : KestrelInMem
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => server.SendRequestAsync(new JsonRpcRequest
         {
-            Id = default,
             Method = RequestMethods.RootsList
         }));
         return ex.Message;
@@ -241,7 +239,6 @@ public class StatelessServerTests(ITestOutputHelper outputHelper) : KestrelInMem
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => server.SendRequestAsync(new JsonRpcRequest
         {
-            Id = default,
             Method = RequestMethods.ElicitationCreate
         }));
         return ex.Message;

--- a/tests/ModelContextProtocol.Tests/Client/McpClientExtensionsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientExtensionsTests.cs
@@ -204,7 +204,6 @@ public class McpClientExtensionsTests
             .Setup(c => c.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(new object(), McpJsonUtilities.DefaultOptions),
             });
 
@@ -226,7 +225,6 @@ public class McpClientExtensionsTests
             .Setup(c => c.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(resultPayload, McpJsonUtilities.DefaultOptions),
             });
 
@@ -249,7 +247,6 @@ public class McpClientExtensionsTests
             .Setup(c => c.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(callResult, McpJsonUtilities.DefaultOptions),
             });
 
@@ -270,7 +267,6 @@ public class McpClientExtensionsTests
             .Setup(c => c.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(new EmptyResult(), McpJsonUtilities.DefaultOptions),
             });
 
@@ -290,7 +286,6 @@ public class McpClientExtensionsTests
             .Setup(c => c.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(new EmptyResult(), McpJsonUtilities.DefaultOptions),
             });
 
@@ -313,7 +308,6 @@ public class McpClientExtensionsTests
             .Setup(c => c.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(resultPayload, McpJsonUtilities.DefaultOptions),
             });
 
@@ -336,7 +330,6 @@ public class McpClientExtensionsTests
             .Setup(c => c.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(resultPayload, McpJsonUtilities.DefaultOptions),
             });
 
@@ -359,7 +352,6 @@ public class McpClientExtensionsTests
             .Setup(c => c.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(resultPayload, McpJsonUtilities.DefaultOptions),
             });
 
@@ -382,7 +374,6 @@ public class McpClientExtensionsTests
             .Setup(c => c.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(resultPayload, McpJsonUtilities.DefaultOptions),
             });
 

--- a/tests/ModelContextProtocol.Tests/McpEndpointExtensionsTests.cs
+++ b/tests/ModelContextProtocol.Tests/McpEndpointExtensionsTests.cs
@@ -57,7 +57,6 @@ public class McpEndpointExtensionsTests
             .Setup(s => s.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(42, McpJsonUtilities.DefaultOptions),
             });
 

--- a/tests/ModelContextProtocol.Tests/Server/McpServerExtensionsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerExtensionsTests.cs
@@ -94,7 +94,6 @@ public class McpServerExtensionsTests
             .Setup(s => s.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(resultPayload, McpJsonUtilities.DefaultOptions),
             });
 
@@ -146,7 +145,6 @@ public class McpServerExtensionsTests
             })
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(resultPayload, McpJsonUtilities.DefaultOptions),
             });
 
@@ -159,7 +157,7 @@ public class McpServerExtensionsTests
         Assert.Equal(ChatRole.Assistant, last.Role);
         Assert.Equal("resp", last.Text);
         mockServer.Verify(s => s.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()), Times.Once);
-        
+
         // Verify that the default value was used
         Assert.NotNull(capturedRequest);
         Assert.Equal(CustomMaxSamplingOutputTokens, capturedRequest.MaxTokens);
@@ -180,7 +178,6 @@ public class McpServerExtensionsTests
             .Setup(s => s.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(resultPayload, McpJsonUtilities.DefaultOptions),
             });
 
@@ -207,7 +204,6 @@ public class McpServerExtensionsTests
             .Setup(s => s.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Id = default,
                 Result = JsonSerializer.SerializeToNode(resultPayload, McpJsonUtilities.DefaultOptions),
             });
 


### PR DESCRIPTION
## Summary

In #892, the `RequestId` property in `JsonRpcMessageWithId` was changed to be `required` to align with with the MCP schema. The intention behind this change was to disallow uninitialized values. However:
1. You can still just assign the value `default`, which is what happens in practice because...
2. The current design actually expects `RequestId` to be uninitialized in some cases so that an ID can be dynamically/lazily generated

Forcing developers to explicitly set `RequestId` to `default` doesn't seem helpful.

## Changes

This PR reverts `RequestId` to be non-`required` and adjusts internal usage to account for this.

Fixes https://github.com/modelcontextprotocol/csharp-sdk/pull/892#discussion_r2507155110