### PR TITLE
Bump version to 0.4.1-preview.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,8 +5,8 @@
     <PackageProjectUrl>https://github.com/modelcontextprotocol/csharp-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/modelcontextprotocol/csharp-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>0.4.0</VersionPrefix>
-    <VersionSuffix>preview.4</VersionSuffix>
+    <VersionPrefix>0.4.1</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
     <Authors>ModelContextProtocolOfficial</Authors>
     <Copyright>© Anthropic and Contributors.</Copyright>
     <PackageTags>ModelContextProtocol;mcp;ai;llm</PackageTags>


### PR DESCRIPTION
Our last release was over a month ago (Oct 20) and there are a lot of changes queued up. Bumping the version to 0.4.1-preview.1.