### PR TITLE
Block Release Publishing workflow from automatically running on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ on:
 
 jobs:
   build-all-configs:
+    # Don't run scheduled/release triggers on forks; allow manual workflow_dispatch
+    if: ${{ github.repository == 'modelcontextprotocol/csharp-sdk' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
Add an if condition to the build-all-configs job to prevent the Release Publishing workflow from running on forks via schedule or release triggers. The `workflow_dispatch` trigger is exempted so fork owners can still manually test the workflow.

Since all downstream jobs (build-package, publish-github, publish-release, publish-nuget) depend on build-all-configs via the needs chain, they are automatically skipped when build-all-configs is skipped. This is consistent with the existing repository check in the publish-nuget job and docs.yml workflow.