### PR TITLE
Add protected resource metadata response inspect & modify support

### DIFF
--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthOptions.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthOptions.cs
@@ -64,6 +64,20 @@ public sealed class ClientOAuthOptions
     public AuthorizationRedirectDelegate? AuthorizationRedirectDelegate { get; set; }
 
     /// <summary>
+    /// Gets or sets the delegate for handling protected resource metadata response.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This delegate provides an opportunity to inspect or modify the protected resource metadata received from the protected resource.
+    /// If not specified, the protected resource metadata will be used as-is without any modifications.
+    /// </para>
+    /// <para>
+    /// If the metadata of the protected resource could not be found, the delegate will be invoked with a <see langword="null"/> argument, allowing the consumers to supply defaults.
+    /// </para>
+    /// </remarks>
+    public Func<ProtectedResourceMetadata?, ProtectedResourceMetadata?>? ProtectedResourceMetadataResponseDelegate { get; set; }
+
+    /// <summary>
     /// Gets or sets the authorization server selector function.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
This patch adds support for legacy behavior [defined](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization#authorization-base-url) in MCP 2025-03-26, where by if the MCP server does not provide a PRM, the MCP client uses the MCP server's base URL as the authorization server.

Since a PRM is not specified, a `resource` indicator is also not specified, this means the code has to updated to handle this optionality.

## Motivation and Context
There exists multiple MCP server implementation out there, and many of them are not compliant with the latest MCP specification. For example, the official Atlassian MCP server.

Without this patch, the C# MCP SDK is not compatible with Atlassian's MCP server (https://mcp.atlassian.com/v1/mcp), and would throw an `McpException` with `Failed to find protected resource metadata at a well-known location for {...}`.

https://github.com/modelcontextprotocol/csharp-sdk/blob/27b5eb80315a6835b78568bafc549ea10bcf03b1/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs#L790-L793

On the other hand, the TypeScript MCP SDK seems to handle this case well.

https://github.com/modelcontextprotocol/typescript-sdk/blob/91f6a277c43babe8962c7782030162530a82b2f5/packages/client/src/client/auth.ts#L410-L416

## How Has This Been Tested?
Performed a successful authentication against Atlassian's MCP server.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

