### PR TITLE
Suppress ExecutionContext flow in BeginErrorReadLine

### DIFF
--- a/src/ModelContextProtocol.Core/Client/StdioClientTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/StdioClientTransport.cs
@@ -191,7 +191,13 @@ public sealed partial class StdioClientTransport : IClientTransport
 
             LogTransportProcessStarted(logger, endpointName, process.Id);
 
-            process.BeginErrorReadLine();
+            // Suppress ExecutionContext flow so the Process's internal async
+            // stderr reader thread doesn't capture the caller's ambient context
+            // (e.g. AsyncLocal values from test infrastructure or HTTP request state).
+            using (ExecutionContext.SuppressFlow())
+            {
+                process.BeginErrorReadLine();
+            }
 
             return new StdioClientSessionTransport(_options, process, endpointName, stderrRollingLog, _loggerFactory);
         }

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -5,6 +5,7 @@ using System.IO.Pipelines;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 
 namespace ModelContextProtocol.Tests.Transport;
 
@@ -57,6 +58,47 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
 
         Assert.InRange(count, 1, int.MaxValue);
         Assert.Contains(id, sb.ToString());
+    }
+
+    [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
+    public async Task CreateAsync_StdErrCallback_DoesNotCaptureCallerAsyncLocal()
+    {
+        var asyncLocal = new AsyncLocal<string>();
+        asyncLocal.Value = "caller-context";
+
+        string? capturedValue = "not-set";
+        var received = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            new(new()
+            {
+                Command = "cmd",
+                Arguments = ["/c", "echo test >&2 & exit /b 1"],
+                StandardErrorLines = _ =>
+                {
+                    capturedValue = asyncLocal.Value;
+                    received.TrySetResult(true);
+                }
+            }, LoggerFactory) :
+            new(new()
+            {
+                Command = "sh",
+                Arguments = ["-c", "echo test >&2; exit 1"],
+                StandardErrorLines = _ =>
+                {
+                    capturedValue = asyncLocal.Value;
+                    received.TrySetResult(true);
+                }
+            }, LoggerFactory);
+
+        await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
+
+        // Wait for the stderr callback to fire.
+        await received.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        // The callback should NOT see the caller's AsyncLocal value because
+        // ExecutionContext flow is suppressed for the stderr reader thread.
+        Assert.Null(capturedValue);
     }
 
     [Theory]

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -61,7 +61,6 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
     }
 
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
-<<<<<<< suppress-ec-flow-stderr
     public async Task CreateAsync_StdErrCallback_DoesNotCaptureCallerAsyncLocal()
     {
         var asyncLocal = new AsyncLocal<string>();
@@ -100,7 +99,9 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
         // The callback should NOT see the caller's AsyncLocal value because
         // ExecutionContext flow is suppressed for the stderr reader thread.
         Assert.Null(capturedValue);
-=======
+    }
+
+    [Fact(Skip= "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
     public async Task CreateAsync_StdErrCallbackThrows_DoesNotCrashProcess()
     {
         StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
@@ -109,7 +110,6 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
 
         // Should throw IOException for the failed server, not crash the host process.
         await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
->>>>>>> main
     }
 
     [Theory]


### PR DESCRIPTION
Process.BeginErrorReadLine() captures the caller's ExecutionContext, causing AsyncLocal values to leak to the background stderr reader thread. This is undesirable—the stderr handler is a long-lived background I/O callback that shouldn't inherit ambient state from whichever call site happened to create the transport.

Wrap BeginErrorReadLine() in ExecutionContext.SuppressFlow() so the stderr reader gets a clean context.

Add a test that sets an AsyncLocal before creating the transport and verifies the stderr callback does NOT see the value.