### PR TITLE
Update NuGet.org package owner to ModelContextProtocol

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ For how-to guides, tutorials, and additional guidance, see the [official MCP doc
 
 ## Official SDK packages
 
-The official C# SDK packages for stable and prerelease versions are published to the [NuGet Gallery](https://www.nuget.org) under the [ModelContextProtocolOfficial](https://www.nuget.org/profiles/ModelContextProtocolOfficial) profile.
+The official C# SDK packages for stable and prerelease versions are published to the [NuGet Gallery](https://www.nuget.org) under the [ModelContextProtocol](https://www.nuget.org/profiles/ModelContextProtocol) profile. _Prior to v0.5.0, packages were published using the [ModelContextProtocolOfficial](https://www.nuget.org/profiles/ModelContextProtocolOfficial) profile._
 
 Continuous integration builds are published to the modelcontextprotocol organization's [GitHub NuGet package registry](https://github.com/orgs/modelcontextprotocol/packages?ecosystem=nuget).
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,7 @@
     <RepositoryType>git</RepositoryType>
     <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix>preview.1</VersionSuffix>
-    <Authors>ModelContextProtocolOfficial</Authors>
+    <Authors>ModelContextProtocol</Authors>
     <Copyright>© Anthropic and Contributors.</Copyright>
     <PackageTags>ModelContextProtocol;mcp;ai;llm</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
We acquired the [ModelContextProtocol](https://www.nuget.org/profiles/ModelContextProtocol) profile on nuget.org and are transitioning package ownership from [ModelContextProtocolOfficial](https://www.nuget.org/profiles/ModelContextProtocolOfficial).