### PR TITLE
Add README code sample validation step to release-notes skill

### DIFF
--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -66,7 +66,7 @@ Use the results (confirmed breaking changes with impact ordering and detail bull
 Verify that all C# code samples in the package README files compile against the current SDK at the target commit. Follow [references/readme-snippets.md](references/readme-snippets.md) for the full procedure.
 
 1. Extract `csharp`-fenced code blocks from `README.md`, `src/ModelContextProtocol.Core/README.md`, and `src/ModelContextProtocol.AspNetCore/README.md`
-2. Create a temporary test project at `tests/ReadmeSnippetValidation/` that references all three SDK projects
+2. Create a temporary test project at `tests/ReadmeSnippetValidation/` that references the SDK projects
 3. Wrap each code block in a compilable method, applying fixups for incomplete snippets (replace `...` with `null!`, add common usings)
 4. Build the project with `dotnet build`
 5. Report results — classify any failures as API mismatches (README bugs) or structural fragments

--- a/.github/skills/release-notes/references/readme-snippets.md
+++ b/.github/skills/release-notes/references/readme-snippets.md
@@ -36,7 +36,7 @@ Some code blocks are illustrative fragments that cannot compile even with wrappe
 
 ## Test Project Approach
 
-Create a **temporary** test project that references all three SDK projects, wraps each README's code samples in compilable methods, and builds.
+Create a **temporary** test project that references the SDK projects, wraps each README's code samples in compilable methods, and builds.
 
 ### Project File Template
 
@@ -107,11 +107,10 @@ public static class RootReadmeSamples
 
 ### Build Commands
 
-```powershell
+```sh
 # Restore and build the validation project
 dotnet restore tests/ReadmeSnippetValidation/ReadmeSnippetValidation.csproj
 dotnet build tests/ReadmeSnippetValidation/ReadmeSnippetValidation.csproj
-```
 
 ### Cleanup
 


### PR DESCRIPTION
Add Step 4 to validate that C# code samples in package README files compile against the current SDK. Includes a reference document with the test project approach, snippet extraction rules, and failure classification guidance. Steps 5-10 renumbered accordingly.