### PR TITLE
Helper method to merge additional metadata into requests, results, and notifications

### DIFF
--- a/src/ModelContextProtocol.Core/Protocol/NotificationParams.cs
+++ b/src/ModelContextProtocol.Core/Protocol/NotificationParams.cs
@@ -21,4 +21,21 @@ public abstract class NotificationParams
     /// </remarks>
     [JsonPropertyName("_meta")]
     public JsonObject? Meta { get; set; }
+
+    /// <summary>
+    /// Merges additional metadata into the existing Meta object.
+    /// </summary>
+    /// <param name="additionalMeta">The additional metadata to merge.</param>
+    public void MergeMeta(JsonObject additionalMeta)
+    {
+        if (Meta == null)
+        {
+            Meta = new JsonObject();
+        }
+
+        foreach (var kvp in additionalMeta)
+        {
+            Meta[kvp.Key] = kvp.Value;
+        }
+    }
 }

--- a/src/ModelContextProtocol.Core/Protocol/RequestParams.cs
+++ b/src/ModelContextProtocol.Core/Protocol/RequestParams.cs
@@ -65,4 +65,21 @@ public abstract class RequestParams
             }
         }
     }
+
+    /// <summary>
+    /// Merges additional metadata into the existing Meta object.
+    /// </summary>
+    /// <param name="additionalMeta">The additional metadata to merge.</param>
+    public void MergeMeta(JsonObject additionalMeta)
+    {
+        if (Meta == null)
+        {
+            Meta = new JsonObject();
+        }
+
+        foreach (var kvp in additionalMeta)
+        {
+            Meta[kvp.Key] = kvp.Value;
+        }
+    }
 }

--- a/src/ModelContextProtocol.Core/Protocol/Result.cs
+++ b/src/ModelContextProtocol.Core/Protocol/Result.cs
@@ -21,4 +21,21 @@ public abstract class Result
     /// </remarks>
     [JsonPropertyName("_meta")]
     public JsonObject? Meta { get; set; }
+
+    /// <summary>
+    /// Merges additional metadata into the existing Meta object.
+    /// </summary>
+    /// <param name="additionalMeta">The additional metadata to merge.</param>
+    public void MergeMeta(JsonObject additionalMeta)
+    {
+        if (Meta == null)
+        {
+            Meta = new JsonObject();
+        }
+
+        foreach (var kvp in additionalMeta)
+        {
+            Meta[kvp.Key] = kvp.Value;
+        }
+    }
 }


### PR DESCRIPTION
## Motivation and Context

This PR adds a helper method to the RequestParams, NotificationParams, and Result classes, all of which have a `Meta` property, that will merge additional metadata into that `Meta` property.

This was motivated comments on #970 but is a standalone feature that can be done in its own PR.

## How Has This Been Tested?

Will add tests.

## Breaking Changes

Not breaking.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

