### PR TITLE
Fix dev container configuration to work in codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 {
 	"name": "C# (.NET SDK)",
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-jammy",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:2-10.0",
 	"features": {
 		"ghcr.io/devcontainers/features/dotnet:2": {
-			"version": "10.0",
-			"additionalVersions": "9.0"
+			"version": "9.0",
+			"additionalVersions": "8.0"
 		},
 		"ghcr.io/devcontainers/features/node:1": {}
 	},


### PR DESCRIPTION
This PR fixes the dev container configuration to use the standard dotnet 10 dev container as the base image, and then add the down-level versions through features. The prior configuration was failing to build with node incompatibilites caused by the downlevel version of node in the dotnet 8 package (I think).
