### PR TITLE
Add examples of icons on tools, resources, prompts, and server implementation to EverythingServer

### DIFF
--- a/samples/EverythingServer/Program.cs
+++ b/samples/EverythingServer/Program.cs
@@ -34,14 +34,14 @@ builder.Services
             Icons = [
                 new Icon
                 {
-                    Source = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Gear/Flat/gear_flat.svg",
+                    Source = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/62ecdc0d7ca5c6df32148c169556bc8d3782fca4/assets/Gear/Flat/gear_flat.svg",
                     MimeType = "image/svg+xml",
                     Sizes = ["any"],
                     Theme = "light"
                 },
                 new Icon
                 {
-                    Source = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Gear/3D/gear_3d.png",
+                    Source = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/62ecdc0d7ca5c6df32148c169556bc8d3782fca4/assets/Gear/3D/gear_3d.png",
                     MimeType = "image/png",
                     Sizes = ["256x256"]
                 }
@@ -90,7 +90,7 @@ builder.Services
                     // High-resolution PNG icon for light theme
                     new Icon
                     {
-                        Source = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Loudspeaker/Flat/loudspeaker_flat.svg",
+                        Source = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/62ecdc0d7ca5c6df32148c169556bc8d3782fca4/assets/Loudspeaker/Flat/loudspeaker_flat.svg",
                         MimeType = "image/svg+xml",
                         Sizes = ["any"],
                         Theme = "light"
@@ -98,7 +98,7 @@ builder.Services
                     // 3D icon for dark theme
                     new Icon
                     {
-                        Source = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Loudspeaker/3D/loudspeaker_3d.png",
+                        Source = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/62ecdc0d7ca5c6df32148c169556bc8d3782fca4/assets/Loudspeaker/3D/loudspeaker_3d.png",
                         MimeType = "image/png",
                         Sizes = ["256x256"],
                         Theme = "dark"

--- a/samples/EverythingServer/Prompts/SimplePromptType.cs
+++ b/samples/EverythingServer/Prompts/SimplePromptType.cs
@@ -6,6 +6,6 @@ namespace EverythingServer.Prompts;
 [McpServerPromptType]
 public class SimplePromptType
 {
-    [McpServerPrompt(Name = "simple_prompt", IconSource = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Light%20bulb/Flat/light_bulb_flat.svg"), Description("A prompt without arguments")]
+    [McpServerPrompt(Name = "simple_prompt", IconSource = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/62ecdc0d7ca5c6df32148c169556bc8d3782fca4/assets/Light%20bulb/Flat/light_bulb_flat.svg"), Description("A prompt without arguments")]
     public static string SimplePrompt() => "This is a simple prompt without arguments";
 }

--- a/samples/EverythingServer/Resources/SimpleResourceType.cs
+++ b/samples/EverythingServer/Resources/SimpleResourceType.cs
@@ -7,7 +7,7 @@ namespace EverythingServer.Resources;
 [McpServerResourceType]
 public class SimpleResourceType
 {
-    [McpServerResource(UriTemplate = "test://direct/text/resource", Name = "Direct Text Resource", MimeType = "text/plain", IconSource = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Memo/Flat/memo_flat.svg")]
+    [McpServerResource(UriTemplate = "test://direct/text/resource", Name = "Direct Text Resource", MimeType = "text/plain", IconSource = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/62ecdc0d7ca5c6df32148c169556bc8d3782fca4/assets/Memo/Flat/memo_flat.svg")]
     [Description("A direct text resource")]
     public static string DirectTextResource() => "This is a direct resource";
 

--- a/samples/EverythingServer/Tools/AddTool.cs
+++ b/samples/EverythingServer/Tools/AddTool.cs
@@ -6,6 +6,6 @@ namespace EverythingServer.Tools;
 [McpServerToolType]
 public class AddTool
 {
-    [McpServerTool(Name = "add", IconSource = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Plus/Flat/plus_flat.svg"), Description("Adds two numbers.")]
+    [McpServerTool(Name = "add", IconSource = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/62ecdc0d7ca5c6df32148c169556bc8d3782fca4/assets/Plus/Flat/plus_flat.svg"), Description("Adds two numbers.")]
     public static string Add(int a, int b) => $"The sum of {a} and {b} is {a + b}";
 }


### PR DESCRIPTION
## Motivation and Context

This PR adds examples of icons for tools, resources, and prompts to the EverythingServer. It also adds icons and metadata to the server implementation. This illustrates the icons and metadata features added to the 2025-11-25 version of the MCP spec by [SEP-973].

[SEP-973]: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/973

## How Has This Been Tested?

I started the EverythingServer and connected to it with the MCP Inspector, and could see the icons associated with the weather tool and add tool, the direct resource, and simple prompt. The inspector also shows the icons for the server but does not display the other server metadata.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

