### PR TITLE
Add an optional `AIJsonSchemaCreateOptions` to `WithToolsFromAssembly`.

### DIFF
--- a/src/ModelContextProtocol/McpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol/McpServerBuilderExtensions.cs
@@ -7,6 +7,7 @@ using ModelContextProtocol.Server;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
+using Microsoft.Extensions.AI;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -125,6 +126,7 @@ public static partial class McpServerBuilderExtensions
     /// <param name="builder">The builder instance.</param>
     /// <param name="toolTypes">Types with <see cref="McpServerToolAttribute"/>-attributed methods to add as tools to the server.</param>
     /// <param name="serializerOptions">The serializer options governing tool parameter marshalling.</param>
+    /// <param name="schemaCreateOptions">The schema creation options governing tool parameter/output schema generation.</param>
     /// <returns>The builder provided in <paramref name="builder"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="builder"/> or <paramref name="toolTypes"/> is <see langword="null"/>.</exception>
     /// <remarks>
@@ -133,7 +135,7 @@ public static partial class McpServerBuilderExtensions
     /// instance for each. For instance methods, an instance is constructed for each invocation of the tool.
     /// </remarks>
     [RequiresUnreferencedCode(WithToolsRequiresUnreferencedCodeMessage)]
-    public static IMcpServerBuilder WithTools(this IMcpServerBuilder builder, IEnumerable<Type> toolTypes, JsonSerializerOptions? serializerOptions = null)
+    public static IMcpServerBuilder  WithTools(this IMcpServerBuilder builder, IEnumerable<Type> toolTypes, JsonSerializerOptions? serializerOptions = null, AIJsonSchemaCreateOptions? schemaCreateOptions = null)
     {
         Throw.IfNull(builder);
         Throw.IfNull(toolTypes);
@@ -147,8 +149,8 @@ public static partial class McpServerBuilderExtensions
                     if (toolMethod.GetCustomAttribute<McpServerToolAttribute>() is not null)
                     {
                         builder.Services.AddSingleton((Func<IServiceProvider, McpServerTool>)(toolMethod.IsStatic ?
-                            services => McpServerTool.Create(toolMethod, options: new() { Services = services, SerializerOptions = serializerOptions }) :
-                            services => McpServerTool.Create(toolMethod, r => CreateTarget(r.Services, toolType), new() { Services = services, SerializerOptions = serializerOptions })));
+                            services => McpServerTool.Create(toolMethod, options: new() { Services = services, SerializerOptions = serializerOptions, SchemaCreateOptions = schemaCreateOptions }) :
+                            services => McpServerTool.Create(toolMethod, r => CreateTarget(r.Services, toolType), new() { Services = services, SerializerOptions = serializerOptions, SchemaCreateOptions = schemaCreateOptions })));
                     }
                 }
             }
@@ -163,6 +165,7 @@ public static partial class McpServerBuilderExtensions
     /// <param name="builder">The builder instance.</param>
     /// <param name="serializerOptions">The serializer options governing tool parameter marshalling.</param>
     /// <param name="toolAssembly">The assembly to load the types from. If <see langword="null"/>, the calling assembly is used.</param>
+    /// <param name="schemaCreateOptions">The schema creation options governing tool parameter/output schema generation.</param>
     /// <returns>The builder provided in <paramref name="builder"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
     /// <remarks>
@@ -186,7 +189,7 @@ public static partial class McpServerBuilderExtensions
     /// </para>
     /// </remarks>
     [RequiresUnreferencedCode(WithToolsRequiresUnreferencedCodeMessage)]
-    public static IMcpServerBuilder WithToolsFromAssembly(this IMcpServerBuilder builder, Assembly? toolAssembly = null, JsonSerializerOptions? serializerOptions = null)
+    public static IMcpServerBuilder WithToolsFromAssembly(this IMcpServerBuilder builder, Assembly? toolAssembly = null, JsonSerializerOptions? serializerOptions = null, AIJsonSchemaCreateOptions? schemaCreateOptions = null)
     {
         Throw.IfNull(builder);
 
@@ -196,7 +199,8 @@ public static partial class McpServerBuilderExtensions
             from t in toolAssembly.GetTypes()
             where t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null
             select t,
-            serializerOptions);
+            serializerOptions,
+            schemaCreateOptions);
     }
     #endregion
 

--- a/src/ModelContextProtocol/McpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol/McpServerBuilderExtensions.cs
@@ -121,7 +121,22 @@ public static partial class McpServerBuilderExtensions
 
         return builder;
     }
-
+    
+    /// <summary>Adds <see cref="McpServerTool"/> instances to the service collection backing <paramref name="builder"/>.</summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="toolTypes">Types with <see cref="McpServerToolAttribute"/>-attributed methods to add as tools to the server.</param>
+    /// <param name="serializerOptions">The serializer options governing tool parameter marshalling.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> or <paramref name="toolTypes"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// This method discovers all instance and static methods (public and non-public) on the specified <paramref name="toolTypes"/>
+    /// types, where the methods are attributed as <see cref="McpServerToolAttribute"/>, and adds an <see cref="McpServerTool"/>
+    /// instance for each. For instance methods, an instance is constructed for each invocation of the tool.
+    /// </remarks>
+    [RequiresUnreferencedCode(WithToolsRequiresUnreferencedCodeMessage)]
+    public static IMcpServerBuilder WithTools(this IMcpServerBuilder builder, IEnumerable<Type> toolTypes, JsonSerializerOptions? serializerOptions = null) =>
+        builder.WithTools(toolTypes, schemaCreateOptions: null, serializerOptions);
+    
     /// <summary>Adds <see cref="McpServerTool"/> instances to the service collection backing <paramref name="builder"/>.</summary>
     /// <param name="builder">The builder instance.</param>
     /// <param name="toolTypes">Types with <see cref="McpServerToolAttribute"/>-attributed methods to add as tools to the server.</param>
@@ -135,7 +150,7 @@ public static partial class McpServerBuilderExtensions
     /// instance for each. For instance methods, an instance is constructed for each invocation of the tool.
     /// </remarks>
     [RequiresUnreferencedCode(WithToolsRequiresUnreferencedCodeMessage)]
-    public static IMcpServerBuilder  WithTools(this IMcpServerBuilder builder, IEnumerable<Type> toolTypes, JsonSerializerOptions? serializerOptions = null, AIJsonSchemaCreateOptions? schemaCreateOptions = null)
+    public static IMcpServerBuilder WithTools(this IMcpServerBuilder builder, IEnumerable<Type> toolTypes, AIJsonSchemaCreateOptions? schemaCreateOptions, JsonSerializerOptions? serializerOptions = null)
     {
         Throw.IfNull(builder);
         Throw.IfNull(toolTypes);
@@ -189,7 +204,7 @@ public static partial class McpServerBuilderExtensions
     /// </para>
     /// </remarks>
     [RequiresUnreferencedCode(WithToolsRequiresUnreferencedCodeMessage)]
-    public static IMcpServerBuilder WithToolsFromAssembly(this IMcpServerBuilder builder, Assembly? toolAssembly = null, JsonSerializerOptions? serializerOptions = null, AIJsonSchemaCreateOptions? schemaCreateOptions = null)
+    public static IMcpServerBuilder WithToolsFromAssembly(this IMcpServerBuilder builder, AIJsonSchemaCreateOptions? schemaCreateOptions, Assembly? toolAssembly = null, JsonSerializerOptions? serializerOptions = null)
     {
         Throw.IfNull(builder);
 
@@ -199,8 +214,51 @@ public static partial class McpServerBuilderExtensions
             from t in toolAssembly.GetTypes()
             where t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null
             select t,
-            serializerOptions,
-            schemaCreateOptions);
+            schemaCreateOptions,
+            serializerOptions);
+    }
+    
+    /// <summary>
+    /// Adds types marked with the <see cref="McpServerToolTypeAttribute"/> attribute from the given assembly as tools to the server.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="serializerOptions">The serializer options governing tool parameter marshalling.</param>
+    /// <param name="toolAssembly">The assembly to load the types from. If <see langword="null"/>, the calling assembly is used.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// This method scans the specified assembly (or the calling assembly if none is provided) for classes
+    /// marked with the <see cref="McpServerToolTypeAttribute"/>. It then discovers all methods within those
+    /// classes that are marked with the <see cref="McpServerToolAttribute"/> and registers them as <see cref="McpServerTool"/>s
+    /// in the <paramref name="builder"/>'s <see cref="IServiceCollection"/>.
+    /// </para>
+    /// <para>
+    /// The method automatically handles both static and instance methods. For instance methods, a new instance
+    /// of the containing class is constructed for each invocation of the tool.
+    /// </para>
+    /// <para>
+    /// Tools registered through this method can be discovered by clients using the <c>list_tools</c> request
+    /// and invoked using the <c>call_tool</c> request.
+    /// </para>
+    /// <para>
+    /// Note that this method performs reflection at runtime and might not work in Native AOT scenarios. For
+    /// Native AOT compatibility, consider using the generic <see cref="M:WithTools"/> method instead.
+    /// </para>
+    /// </remarks>
+    [RequiresUnreferencedCode(WithToolsRequiresUnreferencedCodeMessage)]
+    public static IMcpServerBuilder WithToolsFromAssembly(this IMcpServerBuilder builder, Assembly? toolAssembly = null, JsonSerializerOptions? serializerOptions = null)
+    {
+        Throw.IfNull(builder);
+
+        toolAssembly ??= Assembly.GetCallingAssembly();
+
+        return builder.WithTools(
+            from t in toolAssembly.GetTypes()
+            where t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null
+            select t,
+            schemaCreateOptions: null,
+            serializerOptions);
     }
     #endregion
 

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
@@ -675,7 +675,7 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         };
         
         ServiceCollection sc = new();
-        sc.AddMcpServer().WithTools([typeof(ToolTypeWithSchemaCreateOptions)], schemaCreateOptions: schemaCreateOptions);
+        sc.AddMcpServer().WithTools([typeof(ToolTypeWithSchemaCreateOptions)], schemaCreateOptions);
         IServiceProvider services = sc.BuildServiceProvider();
 
         McpServerTool tool = services.GetServices<McpServerTool>().First(t => t.ProtocolTool.Name == "static_tool");
@@ -692,7 +692,7 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         };
         
         ServiceCollection sc = new();
-        sc.AddMcpServer().WithTools([typeof(ToolTypeWithSchemaCreateOptions)], schemaCreateOptions: schemaCreateOptions);
+        sc.AddMcpServer().WithTools([typeof(ToolTypeWithSchemaCreateOptions)], schemaCreateOptions);
         IServiceProvider services = sc.BuildServiceProvider();
 
         McpServerTool tool = services.GetServices<McpServerTool>().First(t => t.ProtocolTool.Name == "instance_tool");
@@ -709,7 +709,7 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         };
 
         ServiceCollection sc = new();
-        sc.AddMcpServer().WithToolsFromAssembly(schemaCreateOptions: schemaCreateOptions);
+        sc.AddMcpServer().WithToolsFromAssembly(schemaCreateOptions);
         IServiceProvider services = sc.BuildServiceProvider();
 
         McpServerTool tool = services.GetServices<McpServerTool>().First(t => t.ProtocolTool.Name == "instance_tool");

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
@@ -482,7 +482,7 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         IMcpServerBuilder builder = new ServiceCollection().AddMcpServer();
 
         Assert.Throws<ArgumentNullException>("tools", () => builder.WithTools((IEnumerable<McpServerTool>)null!));
-        Assert.Throws<ArgumentNullException>("toolTypes", () => builder.WithTools((IEnumerable<Type>)null!));
+        Assert.Throws<ArgumentNullException>("toolTypes", () => builder.WithTools(toolTypes: (IEnumerable<Type>)null!));
         Assert.Throws<ArgumentNullException>("target", () => builder.WithTools<object>(target: null!));
 
         IMcpServerBuilder nullBuilder = null!;
@@ -663,6 +663,57 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         Assert.Contains(services.GetServices<McpServerTool>(), t => t.ProtocolTool.Name == "method_c");
         Assert.Contains(services.GetServices<McpServerTool>(), t => t.ProtocolTool.Name == "method_d");
         Assert.Contains(services.GetServices<McpServerTool>(), t => t.ProtocolTool.Name == "Returns42");
+    }
+    
+    [Fact]
+    public void Register_Static_Tools_With_Custom_Schema_Create_Options()
+    {
+        var jsonString = "{\"value\":42}";
+        var schemaCreateOptions = new AIJsonSchemaCreateOptions
+        {
+            TransformSchemaNode = (context, node) => JsonNode.Parse(jsonString)!
+        };
+        
+        ServiceCollection sc = new();
+        sc.AddMcpServer().WithTools([typeof(ToolTypeWithSchemaCreateOptions)], schemaCreateOptions: schemaCreateOptions);
+        IServiceProvider services = sc.BuildServiceProvider();
+
+        McpServerTool tool = services.GetServices<McpServerTool>().First(t => t.ProtocolTool.Name == "static_tool");
+        Assert.Contains("42", tool.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("input").GetProperty("value").ToString());
+    }
+
+    [Fact]
+    public void Register_Instance_Tools_With_Custom_Schema_Create_Options()
+    {
+        var jsonString = "{\"value\":42}";
+        var schemaCreateOptions = new AIJsonSchemaCreateOptions
+        {
+            TransformSchemaNode = (context, node) => JsonNode.Parse(jsonString)!
+        };
+        
+        ServiceCollection sc = new();
+        sc.AddMcpServer().WithTools([typeof(ToolTypeWithSchemaCreateOptions)], schemaCreateOptions: schemaCreateOptions);
+        IServiceProvider services = sc.BuildServiceProvider();
+
+        McpServerTool tool = services.GetServices<McpServerTool>().First(t => t.ProtocolTool.Name == "instance_tool");
+        Assert.Contains("42", tool.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("input").GetProperty("value").ToString());
+    }
+
+    [Fact]
+    public void WithToolsFromAssembly_With_Custom_Schema_Create_Options()
+    {
+        var jsonString = "{\"value\":42}";
+        var schemaCreateOptions = new AIJsonSchemaCreateOptions
+        {
+            TransformSchemaNode = (context, node) => JsonNode.Parse(jsonString)!
+        };
+
+        ServiceCollection sc = new();
+        sc.AddMcpServer().WithToolsFromAssembly(schemaCreateOptions: schemaCreateOptions);
+        IServiceProvider services = sc.BuildServiceProvider();
+
+        McpServerTool tool = services.GetServices<McpServerTool>().First(t => t.ProtocolTool.Name == "instance_tool");
+        Assert.Contains("42", tool.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("input").GetProperty("value").ToString());
     }
 
     [Fact]
@@ -951,6 +1002,17 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         public string? Name { get; set; }
         public int Age { get; set; }
     }
+    
+    [McpServerToolType]
+    internal class ToolTypeWithSchemaCreateOptions
+    {
+        [McpServerTool]
+        public static string StaticTool(string input) => input;
+        
+        [McpServerTool]
+        public string InstanceTool(string input) => input;
+    }
+    
 
     [JsonSerializable(typeof(bool))]
     [JsonSerializable(typeof(int))]


### PR DESCRIPTION
# Add optional `AIJsonSchemaCreateOptions` parameter to tool registration methods

## Summary

Add optional `AIJsonSchemaCreateOptions` parameter to `WithTools` and `WithToolsFromAssembly` extension methods, enabling developers to customize JSON schema generation for MCP tool parameters and outputs.

## Motivation and Context

When registering MCP tools using `WithTools` or `WithToolsFromAssembly`, developers previously had no way to customize how JSON schemas were generated for tool parameters and return types. This limitation prevented use cases such as:
- Custom schema transformations
- Applying specific validation rules
- Modifying schema nodes to meet specific client requirements

This change adds an optional `AIJsonSchemaCreateOptions` parameter to both methods, providing the same level of schema customization that's available when creating tools directly via `McpServerTool.Create`.

## How Has This Been Tested?

- Added three new unit tests in `McpServerBuilderExtensionsToolsTests.cs`:
  - `Register_Static_Tools_With_Custom_Schema_Create_Options` - Verifies static tool registration with custom schema options
  - `Register_Instance_Tools_With_Custom_Schema_Create_Options` - Verifies instance tool registration with custom schema options
  - `WithToolsFromAssembly_With_Custom_Schema_Create_Options` - Verifies assembly scanning with custom schema options
- All tests verify that the `TransformSchemaNode` callback is properly applied to generated schemas
- Existing tests continue to pass, confirming backward compatibility

## Breaking Changes

None. The new parameter is optional and defaults to `null`, maintaining full backward compatibility with existing code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Implementation details:**
- Added `AIJsonSchemaCreateOptions? schemaCreateOptions = null` parameter to both `WithTools` and `WithToolsFromAssembly` methods
- The parameter is threaded through to `McpServerTool.Create` calls for both static and instance methods
- Added `using Microsoft.Extensions.AI;` import to support the new parameter type
- Updated XML documentation to describe the new parameter