### PR TITLE
Fix $ref pointer resolution after output schema wrapping

### DIFF
--- a/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
@@ -581,8 +581,9 @@ internal sealed partial class AIFunctionMcpServerTool : McpServerTool
                 }
             }
 
-            // ToList() creates a snapshot because the $ref assignment above may invalidate the enumerator.
-            foreach (var property in obj.ToList())
+            // Safe to iterate without snapshot: the $ref assignment above completes before
+            // this enumerator is created, and recursive calls only mutate descendant objects.
+            foreach (var property in obj)
             {
                 RewriteRefPointers(property.Value);
             }

--- a/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
@@ -537,6 +537,11 @@ internal sealed partial class AIFunctionMcpServerTool : McpServerTool
                     ["required"] = new JsonArray { (JsonNode)"result" }
                 };
 
+                // After wrapping, any internal $ref pointers that used absolute JSON Pointer
+                // paths (e.g., "#/items/..." or "#") are now invalid because the original schema
+                // has moved under "#/properties/result". Rewrite them to account for the new location.
+                RewriteRefPointers(schemaNode["properties"]!["result"]);
+
                 structuredOutputRequiresWrapping = true;
             }
 
@@ -544,6 +549,51 @@ internal sealed partial class AIFunctionMcpServerTool : McpServerTool
         }
 
         return outputSchema;
+    }
+
+    /// <summary>
+    /// Recursively rewrites all <c>$ref</c> JSON Pointer values in the given node
+    /// to account for the schema having been wrapped under <c>properties.result</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>System.Text.Json</c>'s <see cref="System.Text.Json.Schema.JsonSchemaExporter"/> uses absolute
+    /// JSON Pointer paths (e.g., <c>#/items/properties/foo</c>) to deduplicate types that appear at
+    /// multiple locations in the schema. When the original schema is moved under
+    /// <c>#/properties/result</c> by the wrapping logic above, these pointers become unresolvable.
+    /// This method prepends <c>/properties/result</c> to every <c>$ref</c> that starts with <c>#/</c>,
+    /// and rewrites bare <c>#</c> (root self-references from recursive types) to <c>#/properties/result</c>,
+    /// so the pointers remain valid after wrapping.
+    /// </remarks>
+    private static void RewriteRefPointers(JsonNode? node)
+    {
+        if (node is JsonObject obj)
+        {
+            if (obj.TryGetPropertyValue("$ref", out JsonNode? refNode) &&
+                refNode?.GetValue<string>() is string refValue)
+            {
+                if (refValue == "#")
+                {
+                    obj["$ref"] = "#/properties/result";
+                }
+                else if (refValue.StartsWith("#/", StringComparison.Ordinal))
+                {
+                    obj["$ref"] = "#/properties/result" + refValue.Substring(1);
+                }
+            }
+
+            // ToList() creates a snapshot because the $ref assignment above may invalidate the enumerator.
+            foreach (var property in obj.ToList())
+            {
+                RewriteRefPointers(property.Value);
+            }
+        }
+        else if (node is JsonArray arr)
+        {
+            foreach (var item in arr)
+            {
+                RewriteRefPointers(item);
+            }
+        }
     }
 
     private JsonElement? CreateStructuredResponse(object? aiFunctionResult)

--- a/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
@@ -794,6 +794,180 @@ public partial class McpServerToolTests
         Assert.True(JsonElement.DeepEquals(expectedSchema, tool.ProtocolTool.InputSchema));
     }
 
+    [Fact]
+    public async Task StructuredOutput_WithDuplicateTypeRefs_RewritesRefPointers()
+    {
+        // When a non-object return type contains the same type at multiple locations,
+        // System.Text.Json's schema exporter emits $ref pointers for deduplication.
+        // After wrapping the schema under properties.result, those $ref pointers must
+        // be rewritten to remain valid. This test verifies that fix.
+        var data = new List<ContactInfo>
+        {
+            new()
+            {
+                WorkPhones = [new() { Number = "555-0100", Type = "work" }],
+                HomePhones = [new() { Number = "555-0200", Type = "home" }],
+            }
+        };
+
+        JsonSerializerOptions options = new() { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
+        McpServerTool tool = McpServerTool.Create(() => data, new() { Name = "tool", UseStructuredContent = true, SerializerOptions = options });
+        var mockServer = new Mock<McpServer>();
+        var request = new RequestContext<CallToolRequestParams>(mockServer.Object, CreateTestJsonRpcRequest())
+        {
+            Params = new CallToolRequestParams { Name = "tool" },
+        };
+
+        var result = await tool.InvokeAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(tool.ProtocolTool.OutputSchema);
+        Assert.Equal("object", tool.ProtocolTool.OutputSchema.Value.GetProperty("type").GetString());
+        Assert.NotNull(result.StructuredContent);
+
+        // Verify $ref pointers in the schema point to valid locations after wrapping.
+        // Without the fix, $ref values like "#/items/..." would be unresolvable because
+        // the original schema was moved under "#/properties/result".
+        AssertMatchesJsonSchema(tool.ProtocolTool.OutputSchema.Value, result.StructuredContent);
+
+        // Also verify that any $ref in the schema starts with #/properties/result
+        // (confirming the rewrite happened).
+        string schemaJson = tool.ProtocolTool.OutputSchema.Value.GetRawText();
+        var schemaNode = JsonNode.Parse(schemaJson)!;
+        AssertAllRefsStartWith(schemaNode, "#/properties/result");
+        AssertAllRefsResolvable(schemaNode, schemaNode);
+    }
+
+    [Fact]
+    public async Task StructuredOutput_WithRecursiveTypeRefs_RewritesRefPointers()
+    {
+        // When a non-object return type contains a recursive type, System.Text.Json's
+        // schema exporter emits $ref pointers (including potentially bare "#") for the
+        // recursive reference. After wrapping, these must be rewritten. For List<TreeNode>,
+        // Children's items emit "$ref": "#/items" which must become "#/properties/result/items".
+        var data = new List<TreeNode>
+        {
+            new()
+            {
+                Name = "root",
+                Children = [new() { Name = "child" }],
+            }
+        };
+
+        JsonSerializerOptions options = new() { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
+        McpServerTool tool = McpServerTool.Create(() => data, new() { Name = "tool", UseStructuredContent = true, SerializerOptions = options });
+        var mockServer = new Mock<McpServer>();
+        var request = new RequestContext<CallToolRequestParams>(mockServer.Object, CreateTestJsonRpcRequest())
+        {
+            Params = new CallToolRequestParams { Name = "tool" },
+        };
+
+        var result = await tool.InvokeAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(tool.ProtocolTool.OutputSchema);
+        Assert.Equal("object", tool.ProtocolTool.OutputSchema.Value.GetProperty("type").GetString());
+        Assert.NotNull(result.StructuredContent);
+
+        AssertMatchesJsonSchema(tool.ProtocolTool.OutputSchema.Value, result.StructuredContent);
+
+        string schemaJson = tool.ProtocolTool.OutputSchema.Value.GetRawText();
+        var schemaNode = JsonNode.Parse(schemaJson)!;
+        AssertAllRefsStartWith(schemaNode, "#/properties/result");
+        AssertAllRefsResolvable(schemaNode, schemaNode);
+    }
+
+    private static void AssertAllRefsStartWith(JsonNode? node, string expectedPrefix)
+    {
+        if (node is JsonObject obj)
+        {
+            if (obj.TryGetPropertyValue("$ref", out JsonNode? refNode) &&
+                refNode?.GetValue<string>() is string refValue)
+            {
+                Assert.StartsWith(expectedPrefix, refValue);
+            }
+
+            foreach (var property in obj)
+            {
+                AssertAllRefsStartWith(property.Value, expectedPrefix);
+            }
+        }
+        else if (node is JsonArray arr)
+        {
+            foreach (var item in arr)
+            {
+                AssertAllRefsStartWith(item, expectedPrefix);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Walks the JSON tree and verifies that every <c>$ref</c> pointer resolves to a valid node.
+    /// </summary>
+    private static void AssertAllRefsResolvable(JsonNode root, JsonNode? node)
+    {
+        if (node is JsonObject obj)
+        {
+            if (obj.TryGetPropertyValue("$ref", out JsonNode? refNode) &&
+                refNode?.GetValue<string>() is string refValue &&
+                refValue.StartsWith("#", StringComparison.Ordinal))
+            {
+                var resolved = ResolveJsonPointer(root, refValue);
+                Assert.True(resolved is not null, $"$ref \"{refValue}\" does not resolve to a valid node in the schema.");
+            }
+
+            foreach (var property in obj)
+            {
+                AssertAllRefsResolvable(root, property.Value);
+            }
+        }
+        else if (node is JsonArray arr)
+        {
+            foreach (var item in arr)
+            {
+                AssertAllRefsResolvable(root, item);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves a JSON Pointer (e.g., <c>#/properties/result/items</c>) against a root node.
+    /// Returns <c>null</c> if the pointer cannot be resolved.
+    /// </summary>
+    private static JsonNode? ResolveJsonPointer(JsonNode root, string pointer)
+    {
+        if (pointer == "#")
+        {
+            return root;
+        }
+
+        if (!pointer.StartsWith("#/", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        JsonNode? current = root;
+        string[] segments = pointer.Substring(2).Split('/');
+        foreach (string segment in segments)
+        {
+            if (current is JsonObject obj)
+            {
+                if (!obj.TryGetPropertyValue(segment, out current))
+                {
+                    return null;
+                }
+            }
+            else if (current is JsonArray arr && int.TryParse(segment, out int index) && index >= 0 && index < arr.Count)
+            {
+                current = arr[index];
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        return current;
+    }
+
     public static IEnumerable<object[]> StructuredOutput_ReturnsExpectedSchema_Inputs()
     {
         yield return new object[] { "string" };
@@ -924,6 +1098,30 @@ public partial class McpServerToolTests
         JsonSerializerOptions options = new(McpJsonUtilities.DefaultOptions);
         options.TypeInfoResolverChain.Add(JsonContext2.Default);
         return options;
+    }
+
+    // Types used by StructuredOutput_WithDuplicateTypeRefs_RewritesRefPointers.
+    // ContactInfo has two properties of the same type (PhoneNumber) which causes
+    // System.Text.Json's schema exporter to emit $ref pointers for deduplication.
+    private sealed class PhoneNumber
+    {
+        public string? Number { get; set; }
+        public string? Type { get; set; }
+    }
+
+    private sealed class ContactInfo
+    {
+        public List<PhoneNumber>? WorkPhones { get; set; }
+        public List<PhoneNumber>? HomePhones { get; set; }
+    }
+
+    // Recursive type used by StructuredOutput_WithRecursiveTypeRefs_RewritesRefPointers.
+    // When List<TreeNode> is the return type, Children's items emit "$ref": "#/items"
+    // pointing back to the first TreeNode definition, which must be rewritten after wrapping.
+    private sealed class TreeNode
+    {
+        public string? Name { get; set; }
+        public List<TreeNode>? Children { get; set; }
     }
 
     [Fact]

--- a/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
@@ -833,8 +833,10 @@ public partial class McpServerToolTests
         // (confirming the rewrite happened).
         string schemaJson = tool.ProtocolTool.OutputSchema.Value.GetRawText();
         var schemaNode = JsonNode.Parse(schemaJson)!;
-        AssertAllRefsStartWith(schemaNode, "#/properties/result");
-        AssertAllRefsResolvable(schemaNode, schemaNode);
+        int refCount = AssertAllRefsStartWith(schemaNode, "#/properties/result");
+        Assert.True(refCount > 0, "Expected at least one $ref in the schema to validate the rewrite, but none were found.");
+        int resolvableCount = AssertAllRefsResolvable(schemaNode, schemaNode);
+        Assert.True(resolvableCount > 0, "Expected at least one resolvable $ref in the schema, but none were found.");
     }
 
     [Fact]
@@ -871,39 +873,46 @@ public partial class McpServerToolTests
 
         string schemaJson = tool.ProtocolTool.OutputSchema.Value.GetRawText();
         var schemaNode = JsonNode.Parse(schemaJson)!;
-        AssertAllRefsStartWith(schemaNode, "#/properties/result");
-        AssertAllRefsResolvable(schemaNode, schemaNode);
+        int refCount = AssertAllRefsStartWith(schemaNode, "#/properties/result");
+        Assert.True(refCount > 0, "Expected at least one $ref in the schema to validate the rewrite, but none were found.");
+        int resolvableCount = AssertAllRefsResolvable(schemaNode, schemaNode);
+        Assert.True(resolvableCount > 0, "Expected at least one resolvable $ref in the schema, but none were found.");
     }
 
-    private static void AssertAllRefsStartWith(JsonNode? node, string expectedPrefix)
+    private static int AssertAllRefsStartWith(JsonNode? node, string expectedPrefix)
     {
+        int count = 0;
         if (node is JsonObject obj)
         {
             if (obj.TryGetPropertyValue("$ref", out JsonNode? refNode) &&
                 refNode?.GetValue<string>() is string refValue)
             {
                 Assert.StartsWith(expectedPrefix, refValue);
+                count++;
             }
 
             foreach (var property in obj)
             {
-                AssertAllRefsStartWith(property.Value, expectedPrefix);
+                count += AssertAllRefsStartWith(property.Value, expectedPrefix);
             }
         }
         else if (node is JsonArray arr)
         {
             foreach (var item in arr)
             {
-                AssertAllRefsStartWith(item, expectedPrefix);
+                count += AssertAllRefsStartWith(item, expectedPrefix);
             }
         }
+
+        return count;
     }
 
     /// <summary>
     /// Walks the JSON tree and verifies that every <c>$ref</c> pointer resolves to a valid node.
     /// </summary>
-    private static void AssertAllRefsResolvable(JsonNode root, JsonNode? node)
+    private static int AssertAllRefsResolvable(JsonNode root, JsonNode? node)
     {
+        int count = 0;
         if (node is JsonObject obj)
         {
             if (obj.TryGetPropertyValue("$ref", out JsonNode? refNode) &&
@@ -912,20 +921,23 @@ public partial class McpServerToolTests
             {
                 var resolved = ResolveJsonPointer(root, refValue);
                 Assert.True(resolved is not null, $"$ref \"{refValue}\" does not resolve to a valid node in the schema.");
+                count++;
             }
 
             foreach (var property in obj)
             {
-                AssertAllRefsResolvable(root, property.Value);
+                count += AssertAllRefsResolvable(root, property.Value);
             }
         }
         else if (node is JsonArray arr)
         {
             foreach (var item in arr)
             {
-                AssertAllRefsResolvable(root, item);
+                count += AssertAllRefsResolvable(root, item);
             }
         }
+
+        return count;
     }
 
     /// <summary>

--- a/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
@@ -813,12 +813,9 @@ public partial class McpServerToolTests
         JsonSerializerOptions options = new() { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
         McpServerTool tool = McpServerTool.Create(() => data, new() { Name = "tool", UseStructuredContent = true, SerializerOptions = options });
         var mockServer = new Mock<McpServer>();
-        var request = new RequestContext<CallToolRequestParams>(mockServer.Object, CreateTestJsonRpcRequest())
-        {
-            Params = new CallToolRequestParams { Name = "tool" },
-        };
-
-        var result = await tool.InvokeAsync(request, TestContext.Current.CancellationToken);
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, CreateTestJsonRpcRequest(), new() { Name = "tool" }),
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(tool.ProtocolTool.OutputSchema);
         Assert.Equal("object", tool.ProtocolTool.OutputSchema.Value.GetProperty("type").GetString());
@@ -858,12 +855,9 @@ public partial class McpServerToolTests
         JsonSerializerOptions options = new() { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
         McpServerTool tool = McpServerTool.Create(() => data, new() { Name = "tool", UseStructuredContent = true, SerializerOptions = options });
         var mockServer = new Mock<McpServer>();
-        var request = new RequestContext<CallToolRequestParams>(mockServer.Object, CreateTestJsonRpcRequest())
-        {
-            Params = new CallToolRequestParams { Name = "tool" },
-        };
-
-        var result = await tool.InvokeAsync(request, TestContext.Current.CancellationToken);
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, CreateTestJsonRpcRequest(), new() { Name = "tool" }),
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(tool.ProtocolTool.OutputSchema);
         Assert.Equal("object", tool.ProtocolTool.OutputSchema.Value.GetProperty("type").GetString());


### PR DESCRIPTION
## Summary

- **Fix**: After `CreateOutputSchema()` wraps a non-object schema under `properties.result`, rewrite all internal `$ref` JSON Pointers so they remain valid at their new location.
- **Test**: Add `StructuredOutput_WithDuplicateTypeRefs_RewritesRefPointers` to verify the fix.

## Problem

`System.Text.Json`'s `JsonSchemaExporter` deduplicates repeated types by emitting `$ref` pointers with absolute JSON Pointer paths (e.g., `#/items/properties/foo/items`). When `CreateOutputSchema()` wraps a non-object schema inside `{ "type": "object", "properties": { "result": <original> } }`, these `$ref` paths become unresolvable because the original schema has moved under `#/properties/result`.

This breaks all tools that:
1. Return a non-object type (`IEnumerable<T>`, `List<T>`, arrays, primitives)
2. Have `UseStructuredContent = true`
3. Have a return type graph containing the same type at multiple locations (triggering `$ref` deduplication)

When a client calls `tools/list`, the broken schema causes JSON Schema validation errors. In MCP clients that don't isolate per-tool errors (e.g., the TypeScript SDK's `cacheToolMetadata()`), **one broken tool schema prevents all tools from being enumerated**.

## Fix

Add `RewriteRefPointers()` — a recursive walk over the wrapped JSON tree that prepends `/properties/result` to every `$ref` value starting with `#/`. Called immediately after the wrapping block in `CreateOutputSchema()`.

## Reproduction

A minimal repro is available as a gist: https://gist.github.com/weinong/7a750e9b99c846dadc4fa41fc6c856fc

Fixes #1434