### PR TITLE
Unskip GetRequest_Receives_UnsolicitedNotifications test

### DIFF
--- a/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerConformanceTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerConformanceTests.cs
@@ -249,7 +249,7 @@ public class StreamableHttpServerConformanceTests(ITestOutputHelper outputHelper
         await Task.WhenAll(echoTasks);
     }
 
-    [Fact(Skip = "https://github.com/modelcontextprotocol/csharp-sdk/issues/1211")]
+    [Fact]
     public async Task GetRequest_Receives_UnsolicitedNotifications()
     {
         McpServer? server = null;


### PR DESCRIPTION
The underlying issue (#1211) has been fixed. This removes the `Skip` attribute from `GetRequest_Receives_UnsolicitedNotifications` so it runs as part of the conformance test suite. Verified passing on net8.0, net9.0, and net10.0.