### PR TITLE
Fix compilation errors in README code samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ IList<McpClientTool> tools = await client.ListToolsAsync();
 IChatClient chatClient = ...;
 var response = await chatClient.GetResponseAsync(
     "your prompt here",
-    new() { Tools = [.. tools] },
+    new() { Tools = [.. tools] });
 ```
 
 ## Getting Started (Server)
@@ -218,7 +218,7 @@ McpServerOptions options = new()
 
                 return ValueTask.FromResult(new CallToolResult
                 {
-                    Content = [new TextContentBlock { Text = $"Echo: {message}", Type = "text" }]
+                    Content = [new TextContentBlock { Text = $"Echo: {message}" }]
                 });
             }
 


### PR DESCRIPTION
- Core README client sample: Use .OfType<TextContentBlock>() instead of .First(c => c.Type == "text").Text since ContentBlock base class lacks Text
- Core README server sample: Use McpServerOptions.ToolCollection, McpServer.Create(), StdioServerTransport(name), and await using
- Root README advanced server: Remove read-only Type property from TextContentBlock initializer
- Both IChatClient snippets: Fix trailing comma and missing closing paren
