### PR TITLE
Release v1.3.0

### DIFF
--- a/docs/concepts/stateless/stateless.md
+++ b/docs/concepts/stateless/stateless.md
@@ -279,7 +279,7 @@ This is entirely automatic — you don't need to manage the session ID yourself.
 
 The server can terminate a session at any time — due to idle timeout, max session count exceeded, explicit shutdown, or any server-side policy. When this happens, subsequent requests with that session ID receive HTTP `404`. The client detects this and:
 
-1. Wraps the failure in a `TransportClosedException` with <xref:ModelContextProtocol.Client.HttpClientCompletionDetails> containing the HTTP status code
+1. Wraps the failure in a <xref:ModelContextProtocol.Client.ClientTransportClosedException> with <xref:ModelContextProtocol.Client.HttpClientCompletionDetails> containing the HTTP status code
 2. Cancels all in-flight operations
 3. Completes the <xref:ModelContextProtocol.Client.McpClient.Completion> task
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <PackageProjectUrl>https://csharp.sdk.modelcontextprotocol.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/modelcontextprotocol/csharp-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>ModelContextProtocol</Authors>
     <Copyright>© Model Context Protocol a Series of LF Projects, LLC.</Copyright>
     <PackageTags>ModelContextProtocol;mcp;ai;llm</PackageTags>


### PR DESCRIPTION
# Release v1.3.0

**v1.3.0** focuses on improved transport diagnostics and security-focused documentation. The new public `ClientTransportClosedException` gives stdio and HTTP clients structured access to transport closure details (exit codes, process IDs, stderr tails, HTTP status codes) without parsing exception messages. Two reliability fixes harden the stdio process pipeline (preventing host crashes from user `StandardErrorLines` callbacks) and correct the stateless HTTP transport's capability advertisement. New conceptual documentation covers role/identity propagation in tool execution, allowed-hosts and CORS guidance for HTTP servers, and aligns the docs information architecture with the MCP specification structure.

## Release Notes

### What's Changed

* Make `ClientTransportClosedException` public and unify transport exception handling #1467 by @stephentoub (co-authored by @halter73 @Copilot)
  * As part of this unification, SSE/HTTP client connection failures from `McpClient.CreateAsync(...)` now surface as `IOException` (the new `ClientTransportClosedException` derives from `IOException`) rather than `InvalidOperationException`. Caller-triggered `OperationCanceledException` is also no longer wrapped, matching standard async cancellation semantics.
* Fix process crash when testing Stderr #1449 by @ericstj (co-authored by @Copilot)
* Fix stateless HTTP transport advertising listChanged capability #1509 by @jayaraman-venkatesan

### Documentation Updates

* docs: align docs IA with MCP specification structure #1481 by @jeffhandley (co-authored by @mikekistler @Copilot)
* Document recommended pattern for role/identity propagation in MCP tool execution #1497 by @jeffhandley (co-authored by @halter73 @mikekistler @Copilot)
* Document and demonstrate allowed hosts and CORS policy guidance #1554 by @jeffhandley (co-authored by @halter73 @mikekistler @Copilot)

### Test Improvements

* Fix flaky OutgoingFilter_MultipleFilters_ExecuteInOrder test #1488 by @ericstj (co-authored by @Copilot)

### Repository Infrastructure Updates

* Bump the opentelemetry-testing group with 5 updates #1478
* Bump actions/deploy-pages from 4.0.5 to 5.0.0 #1477
* Bump actions/download-artifact from 8.0.0 to 8.0.1 #1437
* Bump actions/setup-dotnet from 5.1.0 to 5.2.0 #1418
* Bump actions/setup-node from 6.2.0 to 6.3.0 #1419
* Bump the testing-frameworks group with 1 update #1459
* Bump the npm_and_yarn group across 1 directory with 2 updates #1410
* Switch to custom CodeQL workflow #1489 by @jeffhandley
* Block Release Publishing workflow from automatically running on forks #1450 by @jeffhandley (co-authored by @Copilot)
* Bump actions/checkout from 4 to 6 #1504
* Add testing guidelines, update copilot instructions for tests #1507 by @ericstj
* Bump OpenTelemetry and 3 others #1514
* Bump the opentelemetry-testing group with 6 updates #1533
* Bump actions/setup-node from 6.3.0 to 6.4.0 #1522
* Bump actions/upload-pages-artifact from 4.0.0 to 5.0.0 #1511
* Bump the npm_and_yarn group across 1 directory with 5 updates #1500
* Bump Anthropic from 12.9.0 to 12.11.0 #1506
* Bump actions/upload-artifact from 7.0.0 to 7.0.1 #1512
* Bump danielpalme/ReportGenerator-GitHub-Action from 5.5.4 to 5.5.5 #1521
* Bump the testing-frameworks group with 2 updates #1523
* Bump the other-testing group with 2 updates #1534
* Bump Microsoft.Extensions.AI from 10.4.1 to 10.5.0 #1525
* Remove extraneous labels from dependabot.yml #1535 by @mikekistler
* Bump Anthropic from 12.11.0 to 12.17.0 #1544
* Fix dev container configuration to work in codespaces #1555 by @mikekistler
* Bump Microsoft.NET.Test.Sdk from 18.4.0 to 18.5.1 #1543
* Bump the npm_and_yarn group across 1 directory with 3 updates #1565
* Bump Microsoft.Extensions.AI.Abstractions from 10.5.0 to 10.5.2 #1561

### Acknowledgements

* @jayaraman-venkatesan made their first contribution in #1509
* @hulumane submitted issue #1455 (resolved by #1467)
* @mikekistler submitted issue #1486 (resolved by #1509)
* @JLLeitschuh submitted issue #1520 (resolved by #1554)
* @mikekistler @stephentoub @jeffhandley @ericstj @halter73 @eiriktsarpalis reviewed pull requests

**Full Changelog**: https://github.com/modelcontextprotocol/csharp-sdk/compare/v1.2.0...release-1.3.0

---

## API Compatibility Report

✅ All 3 packages pass API compatibility validation against baseline `v1.0.0` (no `CP*` or `PKV*` warnings/errors during `dotnet pack`).

`PackageValidationBaselineVersion` remains at `1.0.0` (unchanged for MINOR release).

## API Diff Report

Generated with `Microsoft.DotNet.ApiDiff.Tool` 10.0.300-preview.26154.111 against `net10.0`. The other target frameworks (`net9.0`, `net8.0`, `netstandard2.0`) had no public surface changes.

### ModelContextProtocol.Core

```diff
  namespace ModelContextProtocol.Client
  {
+     public sealed class ClientTransportClosedException
+     {
+         public ClientTransportClosedException(ModelContextProtocol.Client.ClientCompletionDetails details);
+         public ModelContextProtocol.Client.ClientCompletionDetails Details { get; }
+     }
  }
```

### ModelContextProtocol

_No public API changes._

### ModelContextProtocol.AspNetCore

_No public API changes._
