### PR TITLE
fix: propagate auth errors (401/403) immediately instead of falling b…

### DIFF
--- a/src/ModelContextProtocol.Core/Client/AutoDetectingClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/AutoDetectingClientSessionTransport.cs
@@ -73,9 +73,21 @@ internal sealed partial class AutoDetectingClientSessionTransport : ITransport
                 LogUsingStreamableHttp(_name);
                 ActiveTransport = streamableHttpTransport;
             }
+            else if (IsAuthError(response.StatusCode))
+            {
+                // Authentication/authorization errors (401, 403) are not transport-related —
+                // the server understood the request but rejected the credentials. Falling back
+                // to SSE would fail with the same credentials and mask the real error.
+                await streamableHttpTransport.DisposeAsync().ConfigureAwait(false);
+
+                LogStreamableHttpAuthError(_name, response.StatusCode);
+
+                await response.EnsureSuccessStatusCodeWithResponseBodyAsync(cancellationToken).ConfigureAwait(false);
+            }
             else
             {
-                // If the status code is not success, fall back to SSE
+                // Non-auth, non-success status codes (404, 405, 501, etc.) suggest the server
+                // may not support Streamable HTTP — fall back to SSE.
                 LogStreamableHttpFailed(_name, response.StatusCode);
 
                 await streamableHttpTransport.DisposeAsync().ConfigureAwait(false);
@@ -90,6 +102,9 @@ internal sealed partial class AutoDetectingClientSessionTransport : ITransport
             throw;
         }
     }
+
+    private static bool IsAuthError(HttpStatusCode statusCode) =>
+        statusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
 
     private async Task InitializeSseTransportAsync(JsonRpcMessage message, CancellationToken cancellationToken)
     {
@@ -138,6 +153,9 @@ internal sealed partial class AutoDetectingClientSessionTransport : ITransport
 
     [LoggerMessage(Level = LogLevel.Information, Message = "{EndpointName} streamable HTTP transport failed with status code {StatusCode}, falling back to SSE transport.")]
     private partial void LogStreamableHttpFailed(string endpointName, HttpStatusCode statusCode);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{EndpointName} streamable HTTP transport received authentication error {StatusCode}. Not falling back to SSE.")]
+    private partial void LogStreamableHttpAuthError(string endpointName, HttpStatusCode statusCode);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "{EndpointName} using Streamable HTTP transport.")]
     private partial void LogUsingStreamableHttp(string endpointName);

--- a/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportAutoDetectTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportAutoDetectTests.cs
@@ -47,6 +47,59 @@ public class HttpClientTransportAutoDetectTests(ITestOutputHelper testOutputHelp
         Assert.NotNull(session);
     }
 
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public async Task AutoDetectMode_DoesNotFallBackToSse_OnAuthError(HttpStatusCode authStatusCode)
+    {
+        // Auth errors (401, 403) are not transport-related — the server understood the
+        // request but rejected the credentials. The SDK should propagate the error
+        // immediately instead of falling back to SSE, which would mask the real cause.
+        var options = new HttpClientTransportOptions
+        {
+            Endpoint = new Uri("http://localhost"),
+            TransportMode = HttpTransportMode.AutoDetect,
+            Name = "AutoDetect test client"
+        };
+
+        using var mockHttpHandler = new MockHttpHandler();
+        using var httpClient = new HttpClient(mockHttpHandler);
+        await using var transport = new HttpClientTransport(options, httpClient, LoggerFactory);
+
+        var requestMethods = new List<HttpMethod>();
+
+        mockHttpHandler.RequestHandler = (request) =>
+        {
+            requestMethods.Add(request.Method);
+
+            if (request.Method == HttpMethod.Post)
+            {
+                // Streamable HTTP POST returns auth error
+                return Task.FromResult(new HttpResponseMessage
+                {
+                    StatusCode = authStatusCode,
+                    Content = new StringContent($"{{\"error\": \"{authStatusCode}\"}}")
+                });
+            }
+
+            // SSE GET should never be reached
+            throw new InvalidOperationException("Should not fall back to SSE on auth error");
+        };
+
+        // ConnectAsync for AutoDetect mode just creates the transport without sending
+        // any HTTP request. The auto-detection is triggered lazily by the first
+        // SendMessageAsync call, which happens inside McpClient.CreateAsync when it
+        // sends the JSON-RPC "initialize" message.
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => McpClient.CreateAsync(transport, cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(authStatusCode, ex.StatusCode);
+
+        // Verify only POST was sent — no GET fallback
+        Assert.Single(requestMethods);
+        Assert.Equal(HttpMethod.Post, requestMethods[0]);
+    }
+
     [Fact] 
     public async Task AutoDetectMode_FallsBackToSse_WhenStreamableHttpFails()
     {


### PR DESCRIPTION
…ack to SSE

When AutoDetectingClientSessionTransport receives a 401 or 403 from the initial Streamable HTTP POST, it should NOT fall back to SSE transport. Auth errors are not transport-related — the server understood the request but rejected the credentials. Falling back to SSE would:

1. Fail with the same credentials (or a different transport error)
2. Mask the real authentication error from the caller

This was discovered investigating Azure AI Search MCP endpoints returning 403 on Streamable HTTP POST, which caused the SDK to fall back to SSE GET, resulting in a confusing 405 error that hid the real auth failure.

The fix adds an explicit check for 401/403 before the SSE fallback path, and throws HttpRequestException with the auth status code immediately.

Code reference:
  AutoDetectingClientSessionTransport.InitializeAsync
  https://github.com/modelcontextprotocol/csharp-sdk/blob/v0.9.0-preview.2/src/ModelContextProtocol.Core/Client/AutoDetectingClientSessionTransport.cs#L61

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
