### PR TITLE
Remove extraneous labels from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
       - dependency-name: "Microsoft.Extensions.Hosting.Abstractions"
       - dependency-name: "Microsoft.Extensions.Logging.Abstractions"
       - dependency-name: "Microsoft.Extensions.AI.OpenAI"
-      - dependency-name: "Microsoft.Extensions.TimeProvider.Testing" 
+      - dependency-name: "Microsoft.Extensions.TimeProvider.Testing"
       - dependency-name: "Microsoft.AspNetCore.*"
       - dependency-name: "Microsoft.IdentityModel.*"
       - dependency-name: "Microsoft.Bcl.*"
@@ -56,7 +56,6 @@ updates:
     # Add labels to dependency update PRs
     labels:
       - "dependencies"
-      - "testing"
 
   # Monitor GitHub Actions
   - package-ecosystem: "github-actions"
@@ -70,4 +69,3 @@ updates:
     # Add labels to GitHub Actions update PRs
     labels:
       - "dependencies"
-      - "github-actions"


### PR DESCRIPTION
This PR removes two labels from the dependabot configuration because they are not defined in the repo.

The dependabot configuration specifies labels to add to its PRs in certain situations, but some of these labels were not defined in the repo so we'd wind up with a message like this in the PR:

<img width="986" height="257" alt="image" src="https://github.com/user-attachments/assets/ce8fde77-4f75-4201-a5d3-f32c8a1f67c3" />

I checked several dotnet repos and also some of the modelcontextprotocol repos and none of them have these labels or configure dependabot to add them.

I checked the history of the lines in dependabot.yml to see who added them and found it was copilot.

So the simplest fix seemed to be just removing these labels from the config.