### PR TITLE
Add ScopeSelectorDelegate to enhance OAuth options for scope filtering

### DIFF
--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthOptions.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthOptions.cs
@@ -35,18 +35,39 @@ public sealed class ClientOAuthOptions
     public Uri? ClientMetadataDocumentUri { get; set; }
 
     /// <summary>
-    /// Gets or sets the OAuth scopes to request.
+    /// Gets or sets the OAuth scopes to request as a fallback.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// When specified, these scopes will be used instead of the scopes advertised by the protected resource.
-    /// If not specified, the provider will use the scopes from the protected resource metadata.
+    /// These scopes are used only when the server does not provide scope information via the
+    /// WWW-Authenticate header or Protected Resource Metadata (<c>scopes_supported</c>). This
+    /// matches the MCP scope selection strategy: WWW-Authenticate scope → PRM scopes_supported →
+    /// client-configured scopes → omit scope parameter.
     /// </para>
     /// <para>
-    /// Common OAuth scopes include "openid", "profile", and "email".
+    /// To filter or customize scopes when the server <em>does</em> provide scope information,
+    /// use <see cref="ScopeSelector"/> instead.
     /// </para>
     /// </remarks>
     public IEnumerable<string>? Scopes { get; set; }
+
+    /// <summary>
+    /// Gets or sets a delegate that selects or filters the OAuth scopes to request.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When set, this delegate is called after the MCP scope selection strategy has determined the
+    /// candidate scopes (WWW-Authenticate → PRM <c>scopes_supported</c> → <see cref="Scopes"/> fallback)
+    /// and after <c>offline_access</c> has been automatically appended when advertised by the
+    /// authorization server. The return value replaces the candidate scopes in the authorization request.
+    /// </para>
+    /// <para>
+    /// Use this to request only a subset of the scopes offered by the server, or to append a custom
+    /// scope that is not advertised in the server metadata. Return <see langword="null"/> or an empty
+    /// enumerable to omit the <c>scope</c> parameter entirely.
+    /// </para>
+    /// </remarks>
+    public ScopeSelectorDelegate? ScopeSelector { get; set; }
 
     /// <summary>
     /// Gets or sets the authorization redirect delegate for handling the OAuth authorization flow.

--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
@@ -28,6 +28,7 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
     private readonly Uri _serverUrl;
     private readonly Uri _redirectUri;
     private readonly string? _configuredScopes;
+    private readonly ScopeSelectorDelegate? _scopeSelector;
     private readonly IDictionary<string, string> _additionalAuthorizationParameters;
     private readonly Func<IReadOnlyList<Uri>, Uri?> _authServerSelector;
     private readonly AuthorizationRedirectDelegate _authorizationRedirectDelegate;
@@ -76,6 +77,7 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
         _clientSecret = options.ClientSecret;
         _redirectUri = options.RedirectUri ?? throw new ArgumentException("ClientOAuthOptions.RedirectUri must configured.", nameof(options));
         _configuredScopes = options.Scopes is null ? null : string.Join(" ", options.Scopes);
+        _scopeSelector = options.ScopeSelector;
         _additionalAuthorizationParameters = options.AdditionalAuthorizationParameters;
         _clientMetadataDocumentUri = options.ClientMetadataDocumentUri;
 
@@ -493,6 +495,11 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
 
         var scope = GetScopeParameter(protectedResourceMetadata);
         scope = AugmentScopeWithOfflineAccess(scope, authServerMetadata);
+        if (_scopeSelector is not null)
+        {
+            var selectedScope = _scopeSelector(scope?.Split(" "));
+            scope = selectedScope is not null ? string.Join(" ", selectedScope) : null;
+        }
         if (!string.IsNullOrEmpty(scope))
         {
             queryParamsDictionary["scope"] = scope!;

--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
@@ -493,13 +493,7 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
             queryParamsDictionary["resource"] = resourceUri;
         }
 
-        var scope = GetScopeParameter(protectedResourceMetadata);
-        scope = AugmentScopeWithOfflineAccess(scope, authServerMetadata);
-        if (_scopeSelector is not null)
-        {
-            var selectedScope = _scopeSelector(scope?.Split(' '));
-            scope = selectedScope is not null ? string.Join(" ", selectedScope) : null;
-        }
+        var scope = ComputeEffectiveScope(protectedResourceMetadata, authServerMetadata);
         if (!string.IsNullOrEmpty(scope))
         {
             queryParamsDictionary["scope"] = scope!;
@@ -661,7 +655,7 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
             TokenEndpointAuthMethod = "client_secret_post",
             ClientName = _dcrClientName,
             ClientUri = _dcrClientUri?.ToString(),
-            Scope = GetScopeParameter(protectedResourceMetadata),
+            Scope = ComputeEffectiveScope(protectedResourceMetadata, authServerMetadata),
         };
 
         var requestBytes = JsonSerializer.SerializeToUtf8Bytes(registrationRequest, McpJsonUtilities.JsonContext.Default.DynamicClientRegistrationRequest);
@@ -719,6 +713,20 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
 
     private static string? GetResourceUri(ProtectedResourceMetadata protectedResourceMetadata)
         => protectedResourceMetadata.Resource;
+
+    private string? ComputeEffectiveScope(
+        ProtectedResourceMetadata protectedResourceMetadata,
+        AuthorizationServerMetadata authServerMetadata)
+    {
+        var scope = GetScopeParameter(protectedResourceMetadata);
+        scope = AugmentScopeWithOfflineAccess(scope, authServerMetadata);
+        if (_scopeSelector is not null)
+        {
+            var selected = _scopeSelector(scope?.Split(' '));
+            scope = selected is not null ? string.Join(" ", selected) : null;
+        }
+        return scope;
+    }
 
     private string? GetScopeParameter(ProtectedResourceMetadata protectedResourceMetadata)
     {

--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
@@ -497,7 +497,7 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
         scope = AugmentScopeWithOfflineAccess(scope, authServerMetadata);
         if (_scopeSelector is not null)
         {
-            var selectedScope = _scopeSelector(scope?.Split(" "));
+            var selectedScope = _scopeSelector(scope?.Split(' '));
             scope = selectedScope is not null ? string.Join(" ", selectedScope) : null;
         }
         if (!string.IsNullOrEmpty(scope))

--- a/src/ModelContextProtocol.Core/Authentication/ScopeSelectorDelegate.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ScopeSelectorDelegate.cs
@@ -1,0 +1,33 @@
+
+namespace ModelContextProtocol.Authentication;
+
+/// <summary>
+/// Represents a method that selects or filters the OAuth scopes to request during authorization.
+/// </summary>
+/// <param name="scope">
+/// The scopes determined by the MCP scope selection strategy (WWW-Authenticate header scope →
+/// <c>scopes_supported</c> from Protected Resource Metadata → <see cref="ClientOAuthOptions.Scopes"/>
+/// fallback), with <c>offline_access</c> appended when advertised by the authorization server. May be
+/// <see langword="null"/> if the server provided no scope information and no fallback scopes are configured.
+/// </param>
+/// <returns>
+/// The scopes to include in the authorization request. Return <see langword="null"/> or an empty
+/// enumerable to omit the <c>scope</c> parameter entirely.
+/// </returns>
+/// <remarks>
+/// <para>
+/// Use this delegate to filter or customize the proposed scopes before the authorization request is made.
+/// Common scenarios include:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Requesting only a subset of the scopes offered by the server.</description></item>
+/// <item><description>Appending a custom scope not advertised in the server metadata.</description></item>
+/// </list>
+/// <para>
+/// The MCP specification defines the following scope selection priority (highest to lowest):
+/// WWW-Authenticate header scope → PRM <c>scopes_supported</c> → omit scope parameter. The
+/// <paramref name="scope"/> parameter already reflects this priority. The delegate runs after
+/// <c>offline_access</c> has been auto-appended, so it can also remove that scope if desired.
+/// </para>
+/// </remarks>
+public delegate IEnumerable<string>? ScopeSelectorDelegate(IEnumerable<string>? scope);

--- a/src/ModelContextProtocol.Core/Authentication/ScopeSelectorDelegate.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ScopeSelectorDelegate.cs
@@ -11,8 +11,8 @@ namespace ModelContextProtocol.Authentication;
 /// <see langword="null"/> if the server provided no scope information and no fallback scopes are configured.
 /// </param>
 /// <returns>
-/// The scopes to include in the authorization request. Return <see langword="null"/> or an empty
-/// enumerable to omit the <c>scope</c> parameter entirely.
+/// The scopes to include in the authorization and Dynamic Client Registration requests. Return
+/// <see langword="null"/> or an empty enumerable to omit the <c>scope</c> parameter entirely.
 /// </returns>
 /// <remarks>
 /// <para>
@@ -29,5 +29,9 @@ namespace ModelContextProtocol.Authentication;
 /// <paramref name="scope"/> parameter already reflects this priority. The delegate runs after
 /// <c>offline_access</c> has been auto-appended, so it can also remove that scope if desired.
 /// </para>
+/// <para>
+/// The resolved scope is applied consistently to both the authorization URL and the Dynamic Client
+/// Registration (DCR) request, so the registered client scope matches what is actually requested.
+/// </para>
 /// </remarks>
-public delegate IEnumerable<string>? ScopeSelectorDelegate(IEnumerable<string>? scope);
+public delegate IEnumerable<string>? ScopeSelectorDelegate(IReadOnlyCollection<string>? scope);

--- a/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
@@ -1529,4 +1529,32 @@ public class AuthTests : OAuthTestBase
 
         Assert.False(scopePresent);
     }
+
+    [Fact]
+    public async Task DynamicClientRegistration_ScopeSelector_AppliesToDcrScope()
+    {
+        Builder.Services.Configure<McpAuthenticationOptions>(McpAuthenticationDefaults.AuthenticationScheme, options =>
+        {
+            options.ResourceMetadata!.ScopesSupported = ["mcp:tools", "files:read"];
+        });
+
+        await using var app = await StartMcpServerAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new ClientOAuthOptions()
+            {
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationRedirectDelegate = HandleAuthorizationUrlAsync,
+                DynamicClientRegistration = new() { ClientName = "Test MCP Client" },
+                ScopeSelector = scopes => scopes?.Where(s => s == "mcp:tools"),
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("mcp:tools", TestOAuthServer.LastRegistrationScope);
+    }
 }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
@@ -1365,4 +1365,168 @@ public class AuthTests : OAuthTestBase
         var scopeTokens = requestedScope!.Split(' ');
         Assert.Single(scopeTokens, t => t == "offline_access");
     }
+
+    [Fact]
+    public async Task AuthorizationFlow_ScopeSelector_CanFilterServerProposedScopes()
+    {
+        Builder.Services.Configure<McpAuthenticationOptions>(McpAuthenticationDefaults.AuthenticationScheme, options =>
+        {
+            options.ResourceMetadata!.ScopesSupported = ["mcp:tools", "files:read"];
+        });
+
+        await using var app = await StartMcpServerAsync();
+
+        string? requestedScope = null;
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new()
+            {
+                ClientId = "demo-client",
+                ClientSecret = "demo-secret",
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationRedirectDelegate = (uri, redirect, ct) =>
+                {
+                    var query = QueryHelpers.ParseQuery(uri.Query);
+                    requestedScope = query["scope"].ToString();
+                    return HandleAuthorizationUrlAsync(uri, redirect, ct);
+                },
+                ScopeSelector = scopes => scopes?.Where(s => s == "mcp:tools"),
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("mcp:tools", requestedScope);
+    }
+
+    [Fact]
+    public async Task AuthorizationFlow_ScopeSelector_CanAddCustomScope()
+    {
+        await using var app = await StartMcpServerAsync();
+
+        string? requestedScope = null;
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new()
+            {
+                ClientId = "demo-client",
+                ClientSecret = "demo-secret",
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationRedirectDelegate = (uri, redirect, ct) =>
+                {
+                    var query = QueryHelpers.ParseQuery(uri.Query);
+                    requestedScope = query["scope"].ToString();
+                    return HandleAuthorizationUrlAsync(uri, redirect, ct);
+                },
+                ScopeSelector = scopes => scopes?.Append("custom:scope") ?? ["custom:scope"],
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(requestedScope);
+        Assert.Contains("custom:scope", requestedScope!.Split(' '));
+    }
+
+    [Fact]
+    public async Task AuthorizationFlow_ScopeSelector_ReceivesNull_WhenServerProvidesNoScopes()
+    {
+        // No ScopesSupported on PRM, no Scopes fallback on client, no offline_access on AS (default).
+        Builder.Services.Configure<McpAuthenticationOptions>(McpAuthenticationDefaults.AuthenticationScheme, options =>
+        {
+            options.ResourceMetadata!.ScopesSupported = [];
+        });
+
+        await using var app = await StartMcpServerAsync();
+
+        IEnumerable<string>? capturedInput = ["sentinel"];
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new()
+            {
+                ClientId = "demo-client",
+                ClientSecret = "demo-secret",
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationRedirectDelegate = HandleAuthorizationUrlAsync,
+                ScopeSelector = scopes =>
+                {
+                    capturedInput = scopes;
+                    return scopes;
+                },
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Null(capturedInput);
+    }
+
+    [Fact]
+    public async Task AuthorizationFlow_ScopeSelector_ReturningNull_OmitsScopeParameter()
+    {
+        await using var app = await StartMcpServerAsync();
+
+        bool? scopePresent = null;
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new()
+            {
+                ClientId = "demo-client",
+                ClientSecret = "demo-secret",
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationRedirectDelegate = (uri, redirect, ct) =>
+                {
+                    scopePresent = QueryHelpers.ParseQuery(uri.Query).ContainsKey("scope");
+                    return HandleAuthorizationUrlAsync(uri, redirect, ct);
+                },
+                ScopeSelector = _ => null,
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(scopePresent);
+    }
+
+    [Fact]
+    public async Task AuthorizationFlow_ScopeSelector_ReturningEmpty_OmitsScopeParameter()
+    {
+        await using var app = await StartMcpServerAsync();
+
+        bool? scopePresent = null;
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new()
+            {
+                ClientId = "demo-client",
+                ClientSecret = "demo-secret",
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationRedirectDelegate = (uri, redirect, ct) =>
+                {
+                    scopePresent = QueryHelpers.ParseQuery(uri.Query).ContainsKey("scope");
+                    return HandleAuthorizationUrlAsync(uri, redirect, ct);
+                },
+                ScopeSelector = _ => [],
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(scopePresent);
+    }
 }

--- a/tests/ModelContextProtocol.TestOAuthServer/Program.cs
+++ b/tests/ModelContextProtocol.TestOAuthServer/Program.cs
@@ -91,6 +91,9 @@ public sealed class Program
     public HashSet<string> DisabledMetadataPaths { get; } = new(StringComparer.OrdinalIgnoreCase);
     public IReadOnlyCollection<string> MetadataRequests => _metadataRequests.ToArray();
 
+    /// <summary>Gets the <c>scope</c> field from the most recent Dynamic Client Registration request.</summary>
+    public string? LastRegistrationScope { get; private set; }
+
     /// <summary>
     /// Entry point for the application.
     /// </summary>
@@ -512,6 +515,8 @@ public sealed class Program
                     ErrorDescription = "Invalid registration request"
                 });
             }
+
+            LastRegistrationScope = registrationRequest.Scope;
 
             // Validate redirect URIs are provided
             if (registrationRequest.RedirectUris.Count == 0)


### PR DESCRIPTION
Add a `ScopeSelector` hook to `ClientOAuthOptions` for customizing OAuth scopes

## Motivation and Context

The MCP authorization spec defines a strict scope selection priority: WWW-Authenticate header scope → PRM `scopes_supported` → omit scope parameter. Clients sometimes need to request only a subset of the scopes a server advertises (e.g. a client that only supports `mcp:tools` but the server lists ten scopes), or to append a scope not in the server metadata (e.g. a non-standard scope required by a specific deployment).

The existing `Scopes` property on `ClientOAuthOptions` was documented as an override but only ever acted as a last-resort fallback — consistent with the TypeScript and Python SDKs. That misleading documentation has been corrected. The new `ScopeSelector` delegate is the intended extension point for clients that need to influence scope selection when the server *does* provide scope information.

This closes out the use-case from #1238 and #1236 without violating the spec's priority order.

## How Has This Been Tested?

Five integration tests were added to `AuthTests.cs`, covering all input/output combinations of the delegate:

- Non-null input → filtered subset (client keeps only `mcp:tools` from a two-scope server)
- Non-null input → superset (client appends a custom scope not advertised by the server)
- **Null input** — server advertises no scopes and AS does not include `offline_access`; delegate receives `null`
- **Return `null`** — `scope` query parameter is absent from the authorization URL
- **Return empty enumerable** — `scope` query parameter is absent from the authorization URL

All tests run end-to-end against the in-process test OAuth server on net8.0, net9.0, and net10.0.

## Breaking Changes

None. The behavior of `Scopes` (last-resort fallback) is unchanged; only its documentation was corrected to match the actual behavior and the spec.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Delegate signature:**
```csharp
public delegate IEnumerable<string>? ScopeSelectorDelegate(IEnumerable<string>? scope);
```

The delegate receives the scope list *after* the full MCP priority logic and after `offline_access` has been auto-appended (per #1479), so it can also strip that scope if the client opts out. Returning `null` or an empty enumerable omits the `scope` parameter from the authorization request entirely.

The selector is intentionally not applied to the scope hint sent during Dynamic Client Registration — DCR scope is advisory and the authorization request scope is what matters for token issuance.
