### PR TITLE
Remove outdated README reference from transports.md

### DIFF
--- a/docs/concepts/transports/transports.md
+++ b/docs/concepts/transports/transports.md
@@ -137,8 +137,6 @@ app.MapMcp("/mcp");
 
 When using a custom route, Streamable HTTP clients should connect directly to that route (e.g., `https://host/mcp`), while SSE clients should connect to `{route}/sse` (e.g., `https://host/mcp/sse`).
 
-See the `ModelContextProtocol.AspNetCore` package [README](https://github.com/modelcontextprotocol/csharp-sdk/blob/main/src/ModelContextProtocol.AspNetCore/README.md) for more configuration options.
-
 ### SSE transport (legacy)
 
 The [SSE (Server-Sent Events)] transport is a legacy mechanism that uses unidirectional server-to-client streaming with a separate HTTP endpoint for client-to-server messages. New implementations should prefer Streamable HTTP.


### PR DESCRIPTION
Removed a reference to the ModelContextProtocol.AspNetCore package README for configuration options.

@jeffhandley This is a follow up to #1388 which caused a link breakage to be reported [here](https://github.com/modelcontextprotocol/csharp-sdk/actions/runs/22452398979/job/65024269833). I tried to find a replacement link, but couldn't find one. I'm not sure the new PACKAGE.md is a real replacement for the old README.md's. Overall, it feels like a downgrade to me, but regardless we should at least remove the dead link.