### PR TITLE
Fix client to accept any supported server protocol version during negotiation

### DIFF
--- a/src/ModelContextProtocol.Core/Client/McpClientImpl.cs
+++ b/src/ModelContextProtocol.Core/Client/McpClientImpl.cs
@@ -569,8 +569,8 @@ internal sealed partial class McpClientImpl : McpClient
 
                 // Validate protocol version
                 bool isResponseProtocolValid =
-                    _options.ProtocolVersion is { } optionsProtocol ? optionsProtocol == initializeResponse.ProtocolVersion :
-                    McpSessionHandler.SupportedProtocolVersions.Contains(initializeResponse.ProtocolVersion);
+                    McpSessionHandler.SupportedProtocolVersions.Contains(initializeResponse.ProtocolVersion) ||
+                    (_options.ProtocolVersion is { } optionsProtocol && optionsProtocol == initializeResponse.ProtocolVersion);
                 if (!isResponseProtocolValid)
                 {
                     LogServerProtocolVersionMismatch(_endpointName, requestProtocol, initializeResponse.ProtocolVersion);

--- a/tests/ModelContextProtocol.Tests/Client/McpClientTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientTests.cs
@@ -587,6 +587,15 @@ public class McpClientTests : ClientServerTestBase
         Assert.Equal(protocolVersion ?? "2025-11-25", client.NegotiatedProtocolVersion);
     }
 
+    [Theory]
+    [InlineData("2025-11-25", "2025-06-18")]
+    public async Task AcceptsLowerServerProtocolVersion(string clientVersion, string serverVersion)
+    {
+        Server.ServerOptions.ProtocolVersion = serverVersion;
+        await using McpClient client = await CreateMcpClientForServer(new() { ProtocolVersion = clientVersion });
+        Assert.Equal(serverVersion, client.NegotiatedProtocolVersion);
+    }
+
     [Fact]
     public async Task EndToEnd_SamplingWithTools_ServerUsesIChatClientWithFunctionInvocation_ClientHandlesSamplingWithIChatClient()
     {


### PR DESCRIPTION
Fixes #1536

When `McpClientOptions.ProtocolVersion` is explicitly set, the client incorrectly requires the server to respond with that exact version. If the server responds with a different but supported version (e.g., negotiating down from `DRAFT-2026-v1` to `2025-11-25`), the client throws `McpException: Server protocol version mismatch`.

## Changes

1. **Test** (`AcceptsLowerServerProtocolVersion`): Verifies the client accepts a server responding with a lower supported protocol version when the client explicitly requests a higher one.
2. **Fix**: Change the version validation in `McpClientImpl.cs` to accept any version in `SupportedProtocolVersions`, regardless of whether `ProtocolVersion` was explicitly set. The explicit version is still accepted as a fallback for forward compatibility.