### PR TITLE
Don't treat McpServerHandlers as an independent options type

### DIFF
--- a/src/ModelContextProtocol/McpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol/McpServerBuilderExtensions.cs
@@ -583,7 +583,12 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.ListResourceTemplatesHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.ListResourceTemplatesHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Resources ??= new();
+        });
         return builder;
     }
 
@@ -616,7 +621,12 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.ListToolsHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.ListToolsHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Tools ??= new();
+        });
         return builder;
     }
 
@@ -636,7 +646,12 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.CallToolHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.CallToolHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Tools ??= new();
+        });
         return builder;
     }
 
@@ -669,7 +684,12 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.ListPromptsHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.ListPromptsHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Prompts ??= new();
+        });
         return builder;
     }
 
@@ -684,7 +704,12 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.GetPromptHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.GetPromptHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Prompts ??= new();
+        });
         return builder;
     }
 
@@ -705,7 +730,12 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.ListResourcesHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.ListResourcesHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Resources ??= new();
+        });
         return builder;
     }
 
@@ -724,7 +754,12 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.ReadResourceHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.ReadResourceHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Resources ??= new();
+        });
         return builder;
     }
 
@@ -743,7 +778,12 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.CompleteHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.CompleteHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Completions ??= new();
+        });
         return builder;
     }
 
@@ -773,7 +813,13 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.SubscribeToResourcesHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.SubscribeToResourcesHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Resources ??= new();
+            options.Capabilities.Resources.Subscribe = true;
+        });
         return builder;
     }
 
@@ -803,7 +849,13 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.UnsubscribeFromResourcesHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.UnsubscribeFromResourcesHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Resources ??= new();
+            options.Capabilities.Resources.Subscribe = true;
+        });
         return builder;
     }
 
@@ -830,7 +882,12 @@ public static partial class McpServerBuilderExtensions
     {
         Throw.IfNull(builder);
 
-        builder.Services.Configure<McpServerHandlers>(s => s.SetLoggingLevelHandler = handler);
+        builder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.SetLoggingLevelHandler = handler;
+            options.Capabilities ??= new();
+            options.Capabilities.Logging ??= new();
+        });
         return builder;
     }
     #endregion

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsHandlerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsHandlerTests.cs
@@ -26,9 +26,9 @@ public class McpServerBuilderExtensionsHandlerTests
         _builder.Object.WithListToolsHandler(handler);
 
         var serviceProvider = _services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
 
-        Assert.Equal(handler, options.ListToolsHandler);
+        Assert.Equal(handler, options.Handlers.ListToolsHandler);
     }
 
     [Fact]
@@ -39,9 +39,9 @@ public class McpServerBuilderExtensionsHandlerTests
         _builder.Object.WithCallToolHandler(handler);
 
         var serviceProvider = _services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
 
-        Assert.Equal(handler, options.CallToolHandler);
+        Assert.Equal(handler, options.Handlers.CallToolHandler);
     }
 
     [Fact]
@@ -52,9 +52,9 @@ public class McpServerBuilderExtensionsHandlerTests
         _builder.Object.WithListPromptsHandler(handler);
 
         var serviceProvider = _services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
 
-        Assert.Equal(handler, options.ListPromptsHandler);
+        Assert.Equal(handler, options.Handlers.ListPromptsHandler);
     }
 
     [Fact]
@@ -65,9 +65,9 @@ public class McpServerBuilderExtensionsHandlerTests
         _builder.Object.WithGetPromptHandler(handler);
 
         var serviceProvider = _services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
 
-        Assert.Equal(handler, options.GetPromptHandler);
+        Assert.Equal(handler, options.Handlers.GetPromptHandler);
     }
 
     [Fact]
@@ -78,9 +78,9 @@ public class McpServerBuilderExtensionsHandlerTests
         _builder.Object.WithListResourceTemplatesHandler(handler);
 
         var serviceProvider = _services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
 
-        Assert.Equal(handler, options.ListResourceTemplatesHandler);
+        Assert.Equal(handler, options.Handlers.ListResourceTemplatesHandler);
     }
 
     [Fact]
@@ -91,9 +91,9 @@ public class McpServerBuilderExtensionsHandlerTests
         _builder.Object.WithListResourcesHandler(handler);
 
         var serviceProvider = _services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
 
-        Assert.Equal(handler, options.ListResourcesHandler);
+        Assert.Equal(handler, options.Handlers.ListResourcesHandler);
     }
 
     [Fact]
@@ -104,9 +104,9 @@ public class McpServerBuilderExtensionsHandlerTests
         _builder.Object.WithReadResourceHandler(handler);
 
         var serviceProvider = _services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
 
-        Assert.Equal(handler, options.ReadResourceHandler);
+        Assert.Equal(handler, options.Handlers.ReadResourceHandler);
     }
 
     [Fact]
@@ -117,9 +117,9 @@ public class McpServerBuilderExtensionsHandlerTests
         _builder.Object.WithCompleteHandler(handler);
 
         var serviceProvider = _services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
 
-        Assert.Equal(handler, options.CompleteHandler);
+        Assert.Equal(handler, options.Handlers.CompleteHandler);
     }
 
     [Fact]
@@ -130,9 +130,9 @@ public class McpServerBuilderExtensionsHandlerTests
         _builder.Object.WithSubscribeToResourcesHandler(handler);
 
         var serviceProvider = _services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
 
-        Assert.Equal(handler, options.SubscribeToResourcesHandler);
+        Assert.Equal(handler, options.Handlers.SubscribeToResourcesHandler);
     }
 
     [Fact]
@@ -143,8 +143,8 @@ public class McpServerBuilderExtensionsHandlerTests
         _builder.Object.WithUnsubscribeFromResourcesHandler(handler);
 
         var serviceProvider = _services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<McpServerHandlers>>().Value;
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
 
-        Assert.Equal(handler, options.UnsubscribeFromResourcesHandler);
+        Assert.Equal(handler, options.Handlers.UnsubscribeFromResourcesHandler);
     }
 }


### PR DESCRIPTION
When working on #1308, I considered whether I should treat `McpServerFilters` similar to `McpServerHandlers` and resolve it using `IOptions<McpServerFilters>` in case anyone configured it directly as an options type. Ultimately, I decided against it because it added too much complexity.

After more thought, I don't think the complexity makes sense for `McpServerHandlers` either. Having the handler methods on McpServerBuilderExtensions modify the `McpServerOptions.Handlers` directly seems a lot more straightforward and easier to understand than the previous overwriting logic, so I think we should make `McpServerOptions` the source of truth for both handlers and filters before 1.0.