### PR TITLE
Add transport-level cancellation support and proper cancellation token propagation (client->server)

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -479,12 +479,19 @@ internal sealed class StreamableHttpHandler(
         // Implementation for reading a JSON-RPC message from the request body
         var message = await context.Request.ReadFromJsonAsync(s_messageTypeInfo, context.RequestAborted);
 
-        if (context.User?.Identity?.IsAuthenticated == true && message is not null)
+        if (message is null)
         {
-            message.Context = new()
-            {
-                User = context.User,
-            };
+            return null;
+        }
+
+        message.Context = new()
+        {
+            CancellationToken = context.RequestAborted,
+        };
+
+        if (context.User?.Identity?.IsAuthenticated == true)
+        {
+            message.Context.User = context.User;
         }
 
         return message;

--- a/src/ModelContextProtocol.Core/McpSessionHandler.cs
+++ b/src/ModelContextProtocol.Core/McpSessionHandler.cs
@@ -193,7 +193,16 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
                         // out of order.
                         if (messageWithId is not null)
                         {
-                            combinedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                            var requestCancellationToken = message.Context?.CancellationToken;
+                            if (requestCancellationToken is { CanBeCanceled: true })
+                            {
+                                combinedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, requestCancellationToken.Value);
+                            }
+                            else
+                            {
+                                combinedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                            }
+                            
                             _handlingRequests[messageWithId.Id] = combinedCts;
                         }
 
@@ -523,8 +532,6 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
                 LogSendingRequest(EndpointName, request.Method);
             }
 
-            await SendToRelatedTransportAsync(request, cancellationToken).ConfigureAwait(false);
-
             // Now that the request has been sent, register for cancellation. If we registered before,
             // a cancellation request could arrive before the server knew about that request ID, in which
             // case the server could ignore it.
@@ -532,7 +539,16 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
             JsonRpcMessage? response;
             using (var registration = RegisterCancellation(cancellationToken, request))
             {
-                response = await tcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try 
+                {
+                    await SendToRelatedTransportAsync(request, cancellationToken).ConfigureAwait(false);
+                    response = await tcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch(TaskCanceledException)
+                {
+                    await Task.Delay(500).ConfigureAwait(false); //give it time to start the cancel notification to send before we dispose it
+                    throw;
+                }
             }
 
             if (response is JsonRpcError error)

--- a/src/ModelContextProtocol.Core/Protocol/JsonRpcMessageContext.cs
+++ b/src/ModelContextProtocol.Core/Protocol/JsonRpcMessageContext.cs
@@ -74,4 +74,13 @@ public sealed class JsonRpcMessageContext
     /// </para>
     /// </remarks>
     public IDictionary<string, object?>? Items { get; set; }
+
+    /// <summary>
+    /// Gets or sets the cancellation token associated with the transport request that carried this JSON-RPC message.
+    /// </summary>
+    /// <remarks>
+    /// For HTTP transports, this can be linked to the underlying HTTP request's aborted cancellation token (e.g. HttpContext.RequestAborted)
+    /// to propagate transport-level cancellations to tool executions.
+    /// </remarks>
+    public CancellationToken? CancellationToken { get; set; }
 }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/HttpServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/HttpServerIntegrationTests.cs
@@ -23,7 +23,7 @@ public abstract class HttpServerIntegrationTests : LoggedTest, IClassFixture<Sse
 
     protected abstract HttpClientTransportOptions ClientTransportOptions { get; }
 
-    private Task<McpClient> GetClientAsync(McpClientOptions? options = null)
+    protected Task<McpClient> GetClientAsync(McpClientOptions? options = null)
     {
         return _fixture.ConnectMcpClientAsync(options, LoggerFactory);
     }

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -112,6 +112,60 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
         Assert.Empty(textContent.Text);
     }
 
+    [Fact]
+    public async Task CallTool_Stdio_CancelToken_ThrowsOperationCanceledException()
+    {
+        await using var client = await _fixture.CreateClientAsync("test_server");
+
+        using CancellationTokenSource cts = new();
+        var toolTask = client.CallToolAsync(
+            "longRunning",
+            new Dictionary<string, object?> { ["durationMs"] = 10000 },
+            cancellationToken: cts.Token
+        );
+
+        // Allow some time for the request to be sent
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+
+        cts.Cancel();
+
+        // Client throws OperationCanceledException
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await toolTask);
+
+        // Verify the connection is still open by pinging
+        var pingResult = await client.PingAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(pingResult);
+    }
+
+    [Fact]
+    public async Task CallTool_Stdio_ClientDisconnectsAbruptly_CancelsServerToken()
+    {
+        var client = await _fixture.CreateClientAsync("test_server");
+
+        // Send the tool call
+        var toolTask = client.CallToolAsync(
+            "longRunning",
+            new Dictionary<string, object?> { ["durationMs"] = 10000 },
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        // Allow some time for the request to be sent and processing to start
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+
+        // Disposing the client will tear down the stdio pipes abruptly
+        await client.DisposeAsync();
+
+        // The local client task will throw because the transport disconnected
+        await Assert.ThrowsAnyAsync<Exception>(async () => await toolTask);
+
+        // Verify the server process was terminated or we can create a new connection depending on server behavior.
+        // For Stdio, the server process is typically isolated to the client connection instance, 
+        // so we start a new client to ensure the transport factory is healthy.
+        await using var newClient = await _fixture.CreateClientAsync("test_server");
+        var pingResult = await newClient.PingAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(pingResult);
+    }
+
     [Theory]
     [MemberData(nameof(GetClients))]
     public async Task CallTool_Stdio_ViaAIFunction_EchoServer(string clientId)


### PR DESCRIPTION
Closes #1365

Propagate HTTP request cancellation tokens to tool executions via JsonRpcMessageContext having the server able to handle the cancel notification directly or the server to detect the broken request.

The server should properly trigger the cancel token for any tools taking it if either of the above two happen allowing for the server to properly kill any long running tasks.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Right now it looks like cancelling works but it does nothing from a server perspective. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->


## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Shouldn't, technically its a behavior change but I would assume most implementations that take the token would not have a reason for it to not cancel when the client request aborts.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x ] My code follows the repository's style guidelines
- [x ] New and existing tests pass locally
- [x ] I have added appropriate error handling
- [ x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

Unable to figure out how to do a proper socket closure in a test case that would be helpful for the 3rd situation.