### PR TITLE
Fix race condition in SSE GET request initialization

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -154,11 +154,6 @@ internal sealed class StreamableHttpHandler(
         {
             await using var _ = await session.AcquireReferenceAsync(cancellationToken);
             InitializeSseResponse(context);
-
-            // We should flush headers to indicate a 200 success quickly, because the initialization response
-            // will be sent in response to a different POST request. It might be a while before we send a message
-            // over this response body.
-            await context.Response.Body.FlushAsync(cancellationToken);
             await session.Transport.HandleGetRequestAsync(context.Response.Body, cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
@@ -125,6 +125,12 @@ public sealed class StreamableHttpServerTransport : ITransport
                 var primingItem = await _storeSseWriter.WriteEventAsync(SseItem.Prime<JsonRpcMessage>(), cancellationToken).ConfigureAwait(false);
                 await _httpSseWriter.WriteAsync(primingItem, cancellationToken).ConfigureAwait(false);
             }
+            else
+            {
+                // If there's no priming write, flush the stream to ensure HTTP response headers are
+                // sent to the client now that the transport is ready to accept messages via SendMessageAsync.
+                await sseResponseStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
 
         // Wait for the response to be written before returning from the handler.


### PR DESCRIPTION
The StreamableHttpHandler was flushing HTTP response headers before calling HandleGetRequestAsync, which sets _getHttpRequestStarted = true. This allowed a race where SendNotificationAsync could be called after the client received headers but before _getHttpRequestStarted was set, causing the notification to be silently dropped.

Move the flush inside HandleGetRequestAsync so it occurs after _getHttpRequestStarted is set, while still holding the lock. This ensures SendNotificationAsync will either:
- Block on the lock until initialization completes, or
- See _getHttpRequestStarted = true after acquiring the lock

The priming write path already flushes via SseEventWriter.WriteAsync, so the explicit flush is only needed in the non-priming case.

Fixes https://github.com/modelcontextprotocol/csharp-sdk/issues/1211 (hopefully)