### PR TITLE
Add `InheritEnvironmentVariables` to `StdioClientTransportOptions`

### DIFF
--- a/docs/concepts/transports/transports.md
+++ b/docs/concepts/transports/transports.md
@@ -54,12 +54,21 @@ var transport = new StdioClientTransport(new StdioClientTransportOptions
 {
     Command = "my-mcp-server",
     InheritEnvironmentVariables = false,
-    EnvironmentVariables = new Dictionary<string, string?>
-    {
-        // Provide only the variables the server actually needs.
-        ["PATH"] = Environment.GetEnvironmentVariable("PATH"),
-        ["MY_SERVER_API_KEY"] = apiKey,
-    }
+    EnvironmentVariables = StdioClientTransportOptions.GetDefaultEnvironmentVariables(),
+});
+```
+
+`GetDefaultEnvironmentVariables()` returns a curated set of environment variables (such as `PATH`, `HOME`, and standard system directories) that most child processes need to start correctly, without leaking credentials or other sensitive values from the parent process. The allowlist is aligned with the defaults used by the TypeScript and Python MCP SDKs. You can add server-specific variables on top:
+
+```csharp
+var env = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+env["MY_SERVER_API_KEY"] = apiKey;
+
+var transport = new StdioClientTransport(new StdioClientTransportOptions
+{
+    Command = "my-mcp-server",
+    InheritEnvironmentVariables = false,
+    EnvironmentVariables = env,
 });
 ```
 

--- a/docs/concepts/transports/transports.md
+++ b/docs/concepts/transports/transports.md
@@ -75,7 +75,7 @@ var transport = new StdioClientTransport(new StdioClientTransportOptions
 > [!WARNING]
 > **Security risk (inheriting):** Variables such as `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `OPENAI_API_KEY`, and similar credentials present in the parent process automatically flow into the child process unless inheritance is disabled. This can unintentionally expose sensitive values to third-party or untrusted MCP servers.
 >
-> **Compatibility risk (not inheriting):** Disabling inheritance can cause the child process to fail to start or behave incorrectly if it relies on variables provided by the OS or shell. Common requirements include `PATH` (to locate executables), `HOME` (used by many tools on Unix), `DOTNET_ROOT`, `LD_LIBRARY_PATH`, `JAVA_HOME`, and proxy settings (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`). When disabling inheritance, ensure all variables required by the server are explicitly supplied via `EnvironmentVariables`.
+> **Compatibility risk (not inheriting):** Disabling inheritance can cause the child process to fail to start or behave incorrectly if it relies on variables provided by the OS or shell. `GetDefaultEnvironmentVariables()` covers the most common requirements — `PATH`, `HOME`, and standard system directories — so for most servers it is a safe starting point. For servers that need additional variables not in the default set (such as `DOTNET_ROOT`, `LD_LIBRARY_PATH`, `JAVA_HOME`, or proxy settings like `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`), add them on top as shown in the example above.
 
 #### stdio server
 

--- a/docs/concepts/transports/transports.md
+++ b/docs/concepts/transports/transports.md
@@ -39,10 +39,34 @@ Key <xref:ModelContextProtocol.Client.StdioClientTransportOptions> properties:
 | `Command` | The executable to launch (required) |
 | `Arguments` | Command-line arguments for the process |
 | `WorkingDirectory` | Working directory for the server process |
-| `EnvironmentVariables` | Environment variables (merged with current; `null` values remove variables) |
+| `EnvironmentVariables` | Environment variables (merged with current when inheriting; `null` values remove variables) |
+| `InheritEnvironmentVariables` | Whether the server process inherits the current process's environment variables (default: `true`) |
 | `ShutdownTimeout` | Graceful shutdown timeout (default: 5 seconds) |
 | `StandardErrorLines` | Callback for stderr output from the server process |
 | `Name` | Optional transport identifier for logging |
+
+#### Environment variable inheritance
+
+By default, the server process inherits **all** environment variables from the current process. This includes credentials, tokens, proxy settings, and internal configuration that may be sensitive or irrelevant to the server. When running third-party or untrusted MCP servers, consider disabling inheritance to prevent unintentional credential leakage:
+
+```csharp
+var transport = new StdioClientTransport(new StdioClientTransportOptions
+{
+    Command = "my-mcp-server",
+    InheritEnvironmentVariables = false,
+    EnvironmentVariables = new Dictionary<string, string?>
+    {
+        // Provide only the variables the server actually needs.
+        ["PATH"] = Environment.GetEnvironmentVariable("PATH"),
+        ["MY_SERVER_API_KEY"] = apiKey,
+    }
+});
+```
+
+> [!WARNING]
+> **Security risk (inheriting):** Variables such as `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `OPENAI_API_KEY`, and similar credentials present in the parent process automatically flow into the child process unless inheritance is disabled. This can unintentionally expose sensitive values to third-party or untrusted MCP servers.
+>
+> **Compatibility risk (not inheriting):** Disabling inheritance can cause the child process to fail to start or behave incorrectly if it relies on variables provided by the OS or shell. Common requirements include `PATH` (to locate executables), `HOME` (used by many tools on Unix), `DOTNET_ROOT`, `LD_LIBRARY_PATH`, `JAVA_HOME`, and proxy settings (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`). When disabling inheritance, ensure all variables required by the server are explicitly supplied via `EnvironmentVariables`.
 
 #### stdio server
 

--- a/docs/concepts/transports/transports.md
+++ b/docs/concepts/transports/transports.md
@@ -58,11 +58,30 @@ var transport = new StdioClientTransport(new StdioClientTransportOptions
 });
 ```
 
-`GetDefaultEnvironmentVariables()` returns a curated set of environment variables (such as `PATH`, `HOME`, and standard system directories) that most child processes need to start correctly, without leaking credentials or other sensitive values from the parent process. The allowlist is aligned with the defaults used by the TypeScript and Python MCP SDKs. You can add server-specific variables on top:
+`GetDefaultEnvironmentVariables()` returns a curated set of environment variables (such as `PATH`, `HOME`, and standard system directories) that most child processes need to start correctly, without leaking credentials or other sensitive values from the parent process. The allowlist is aligned with the defaults used by the TypeScript and Python MCP SDKs. On Windows it also includes `PATHEXT`, which is required for the OS to recognize `.cmd` and `.bat` files as executable. You can add server-specific variables on top:
 
 ```csharp
 var env = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
 env["MY_SERVER_API_KEY"] = apiKey;
+
+var transport = new StdioClientTransport(new StdioClientTransportOptions
+{
+    Command = "my-mcp-server",
+    InheritEnvironmentVariables = false,
+    EnvironmentVariables = env,
+});
+```
+
+If you need to selectively forward a specific set of variables from the parent environment rather than using the curated allowlist, build the dictionary manually:
+
+```csharp
+var env = new Dictionary<string, string?>();
+foreach (var name in new[] { "PATH", "HOME", "HTTP_PROXY", "HTTPS_PROXY" })
+{
+    var value = Environment.GetEnvironmentVariable(name);
+    if (value is not null)
+        env[name] = value;
+}
 
 var transport = new StdioClientTransport(new StdioClientTransportOptions
 {

--- a/samples/ChatWithTools/Program.cs
+++ b/samples/ChatWithTools/Program.cs
@@ -7,6 +7,7 @@ using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
+using System.Runtime.InteropServices;
 
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddHttpClientInstrumentation()
@@ -39,6 +40,8 @@ var mcpClient = await McpClient.CreateAsync(
         Command = "npx",
         Arguments = ["-y", "--verbose", "@modelcontextprotocol/server-everything"],
         Name = "Everything",
+        InheritEnvironmentVariables = false,
+        EnvironmentVariables = MinimalEnvironment(),
     }),
     clientOptions: new()
     {
@@ -82,4 +85,18 @@ while (true)
     Console.WriteLine();
 
     messages.AddMessages(updates);
+}
+
+// Returns a minimal set of environment variables needed by Node.js/npm tooling.
+// Omitting variables the server doesn't need prevents unintentional leakage of
+// credentials or other sensitive values present in the parent process.
+static Dictionary<string, string?> MinimalEnvironment()
+{
+    string[] names = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? ["PATH", "USERPROFILE", "APPDATA", "LOCALAPPDATA", "TEMP", "TMP"]
+        : ["PATH", "HOME", "TMPDIR"];
+    return names
+        .Select(n => (n, v: Environment.GetEnvironmentVariable(n)))
+        .Where(t => t.v is not null)
+        .ToDictionary(t => t.n, t => (string?)t.v);
 }

--- a/samples/ChatWithTools/Program.cs
+++ b/samples/ChatWithTools/Program.cs
@@ -7,7 +7,6 @@ using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using System.Runtime.InteropServices;
 
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddHttpClientInstrumentation()
@@ -41,7 +40,7 @@ var mcpClient = await McpClient.CreateAsync(
         Arguments = ["-y", "--verbose", "@modelcontextprotocol/server-everything"],
         Name = "Everything",
         InheritEnvironmentVariables = false,
-        EnvironmentVariables = MinimalEnvironment(),
+        EnvironmentVariables = StdioClientTransportOptions.GetDefaultEnvironmentVariables(),
     }),
     clientOptions: new()
     {
@@ -87,16 +86,3 @@ while (true)
     messages.AddMessages(updates);
 }
 
-// Returns a minimal set of environment variables needed by Node.js/npm tooling.
-// Omitting variables the server doesn't need prevents unintentional leakage of
-// credentials or other sensitive values present in the parent process.
-static Dictionary<string, string?> MinimalEnvironment()
-{
-    string[] names = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-        ? ["PATH", "USERPROFILE", "APPDATA", "LOCALAPPDATA", "TEMP", "TMP"]
-        : ["PATH", "HOME", "TMPDIR"];
-    return names
-        .Select(n => (n, v: Environment.GetEnvironmentVariable(n)))
-        .Where(t => t.v is not null)
-        .ToDictionary(t => t.n, t => (string?)t.v);
-}

--- a/samples/ChatWithTools/Program.cs
+++ b/samples/ChatWithTools/Program.cs
@@ -85,4 +85,3 @@ while (true)
 
     messages.AddMessages(updates);
 }
-

--- a/samples/QuickstartClient/Program.cs
+++ b/samples/QuickstartClient/Program.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Hosting;
 using ModelContextProtocol.Client;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -33,7 +32,7 @@ else
         Command = command,
         Arguments = arguments,
         InheritEnvironmentVariables = false,
-        EnvironmentVariables = MinimalEnvironment(),
+        EnvironmentVariables = MinimalDotNetEnvironment(),
     });
 }
 await using var mcpClient = await McpClient.CreateAsync(clientTransport!);
@@ -126,16 +125,20 @@ static string GetCurrentSourceDirectory([CallerFilePath] string? currentFile = n
     return Path.GetDirectoryName(currentFile) ?? throw new InvalidOperationException("Unable to determine source directory.");
 }
 
-// Returns a minimal set of environment variables needed by dotnet/node/python tooling.
+// Returns the safe default environment variables plus extras needed by 'dotnet run'.
 // Omitting variables the server doesn't need prevents unintentional leakage of
 // credentials or other sensitive values present in the parent process.
-static Dictionary<string, string?> MinimalEnvironment()
+static Dictionary<string, string?> MinimalDotNetEnvironment()
 {
-    string[] names = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-        ? ["PATH", "USERPROFILE", "APPDATA", "LOCALAPPDATA", "TEMP", "TMP", "DOTNET_ROOT", "NUGET_PACKAGES"]
-        : ["PATH", "HOME", "TMPDIR", "DOTNET_ROOT", "NUGET_PACKAGES"];
-    return names
-        .Select(n => (n, v: Environment.GetEnvironmentVariable(n)))
-        .Where(t => t.v is not null)
-        .ToDictionary(t => t.n, t => (string?)t.v);
+    var env = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+    // 'dotnet run' also needs DOTNET_ROOT and NUGET_PACKAGES to find the .NET runtime and package cache.
+    foreach (var key in (string[])["DOTNET_ROOT", "NUGET_PACKAGES"])
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        if (value is not null)
+        {
+            env[key] = value;
+        }
+    }
+    return env;
 }

--- a/samples/QuickstartClient/Program.cs
+++ b/samples/QuickstartClient/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using ModelContextProtocol.Client;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -31,6 +32,8 @@ else
         Name = "Demo Server",
         Command = command,
         Arguments = arguments,
+        InheritEnvironmentVariables = false,
+        EnvironmentVariables = MinimalEnvironment(),
     });
 }
 await using var mcpClient = await McpClient.CreateAsync(clientTransport!);
@@ -121,4 +124,18 @@ static string GetCurrentSourceDirectory([CallerFilePath] string? currentFile = n
 {
     Debug.Assert(!string.IsNullOrWhiteSpace(currentFile));
     return Path.GetDirectoryName(currentFile) ?? throw new InvalidOperationException("Unable to determine source directory.");
+}
+
+// Returns a minimal set of environment variables needed by dotnet/node/python tooling.
+// Omitting variables the server doesn't need prevents unintentional leakage of
+// credentials or other sensitive values present in the parent process.
+static Dictionary<string, string?> MinimalEnvironment()
+{
+    string[] names = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? ["PATH", "USERPROFILE", "APPDATA", "LOCALAPPDATA", "TEMP", "TMP", "DOTNET_ROOT", "NUGET_PACKAGES"]
+        : ["PATH", "HOME", "TMPDIR", "DOTNET_ROOT", "NUGET_PACKAGES"];
+    return names
+        .Select(n => (n, v: Environment.GetEnvironmentVariable(n)))
+        .Where(t => t.v is not null)
+        .ToDictionary(t => t.n, t => (string?)t.v);
 }

--- a/samples/QuickstartClient/Program.cs
+++ b/samples/QuickstartClient/Program.cs
@@ -32,7 +32,7 @@ else
         Command = command,
         Arguments = arguments,
         InheritEnvironmentVariables = false,
-        EnvironmentVariables = MinimalDotNetEnvironment(),
+        EnvironmentVariables = GetMinimalDotNetEnvironment(),
     });
 }
 await using var mcpClient = await McpClient.CreateAsync(clientTransport!);
@@ -128,7 +128,7 @@ static string GetCurrentSourceDirectory([CallerFilePath] string? currentFile = n
 // Returns the safe default environment variables plus extras needed by 'dotnet run'.
 // Omitting variables the server doesn't need prevents unintentional leakage of
 // credentials or other sensitive values present in the parent process.
-static Dictionary<string, string?> MinimalDotNetEnvironment()
+static Dictionary<string, string?> GetMinimalDotNetEnvironment()
 {
     var env = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
     // 'dotnet run' also needs DOTNET_ROOT and NUGET_PACKAGES to find the .NET runtime and package cache.

--- a/src/ModelContextProtocol.Core/Client/StdioClientTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/StdioClientTransport.cs
@@ -111,6 +111,11 @@ public sealed partial class StdioClientTransport : IClientTransport
 #endif
             }
 
+            if (!_options.InheritEnvironmentVariables)
+            {
+                startInfo.Environment.Clear();
+            }
+
             if (_options.EnvironmentVariables != null)
             {
                 foreach (var entry in _options.EnvironmentVariables)

--- a/src/ModelContextProtocol.Core/Client/StdioClientTransportOptions.cs
+++ b/src/ModelContextProtocol.Core/Client/StdioClientTransportOptions.cs
@@ -66,7 +66,10 @@ public sealed class StdioClientTransportOptions
             ? s_defaultWindowsVars
             : s_defaultUnixVars;
 
-        var result = new Dictionary<string, string?>(StringComparer.Ordinal);
+        var result = new Dictionary<string, string?>(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal);
         foreach (var name in names)
         {
             var value = Environment.GetEnvironmentVariable(name);

--- a/src/ModelContextProtocol.Core/Client/StdioClientTransportOptions.cs
+++ b/src/ModelContextProtocol.Core/Client/StdioClientTransportOptions.cs
@@ -149,11 +149,12 @@ public sealed class StdioClientTransportOptions
     /// </para>
     /// <para>
     /// <strong>Compatibility consideration:</strong> Disabling inheritance can cause the child process to fail to start or
-    /// behave unexpectedly if it relies on variables provided by the operating system or the user's shell environment. Common
-    /// examples include <c>PATH</c> (required to locate executables), <c>HOME</c> (required by many tools on Unix),
-    /// <c>DOTNET_ROOT</c>, <c>LD_LIBRARY_PATH</c>, <c>JAVA_HOME</c>, and proxy settings (<c>HTTP_PROXY</c>,
-    /// <c>HTTPS_PROXY</c>, <c>NO_PROXY</c>). When disabling inheritance, ensure that all variables required by the server
-    /// process are explicitly provided via <see cref="EnvironmentVariables"/>.
+    /// behave unexpectedly if it relies on variables provided by the operating system or the user's shell environment.
+    /// <see cref="GetDefaultEnvironmentVariables"/> covers the most common requirements — <c>PATH</c>, <c>HOME</c>, and
+    /// standard system directories — and is a safe starting point for most servers. For servers that also need variables
+    /// outside that set (such as <c>DOTNET_ROOT</c>, <c>LD_LIBRARY_PATH</c>, <c>JAVA_HOME</c>, or proxy settings like
+    /// <c>HTTP_PROXY</c>, <c>HTTPS_PROXY</c>, and <c>NO_PROXY</c>), add them explicitly via <see cref="EnvironmentVariables"/>
+    /// after calling <see cref="GetDefaultEnvironmentVariables"/>.
     /// </para>
     /// </remarks>
     public bool InheritEnvironmentVariables { get; set; } = true;

--- a/src/ModelContextProtocol.Core/Client/StdioClientTransportOptions.cs
+++ b/src/ModelContextProtocol.Core/Client/StdioClientTransportOptions.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace ModelContextProtocol.Client;
 
 /// <summary>
@@ -5,6 +7,87 @@ namespace ModelContextProtocol.Client;
 /// </summary>
 public sealed class StdioClientTransportOptions
 {
+    // Platform-appropriate allowlists, aligned with the TypeScript and Python MCP SDK defaults.
+    // TypeScript adds PROGRAMFILES; Python adds PATHEXT. Both are included here.
+    private static readonly string[] s_defaultWindowsVars =
+    [
+        "APPDATA", "HOMEDRIVE", "HOMEPATH", "LOCALAPPDATA", "PATH", "PATHEXT",
+        "PROCESSOR_ARCHITECTURE", "PROGRAMFILES", "SYSTEMDRIVE", "SYSTEMROOT",
+        "TEMP", "USERNAME", "USERPROFILE",
+    ];
+
+    private static readonly string[] s_defaultUnixVars =
+    [
+        "HOME", "LOGNAME", "PATH", "SHELL", "TERM", "USER",
+    ];
+
+    /// <summary>
+    /// Returns a curated set of environment variables from the current process that are safe to forward to a child
+    /// MCP server process.
+    /// </summary>
+    /// <returns>
+    /// A new <see cref="Dictionary{TKey, TValue}"/> populated with the subset of the current process's environment
+    /// variables that most child processes need to start correctly — for example <c>PATH</c>, <c>HOME</c>, and
+    /// standard system directories. Values that appear to be shell function definitions (those starting with
+    /// <c>()</c>) are excluded for security reasons.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The allowlist is aligned with the defaults used by the TypeScript and Python MCP SDKs. On Windows it
+    /// includes: <c>APPDATA</c>, <c>HOMEDRIVE</c>, <c>HOMEPATH</c>, <c>LOCALAPPDATA</c>, <c>PATH</c>,
+    /// <c>PATHEXT</c>, <c>PROCESSOR_ARCHITECTURE</c>, <c>PROGRAMFILES</c>, <c>SYSTEMDRIVE</c>,
+    /// <c>SYSTEMROOT</c>, <c>TEMP</c>, <c>USERNAME</c>, and <c>USERPROFILE</c>. On Unix/macOS it includes:
+    /// <c>HOME</c>, <c>LOGNAME</c>, <c>PATH</c>, <c>SHELL</c>, <c>TERM</c>, and <c>USER</c>.
+    /// </para>
+    /// <para>
+    /// This method is designed to be used together with <see cref="InheritEnvironmentVariables"/> set to
+    /// <see langword="false"/>. Pass the returned dictionary as <see cref="EnvironmentVariables"/>, optionally
+    /// adding any server-specific variables the server requires:
+    /// <code>
+    /// var env = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+    /// env["MY_SERVER_API_KEY"] = apiKey;
+    ///
+    /// var transport = new StdioClientTransport(new StdioClientTransportOptions
+    /// {
+    ///     Command = "my-mcp-server",
+    ///     InheritEnvironmentVariables = false,
+    ///     EnvironmentVariables = env,
+    /// });
+    /// </code>
+    /// </para>
+    /// <para>
+    /// If the server requires additional variables not in the default set (such as <c>DOTNET_ROOT</c>,
+    /// <c>JAVA_HOME</c>, or proxy settings), add them explicitly after calling this method.
+    /// </para>
+    /// </remarks>
+    public static Dictionary<string, string?> GetDefaultEnvironmentVariables()
+    {
+        var names = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? s_defaultWindowsVars
+            : s_defaultUnixVars;
+
+        var result = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var name in names)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            if (value is null)
+            {
+                continue;
+            }
+
+            if (value.StartsWith("()", StringComparison.Ordinal))
+            {
+                // Skip shell function definitions — they are a security risk.
+                continue;
+            }
+
+            result[name] = value;
+        }
+
+        return result;
+    }
+
+
     /// <summary>
     /// Gets or sets the command to execute to start the server process.
     /// </summary>

--- a/src/ModelContextProtocol.Core/Client/StdioClientTransportOptions.cs
+++ b/src/ModelContextProtocol.Core/Client/StdioClientTransportOptions.cs
@@ -39,6 +39,43 @@ public sealed class StdioClientTransportOptions
     public string? WorkingDirectory { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the server process should inherit the current process's environment variables.
+    /// </summary>
+    /// <value>
+    /// <see langword="true"/> to inherit the current process's environment variables (the default); <see langword="false"/>
+    /// to start the server process with an empty environment and only the variables explicitly provided via
+    /// <see cref="EnvironmentVariables"/>.
+    /// </value>
+    /// <remarks>
+    /// <para>
+    /// When <see langword="true"/> (the default), the server process starts with all of the current process's environment
+    /// variables. Any entries in <see cref="EnvironmentVariables"/> are then applied on top, adding or overwriting inherited
+    /// variables.
+    /// </para>
+    /// <para>
+    /// When <see langword="false"/>, the server process starts with a completely empty environment. The <see cref="EnvironmentVariables"/>
+    /// dictionary is the sole source of environment variables for the child process. This is useful when you want to minimize
+    /// the attack surface by preventing credentials, tokens, proxy settings, and other sensitive values present in the current
+    /// environment from unintentionally reaching the child process.
+    /// </para>
+    /// <para>
+    /// <strong>Security consideration:</strong> Inheriting environment variables (the default) can unintentionally expose
+    /// sensitive values to the child process. Variables such as <c>AWS_SECRET_ACCESS_KEY</c>, <c>GITHUB_TOKEN</c>,
+    /// <c>OPENAI_API_KEY</c>, and similar credentials that are present in the parent process will automatically flow into
+    /// the server process, which may be undesirable when running third-party or untrusted MCP servers.
+    /// </para>
+    /// <para>
+    /// <strong>Compatibility consideration:</strong> Disabling inheritance can cause the child process to fail to start or
+    /// behave unexpectedly if it relies on variables provided by the operating system or the user's shell environment. Common
+    /// examples include <c>PATH</c> (required to locate executables), <c>HOME</c> (required by many tools on Unix),
+    /// <c>DOTNET_ROOT</c>, <c>LD_LIBRARY_PATH</c>, <c>JAVA_HOME</c>, and proxy settings (<c>HTTP_PROXY</c>,
+    /// <c>HTTPS_PROXY</c>, <c>NO_PROXY</c>). When disabling inheritance, ensure that all variables required by the server
+    /// process are explicitly provided via <see cref="EnvironmentVariables"/>.
+    /// </para>
+    /// </remarks>
+    public bool InheritEnvironmentVariables { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets environment variables to set for the server process.
     /// </summary>
     /// <remarks>
@@ -48,10 +85,14 @@ public sealed class StdioClientTransportOptions
     /// to the server without modifying its code.
     /// </para>
     /// <para>
-    /// By default, when starting the server process, the server process will inherit the current environment's variables,
-    /// as discovered via <see cref="Environment.GetEnvironmentVariables()"/>. After those variables are found, the entries
-    /// in this <see cref="EnvironmentVariables"/> dictionary are used to augment and overwrite the entries read from the environment.
-    /// That includes removing the variables for any of this collection's entries with a null value.
+    /// When <see cref="InheritEnvironmentVariables"/> is <see langword="true"/> (the default), the server process starts with
+    /// all environment variables inherited from the current process. The entries in this <see cref="EnvironmentVariables"/>
+    /// dictionary are then applied on top: adding new variables, overwriting inherited ones, or removing variables whose
+    /// value is set to <see langword="null"/>.
+    /// </para>
+    /// <para>
+    /// When <see cref="InheritEnvironmentVariables"/> is <see langword="false"/>, the server process starts with an empty
+    /// environment. This dictionary is the sole source of environment variables for the child process.
     /// </para>
     /// </remarks>
     public IDictionary<string, string?>? EnvironmentVariables { get; set; }

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -153,19 +153,19 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
     public async Task InheritEnvironmentVariables_DefaultTrue_ChildSeesParentEnvVars()
     {
-        // PATH is always set in a real process environment. Verify the child sees it
-        // under the default (inherit) behavior without mutating the parent process.
+        // Check the same variable the False test checks for absence (HOME on Unix, USERNAME on Windows)
+        // so the two tests form a direct symmetric pair: one asserts it IS set, the other asserts it is NOT.
         var tcs = new TaskCompletionSource<string>();
         StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-            new(new() { Command = "cmd", Arguments = ["/c", "if defined PATH (echo PATH_IS_SET >&2) else (echo PATH_NOT_SET >&2) & exit /b 1"], StandardErrorLines = line => tcs.TrySetResult(line) }, LoggerFactory) :
-            new(new() { Command = "sh", Arguments = ["-c", "if [ -n \"$PATH\" ]; then echo PATH_IS_SET >&2; else echo PATH_NOT_SET >&2; fi; exit 1"], StandardErrorLines = line => tcs.TrySetResult(line) }, LoggerFactory);
+            new(new() { Command = "cmd", Arguments = ["/c", "if defined USERNAME (echo USERNAME_IS_SET >&2) else (echo USERNAME_NOT_SET >&2) & exit /b 1"], StandardErrorLines = line => tcs.TrySetResult(line) }, LoggerFactory) :
+            new(new() { Command = "sh", Arguments = ["-c", "if [ -n \"$HOME\" ]; then echo HOME_IS_SET >&2; else echo HOME_NOT_SET >&2; fi; exit 1"], StandardErrorLines = line => tcs.TrySetResult(line) }, LoggerFactory);
 
         await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
         string capturedLine = await tcs.Task.WaitAsync(cts.Token);
 
-        Assert.Equal("PATH_IS_SET", capturedLine.Trim());
+        Assert.Equal(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "USERNAME_IS_SET" : "HOME_IS_SET", capturedLine.Trim());
     }
 
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -153,22 +153,12 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
     public async Task InheritEnvironmentVariables_DefaultTrue_ChildSeesParentEnvVars()
     {
-        // PATH is always set in a real process environment. Use it as a reliable
-        // indicator that env vars were inherited without modifying the parent process.
+        // PATH is always set in a real process environment. Verify the child sees it
+        // under the default (inherit) behavior without mutating the parent process.
         var tcs = new TaskCompletionSource<string>();
         StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-            new(new()
-            {
-                Command = "cmd",
-                Arguments = ["/c", "if defined PATH (echo PATH_IS_SET >&2) else (echo PATH_NOT_SET >&2) & exit /b 1"],
-                StandardErrorLines = line => tcs.TrySetResult(line)
-            }, LoggerFactory) :
-            new(new()
-            {
-                Command = "sh",
-                Arguments = ["-c", "if [ -n \"$PATH\" ]; then echo PATH_IS_SET >&2; else echo PATH_NOT_SET >&2; fi; exit 1"],
-                StandardErrorLines = line => tcs.TrySetResult(line)
-            }, LoggerFactory);
+            new(new() { Command = "cmd", Arguments = ["/c", "if defined PATH (echo PATH_IS_SET >&2) else (echo PATH_NOT_SET >&2) & exit /b 1"], StandardErrorLines = line => tcs.TrySetResult(line) }, LoggerFactory) :
+            new(new() { Command = "sh", Arguments = ["-c", "if [ -n \"$PATH\" ]; then echo PATH_IS_SET >&2; else echo PATH_NOT_SET >&2; fi; exit 1"], StandardErrorLines = line => tcs.TrySetResult(line) }, LoggerFactory);
 
         await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
@@ -181,24 +171,24 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
     public async Task InheritEnvironmentVariables_False_ChildDoesNotSeeParentEnvVars()
     {
-        // Use absolute shell paths so the child can be launched even with an empty environment.
-        // Verify that PATH (always set in the parent) is absent in the child when inheritance is disabled.
+        // Pass PATH so cmd/sh can be located. Verify that HOME (Unix) / USERNAME (Windows),
+        // which are always set in the parent, are absent because they were not explicitly provided.
         var tcs = new TaskCompletionSource<string>();
         StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
             new(new()
             {
-                Command = Path.Combine(
-                    Environment.GetEnvironmentVariable("SystemRoot") ?? @"C:\Windows",
-                    "System32", "cmd.exe"),
-                Arguments = ["/c", "if defined PATH (echo PATH_IS_SET >&2) else (echo PATH_NOT_SET >&2) & exit /b 1"],
+                Command = "cmd",
+                Arguments = ["/c", "if defined USERNAME (echo USERNAME_IS_SET >&2) else (echo USERNAME_NOT_SET >&2) & exit /b 1"],
                 InheritEnvironmentVariables = false,
+                EnvironmentVariables = new Dictionary<string, string?> { ["PATH"] = Environment.GetEnvironmentVariable("PATH") },
                 StandardErrorLines = line => tcs.TrySetResult(line)
             }, LoggerFactory) :
             new(new()
             {
-                Command = "/bin/sh",
-                Arguments = ["-c", "if [ -n \"$PATH\" ]; then echo PATH_IS_SET >&2; else echo PATH_NOT_SET >&2; fi; exit 1"],
+                Command = "sh",
+                Arguments = ["-c", "if [ -n \"$HOME\" ]; then echo HOME_IS_SET >&2; else echo HOME_NOT_SET >&2; fi; exit 1"],
                 InheritEnvironmentVariables = false,
+                EnvironmentVariables = new Dictionary<string, string?> { ["PATH"] = Environment.GetEnvironmentVariable("PATH") },
                 StandardErrorLines = line => tcs.TrySetResult(line)
             }, LoggerFactory);
 
@@ -207,15 +197,15 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
         using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
         string capturedLine = await tcs.Task.WaitAsync(cts.Token);
 
-        Assert.Equal("PATH_NOT_SET", capturedLine.Trim());
+        // HOME / USERNAME were in the parent but not passed — should be absent in the child.
+        Assert.Equal(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "USERNAME_NOT_SET" : "HOME_NOT_SET", capturedLine.Trim());
     }
 
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
     public async Task InheritEnvironmentVariables_False_WithExplicitVars_ChildSeesOnlyExplicitVars()
     {
-        // Use absolute shell paths so the child can be launched even with an empty environment.
-        // Verify that: (1) PATH (always in parent) is absent because it was not explicitly provided,
-        //              (2) an explicitly provided variable IS visible in the child.
+        // Pass PATH + one explicit var. Verify HOME (Unix) / USERNAME (Windows) is absent,
+        // and the explicitly provided variable is visible.
         const string explicitVarName = "MCP_STDIO_TEST_EXPLICIT_VAR";
         const string explicitVarValue = "explicit_test_value";
 
@@ -228,34 +218,30 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
             {
                 capturedLines.Add(line.Trim());
                 if (Interlocked.Increment(ref lineCount) >= 2)
-                {
                     tcs.TrySetResult(true);
-                }
             }
         }
 
         StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
             new(new()
             {
-                Command = Path.Combine(
-                    Environment.GetEnvironmentVariable("SystemRoot") ?? @"C:\Windows",
-                    "System32", "cmd.exe"),
+                Command = "cmd",
                 Arguments = ["/c",
-                    $"if defined PATH (echo PATH_IS_SET >&2) else (echo PATH_NOT_SET >&2) " +
+                    $"if defined USERNAME (echo USERNAME_IS_SET >&2) else (echo USERNAME_NOT_SET >&2) " +
                     $"& if defined {explicitVarName} (echo EXPLICIT_IS_SET >&2) else (echo EXPLICIT_NOT_SET >&2) " +
                     $"& exit /b 1"],
                 InheritEnvironmentVariables = false,
-                EnvironmentVariables = new Dictionary<string, string?> { [explicitVarName] = explicitVarValue },
+                EnvironmentVariables = new Dictionary<string, string?> { ["PATH"] = Environment.GetEnvironmentVariable("PATH"), [explicitVarName] = explicitVarValue },
                 StandardErrorLines = CaptureLines
             }, LoggerFactory) :
             new(new()
             {
-                Command = "/bin/sh",
+                Command = "sh",
                 Arguments = ["-c",
-                    $"if [ -n \"$PATH\" ]; then echo PATH_IS_SET >&2; else echo PATH_NOT_SET >&2; fi; " +
+                    $"if [ -n \"$HOME\" ]; then echo HOME_IS_SET >&2; else echo HOME_NOT_SET >&2; fi; " +
                     $"if [ -n \"${explicitVarName}\" ]; then echo EXPLICIT_IS_SET >&2; else echo EXPLICIT_NOT_SET >&2; fi; exit 1"],
                 InheritEnvironmentVariables = false,
-                EnvironmentVariables = new Dictionary<string, string?> { [explicitVarName] = explicitVarValue },
+                EnvironmentVariables = new Dictionary<string, string?> { ["PATH"] = Environment.GetEnvironmentVariable("PATH"), [explicitVarName] = explicitVarValue },
                 StandardErrorLines = CaptureLines
             }, LoggerFactory);
 
@@ -265,7 +251,7 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
         await tcs.Task.WaitAsync(cts.Token);
 
         string allOutput = string.Join(Environment.NewLine, capturedLines);
-        Assert.Contains("PATH_NOT_SET", allOutput);
+        Assert.Contains(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "USERNAME_NOT_SET" : "HOME_NOT_SET", allOutput);
         Assert.Contains("EXPLICIT_IS_SET", allOutput);
     }
 

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -153,146 +153,120 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
     public async Task InheritEnvironmentVariables_DefaultTrue_ChildSeesParentEnvVars()
     {
-        string varName = $"MCP_TEST_{Guid.NewGuid():N}";
-        string varValue = Guid.NewGuid().ToString("N");
-        Environment.SetEnvironmentVariable(varName, varValue);
-        try
-        {
-            var tcs = new TaskCompletionSource<string>();
-            StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                new(new()
-                {
-                    Command = "cmd",
-                    Arguments = ["/c", $"echo %{varName}% >&2 & exit /b 1"],
-                    StandardErrorLines = line => tcs.TrySetResult(line)
-                }, LoggerFactory) :
-                new(new()
-                {
-                    Command = "sh",
-                    Arguments = ["-c", $"echo \"${{{varName}}}\" >&2; exit 1"],
-                    StandardErrorLines = line => tcs.TrySetResult(line)
-                }, LoggerFactory);
+        // PATH is always set in a real process environment. Use it as a reliable
+        // indicator that env vars were inherited without modifying the parent process.
+        var tcs = new TaskCompletionSource<string>();
+        StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            new(new()
+            {
+                Command = "cmd",
+                Arguments = ["/c", "if defined PATH (echo PATH_IS_SET >&2) else (echo PATH_NOT_SET >&2) & exit /b 1"],
+                StandardErrorLines = line => tcs.TrySetResult(line)
+            }, LoggerFactory) :
+            new(new()
+            {
+                Command = "sh",
+                Arguments = ["-c", "if [ -n \"$PATH\" ]; then echo PATH_IS_SET >&2; else echo PATH_NOT_SET >&2; fi; exit 1"],
+                StandardErrorLines = line => tcs.TrySetResult(line)
+            }, LoggerFactory);
 
-            await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
-            using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
-            string capturedLine = await tcs.Task.WaitAsync(cts.Token);
+        using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
+        string capturedLine = await tcs.Task.WaitAsync(cts.Token);
 
-            Assert.Contains(varValue, capturedLine);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(varName, null);
-        }
+        Assert.Equal("PATH_IS_SET", capturedLine.Trim());
     }
 
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
     public async Task InheritEnvironmentVariables_False_ChildDoesNotSeeParentEnvVars()
     {
-        string varName = $"MCP_TEST_{Guid.NewGuid():N}";
-        Environment.SetEnvironmentVariable(varName, "SHOULD_NOT_APPEAR");
-        try
-        {
-            var tcs = new TaskCompletionSource<string>();
-            StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                new(new()
-                {
-                    Command = "cmd",
-                    Arguments = ["/c", $"if defined {varName} (echo FOUND >&2) else (echo NOT_FOUND >&2) & exit /b 1"],
-                    InheritEnvironmentVariables = false,
-                    EnvironmentVariables = new Dictionary<string, string?> { ["PATH"] = Environment.GetEnvironmentVariable("PATH") },
-                    StandardErrorLines = line => tcs.TrySetResult(line)
-                }, LoggerFactory) :
-                new(new()
-                {
-                    Command = "sh",
-                    Arguments = ["-c", $"if [ -n \"${{{varName}}}\" ]; then echo FOUND >&2; else echo NOT_FOUND >&2; fi; exit 1"],
-                    InheritEnvironmentVariables = false,
-                    EnvironmentVariables = new Dictionary<string, string?> { ["PATH"] = Environment.GetEnvironmentVariable("PATH") },
-                    StandardErrorLines = line => tcs.TrySetResult(line)
-                }, LoggerFactory);
+        // Use absolute shell paths so the child can be launched even with an empty environment.
+        // Verify that PATH (always set in the parent) is absent in the child when inheritance is disabled.
+        var tcs = new TaskCompletionSource<string>();
+        StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            new(new()
+            {
+                Command = Path.Combine(
+                    Environment.GetEnvironmentVariable("SystemRoot") ?? @"C:\Windows",
+                    "System32", "cmd.exe"),
+                Arguments = ["/c", "if defined PATH (echo PATH_IS_SET >&2) else (echo PATH_NOT_SET >&2) & exit /b 1"],
+                InheritEnvironmentVariables = false,
+                StandardErrorLines = line => tcs.TrySetResult(line)
+            }, LoggerFactory) :
+            new(new()
+            {
+                Command = "/bin/sh",
+                Arguments = ["-c", "if [ -n \"$PATH\" ]; then echo PATH_IS_SET >&2; else echo PATH_NOT_SET >&2; fi; exit 1"],
+                InheritEnvironmentVariables = false,
+                StandardErrorLines = line => tcs.TrySetResult(line)
+            }, LoggerFactory);
 
-            await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
-            using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
-            string capturedLine = await tcs.Task.WaitAsync(cts.Token);
+        using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
+        string capturedLine = await tcs.Task.WaitAsync(cts.Token);
 
-            Assert.Equal("NOT_FOUND", capturedLine.Trim());
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(varName, null);
-        }
+        Assert.Equal("PATH_NOT_SET", capturedLine.Trim());
     }
 
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
     public async Task InheritEnvironmentVariables_False_WithExplicitVars_ChildSeesOnlyExplicitVars()
     {
-        string inheritedVarName = $"MCP_TEST_INHERITED_{Guid.NewGuid():N}";
-        string explicitVarName = $"MCP_TEST_EXPLICIT_{Guid.NewGuid():N}";
-        string explicitVarValue = Guid.NewGuid().ToString("N");
-        Environment.SetEnvironmentVariable(inheritedVarName, "SHOULD_NOT_APPEAR");
-        try
+        // Use absolute shell paths so the child can be launched even with an empty environment.
+        // Verify that: (1) PATH (always in parent) is absent because it was not explicitly provided,
+        //              (2) an explicitly provided variable IS visible in the child.
+        const string explicitVarName = "MCP_STDIO_TEST_EXPLICIT_VAR";
+        const string explicitVarValue = "explicit_test_value";
+
+        var capturedLines = new List<string>();
+        var lineCount = 0;
+        var tcs = new TaskCompletionSource<bool>();
+        void CaptureLines(string line)
         {
-            var capturedLines = new List<string>();
-            var lineCount = 0;
-            var tcs = new TaskCompletionSource<bool>();
-            void CaptureLines(string line)
+            lock (capturedLines)
             {
-                lock (capturedLines)
+                capturedLines.Add(line.Trim());
+                if (Interlocked.Increment(ref lineCount) >= 2)
                 {
-                    capturedLines.Add(line.Trim());
-                    if (Interlocked.Increment(ref lineCount) >= 2)
-                    {
-                        tcs.TrySetResult(true);
-                    }
+                    tcs.TrySetResult(true);
                 }
             }
-
-            StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                new(new()
-                {
-                    Command = "cmd",
-                    Arguments = ["/c",
-                        $"if defined {inheritedVarName} (echo INHERITED_FOUND >&2) else (echo INHERITED_NOT_FOUND >&2) " +
-                        $"& if defined {explicitVarName} (echo EXPLICIT_FOUND >&2) else (echo EXPLICIT_NOT_FOUND >&2) " +
-                        $"& exit /b 1"],
-                    InheritEnvironmentVariables = false,
-                    EnvironmentVariables = new Dictionary<string, string?>
-                    {
-                        ["PATH"] = Environment.GetEnvironmentVariable("PATH"),
-                        [explicitVarName] = explicitVarValue
-                    },
-                    StandardErrorLines = CaptureLines
-                }, LoggerFactory) :
-                new(new()
-                {
-                    Command = "sh",
-                    Arguments = ["-c",
-                        $"if [ -n \"${{{inheritedVarName}}}\" ]; then echo INHERITED_FOUND >&2; else echo INHERITED_NOT_FOUND >&2; fi; " +
-                        $"if [ -n \"${{{explicitVarName}}}\" ]; then echo EXPLICIT_FOUND >&2; else echo EXPLICIT_NOT_FOUND >&2; fi; exit 1"],
-                    InheritEnvironmentVariables = false,
-                    EnvironmentVariables = new Dictionary<string, string?>
-                    {
-                        ["PATH"] = Environment.GetEnvironmentVariable("PATH"),
-                        [explicitVarName] = explicitVarValue
-                    },
-                    StandardErrorLines = CaptureLines
-                }, LoggerFactory);
-
-            await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
-
-            using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
-            await tcs.Task.WaitAsync(cts.Token);
-
-            string allOutput = string.Join(Environment.NewLine, capturedLines);
-            Assert.Contains("INHERITED_NOT_FOUND", allOutput);
-            Assert.Contains("EXPLICIT_FOUND", allOutput);
         }
-        finally
-        {
-            Environment.SetEnvironmentVariable(inheritedVarName, null);
-        }
+
+        StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            new(new()
+            {
+                Command = Path.Combine(
+                    Environment.GetEnvironmentVariable("SystemRoot") ?? @"C:\Windows",
+                    "System32", "cmd.exe"),
+                Arguments = ["/c",
+                    $"if defined PATH (echo PATH_IS_SET >&2) else (echo PATH_NOT_SET >&2) " +
+                    $"& if defined {explicitVarName} (echo EXPLICIT_IS_SET >&2) else (echo EXPLICIT_NOT_SET >&2) " +
+                    $"& exit /b 1"],
+                InheritEnvironmentVariables = false,
+                EnvironmentVariables = new Dictionary<string, string?> { [explicitVarName] = explicitVarValue },
+                StandardErrorLines = CaptureLines
+            }, LoggerFactory) :
+            new(new()
+            {
+                Command = "/bin/sh",
+                Arguments = ["-c",
+                    $"if [ -n \"$PATH\" ]; then echo PATH_IS_SET >&2; else echo PATH_NOT_SET >&2; fi; " +
+                    $"if [ -n \"${explicitVarName}\" ]; then echo EXPLICIT_IS_SET >&2; else echo EXPLICIT_NOT_SET >&2; fi; exit 1"],
+                InheritEnvironmentVariables = false,
+                EnvironmentVariables = new Dictionary<string, string?> { [explicitVarName] = explicitVarValue },
+                StandardErrorLines = CaptureLines
+            }, LoggerFactory);
+
+        await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
+
+        using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
+        await tcs.Task.WaitAsync(cts.Token);
+
+        string allOutput = string.Join(Environment.NewLine, capturedLines);
+        Assert.Contains("PATH_NOT_SET", allOutput);
+        Assert.Contains("EXPLICIT_IS_SET", allOutput);
     }
 
     [Fact]

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -150,6 +150,151 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
         Assert.Equal(cliArgumentValue ?? "", content.Text);
     }
 
+    [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
+    public async Task InheritEnvironmentVariables_DefaultTrue_ChildSeesParentEnvVars()
+    {
+        string varName = $"MCP_TEST_{Guid.NewGuid():N}";
+        string varValue = Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(varName, varValue);
+        try
+        {
+            var tcs = new TaskCompletionSource<string>();
+            StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                new(new()
+                {
+                    Command = "cmd",
+                    Arguments = ["/c", $"echo %{varName}% >&2 & exit /b 1"],
+                    StandardErrorLines = line => tcs.TrySetResult(line)
+                }, LoggerFactory) :
+                new(new()
+                {
+                    Command = "sh",
+                    Arguments = ["-c", $"echo \"${{{varName}}}\" >&2; exit 1"],
+                    StandardErrorLines = line => tcs.TrySetResult(line)
+                }, LoggerFactory);
+
+            await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
+
+            using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
+            string capturedLine = await tcs.Task.WaitAsync(cts.Token);
+
+            Assert.Contains(varValue, capturedLine);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(varName, null);
+        }
+    }
+
+    [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
+    public async Task InheritEnvironmentVariables_False_ChildDoesNotSeeParentEnvVars()
+    {
+        string varName = $"MCP_TEST_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(varName, "SHOULD_NOT_APPEAR");
+        try
+        {
+            var tcs = new TaskCompletionSource<string>();
+            StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                new(new()
+                {
+                    Command = "cmd",
+                    Arguments = ["/c", $"if defined {varName} (echo FOUND >&2) else (echo NOT_FOUND >&2) & exit /b 1"],
+                    InheritEnvironmentVariables = false,
+                    EnvironmentVariables = new Dictionary<string, string?> { ["PATH"] = Environment.GetEnvironmentVariable("PATH") },
+                    StandardErrorLines = line => tcs.TrySetResult(line)
+                }, LoggerFactory) :
+                new(new()
+                {
+                    Command = "sh",
+                    Arguments = ["-c", $"if [ -n \"${{{varName}}}\" ]; then echo FOUND >&2; else echo NOT_FOUND >&2; fi; exit 1"],
+                    InheritEnvironmentVariables = false,
+                    EnvironmentVariables = new Dictionary<string, string?> { ["PATH"] = Environment.GetEnvironmentVariable("PATH") },
+                    StandardErrorLines = line => tcs.TrySetResult(line)
+                }, LoggerFactory);
+
+            await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
+
+            using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
+            string capturedLine = await tcs.Task.WaitAsync(cts.Token);
+
+            Assert.Equal("NOT_FOUND", capturedLine.Trim());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(varName, null);
+        }
+    }
+
+    [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
+    public async Task InheritEnvironmentVariables_False_WithExplicitVars_ChildSeesOnlyExplicitVars()
+    {
+        string inheritedVarName = $"MCP_TEST_INHERITED_{Guid.NewGuid():N}";
+        string explicitVarName = $"MCP_TEST_EXPLICIT_{Guid.NewGuid():N}";
+        string explicitVarValue = Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(inheritedVarName, "SHOULD_NOT_APPEAR");
+        try
+        {
+            var capturedLines = new List<string>();
+            var lineCount = 0;
+            var tcs = new TaskCompletionSource<bool>();
+            void CaptureLines(string line)
+            {
+                lock (capturedLines)
+                {
+                    capturedLines.Add(line.Trim());
+                    if (Interlocked.Increment(ref lineCount) >= 2)
+                    {
+                        tcs.TrySetResult(true);
+                    }
+                }
+            }
+
+            StdioClientTransport transport = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                new(new()
+                {
+                    Command = "cmd",
+                    Arguments = ["/c",
+                        $"if defined {inheritedVarName} (echo INHERITED_FOUND >&2) else (echo INHERITED_NOT_FOUND >&2) " +
+                        $"& if defined {explicitVarName} (echo EXPLICIT_FOUND >&2) else (echo EXPLICIT_NOT_FOUND >&2) " +
+                        $"& exit /b 1"],
+                    InheritEnvironmentVariables = false,
+                    EnvironmentVariables = new Dictionary<string, string?>
+                    {
+                        ["PATH"] = Environment.GetEnvironmentVariable("PATH"),
+                        [explicitVarName] = explicitVarValue
+                    },
+                    StandardErrorLines = CaptureLines
+                }, LoggerFactory) :
+                new(new()
+                {
+                    Command = "sh",
+                    Arguments = ["-c",
+                        $"if [ -n \"${{{inheritedVarName}}}\" ]; then echo INHERITED_FOUND >&2; else echo INHERITED_NOT_FOUND >&2; fi; " +
+                        $"if [ -n \"${{{explicitVarName}}}\" ]; then echo EXPLICIT_FOUND >&2; else echo EXPLICIT_NOT_FOUND >&2; fi; exit 1"],
+                    InheritEnvironmentVariables = false,
+                    EnvironmentVariables = new Dictionary<string, string?>
+                    {
+                        ["PATH"] = Environment.GetEnvironmentVariable("PATH"),
+                        [explicitVarName] = explicitVarValue
+                    },
+                    StandardErrorLines = CaptureLines
+                }, LoggerFactory);
+
+            await Assert.ThrowsAnyAsync<IOException>(() => McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
+
+            using var cts = new CancellationTokenSource(TestConstants.DefaultTimeout);
+            await tcs.Task.WaitAsync(cts.Token);
+
+            string allOutput = string.Join(Environment.NewLine, capturedLines);
+            Assert.Contains("INHERITED_NOT_FOUND", allOutput);
+            Assert.Contains("EXPLICIT_FOUND", allOutput);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(inheritedVarName, null);
+        }
+    }
+
     [Fact]
     public async Task SendMessageAsync_Should_Use_LF_Not_CRLF()
     {

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -304,10 +304,10 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
     {
         // Verify the postcondition: no returned values start with "()" (shell function markers).
         var result = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
-        foreach (var (key, value) in result)
+        foreach (var kvp in result)
         {
-            Assert.False(value?.StartsWith("()") ?? false,
-                $"Value for '{key}' starts with '()' and should have been filtered as a shell function.");
+            Assert.False(kvp.Value?.StartsWith("()") ?? false,
+                $"Value for '{kvp.Key}' starts with '()' and should have been filtered as a shell function.");
         }
     }
 

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -256,6 +256,83 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
     }
 
     [Fact]
+    public void GetDefaultEnvironmentVariables_ReturnsFreshDictionaryEachCall()
+    {
+        var first = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+        var second = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void GetDefaultEnvironmentVariables_ReturnsCorrectComparer()
+    {
+        var result = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Equal(StringComparer.OrdinalIgnoreCase, result.Comparer);
+        }
+        else
+        {
+            Assert.Equal(StringComparer.Ordinal, result.Comparer);
+        }
+    }
+
+    [Fact]
+    public void GetDefaultEnvironmentVariables_ContainsOnlyAllowlistedKeys()
+    {
+        HashSet<string> allowedKeys = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? new(StringComparer.OrdinalIgnoreCase)
+            {
+                "APPDATA", "HOMEDRIVE", "HOMEPATH", "LOCALAPPDATA", "PATH", "PATHEXT",
+                "PROCESSOR_ARCHITECTURE", "PROGRAMFILES", "SYSTEMDRIVE", "SYSTEMROOT",
+                "TEMP", "USERNAME", "USERPROFILE",
+            }
+            : new(StringComparer.Ordinal)
+            {
+                "HOME", "LOGNAME", "PATH", "SHELL", "TERM", "USER",
+            };
+
+        var result = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+        foreach (var key in result.Keys)
+        {
+            Assert.Contains(key, allowedKeys);
+        }
+    }
+
+    [Fact]
+    public void GetDefaultEnvironmentVariables_ExcludesShellFunctionValues()
+    {
+        // Verify the postcondition: no returned values start with "()" (shell function markers).
+        var result = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+        foreach (var (key, value) in result)
+        {
+            Assert.False(value?.StartsWith("()") ?? false,
+                $"Value for '{key}' starts with '()' and should have been filtered as a shell function.");
+        }
+    }
+
+    [Fact]
+    public void GetDefaultEnvironmentVariables_PathIsPresent_WhenSetInEnvironment()
+    {
+        // PATH is always set in a real process environment; verify it is included.
+        var result = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+        if (Environment.GetEnvironmentVariable("PATH") is not null)
+        {
+            Assert.True(result.ContainsKey("PATH"), "PATH should be present when it exists in the parent environment.");
+        }
+    }
+
+    [Fact]
+    public void GetDefaultEnvironmentVariables_DoesNotIncludeNonAllowlistedKeys()
+    {
+        // Keys that are definitely not on the allowlist must never appear.
+        var result = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+        Assert.False(result.ContainsKey("AWS_SECRET_ACCESS_KEY"));
+        Assert.False(result.ContainsKey("GITHUB_TOKEN"));
+        Assert.False(result.ContainsKey("OPENAI_API_KEY"));
+    }
+
+    [Fact]
     public async Task SendMessageAsync_Should_Use_LF_Not_CRLF()
     {
         using var serverInput = new MemoryStream();


### PR DESCRIPTION
## Summary

Introduces a new `bool InheritEnvironmentVariables { get; set; } = true` property on `StdioClientTransportOptions` that controls whether the child server process inherits the current process's environment variables.

## Motivation

Previously, `EnvironmentVariables` only augmented/overwrote inherited vars — there was no way to start the server with a clean environment. Retconning the dictionary to mean "only these vars" would be breaking.

## Behavior

| `InheritEnvironmentVariables` | `EnvironmentVariables` | Result |
|---|---|---|
| `true` (default) | `null` | Child inherits all parent env vars (unchanged) |
| `true` (default) | `{ "X": "y" }` | Child inherits all + `X=y` on top |
| `false` | `null` | Child starts with empty environment |
| `false` | `{ "PATH": "...", "API_KEY": "..." }` | Child only sees the explicitly provided vars |

When `false`, `startInfo.Environment.Clear()` is called before any `EnvironmentVariables` entries are applied.

## Security / Compatibility note

The docs and XML comments explain both sides:
- **Security risk (inheriting):** Credentials like `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `OPENAI_API_KEY` automatically flow into the child process.
- **Compatibility risk (disabling):** `PATH`, `HOME`, `DOTNET_ROOT`, `LD_LIBRARY_PATH`, `JAVA_HOME`, proxy vars etc. are required by many tools — forgetting them causes the process to fail to start.

## Changes

- `StdioClientTransportOptions.cs` — new `InheritEnvironmentVariables` property with comprehensive XML docs
- `StdioClientTransport.cs` — calls `startInfo.Environment.Clear()` when `!InheritEnvironmentVariables`
- `StdioClientTransportTests.cs` — 3 new tests verifying inherit, block, and explicit-only scenarios
- `transports.md` — new property in the options table + "Environment variable inheritance" section with code sample and `[!WARNING]` callout