### PR TITLE
Bump version to 0.5.0-preview.2. Update NuGet Project URL.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,11 +2,11 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <PackageProjectUrl>https://github.com/modelcontextprotocol/csharp-sdk</PackageProjectUrl>
+    <PackageProjectUrl>https://modelcontextprotocol.github.io/csharp-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/modelcontextprotocol/csharp-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>preview.2</VersionSuffix>
     <Authors>ModelContextProtocol</Authors>
     <Copyright>© Anthropic and Contributors.</Copyright>
     <PackageTags>ModelContextProtocol;mcp;ai;llm</PackageTags>


### PR DESCRIPTION
This sets the Project Website URL recognized by NuGet to point to the [MCP C# SDK documentation](https://modelcontextprotocol.github.io/csharp-sdk) instead of to the GitHub repo. The repository address remains in place to point here too.

@mikekistler and I also updated the repo's metadata to point to the documentation site.