### PR TITLE
Remove explicit SSE content encoding

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -478,7 +478,6 @@ internal sealed class StreamableHttpHandler(
         context.Response.Headers.CacheControl = "no-cache,no-store";
 
         // Make sure we disable all response buffering for SSE.
-        context.Response.Headers.ContentEncoding = "identity";
         context.Response.Headers["X-Accel-Buffering"] = "no";
         context.Features.GetRequiredFeature<IHttpResponseBodyFeature>().DisableBuffering();
     }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/SseServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/SseServerIntegrationTests.cs
@@ -22,7 +22,7 @@ public class SseServerIntegrationTests(SseServerIntegrationTestFixture fixture, 
         sseResponse.EnsureSuccessStatusCode();
 
         Assert.Equal("text/event-stream", sseResponse.Content.Headers.ContentType?.MediaType);
-        Assert.Equal("identity", sseResponse.Content.Headers.ContentEncoding.ToString());
+        Assert.Empty(sseResponse.Content.Headers.ContentEncoding);
         Assert.NotNull(sseResponse.Headers.CacheControl);
         Assert.True(sseResponse.Headers.CacheControl.NoStore);
         Assert.True(sseResponse.Headers.CacheControl.NoCache);

--- a/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerIntegrationTests.cs
@@ -35,7 +35,7 @@ public class StreamableHttpServerIntegrationTests(SseServerIntegrationTestFixtur
         sseResponse.EnsureSuccessStatusCode();
 
         Assert.Equal("text/event-stream", sseResponse.Content.Headers.ContentType?.MediaType);
-        Assert.Equal("identity", sseResponse.Content.Headers.ContentEncoding.ToString());
+        Assert.Empty(sseResponse.Content.Headers.ContentEncoding);
         Assert.NotNull(sseResponse.Headers.CacheControl);
         Assert.True(sseResponse.Headers.CacheControl.NoStore);
         Assert.True(sseResponse.Headers.CacheControl.NoCache);


### PR DESCRIPTION
## Motivation and Context

Fixes #1574.

SSE responses currently emit `Content-Encoding: identity` even though no content coding is applied. RFC 9110 section 8.4 defines `Content-Encoding` as the list of content codings that were applied to the representation and notes that `identity` is reserved for `Accept-Encoding`, so it SHOULD NOT be included in `Content-Encoding`.

Since no SSE content coding is applied here, the response can omit the header while still preserving the existing SSE buffering controls.

## Changes

- Removes the explicit `Content-Encoding: identity` assignment from SSE response initialization.
- Updates legacy SSE and Streamable HTTP integration tests to assert that SSE responses do not include a content encoding.
- Keeps the existing `Cache-Control`, `X-Accel-Buffering`, and `DisableBuffering()` behavior.

## How Has This Been Tested?

- `dotnet test tests/ModelContextProtocol.AspNetCore.Tests/ModelContextProtocol.AspNetCore.Tests.csproj -f net10.0 --filter "FullyQualifiedName~EventSourceResponse_Includes_ExpectedHeaders"`
  - RED before the production change: 3 failed because the collection contained `identity`.
  - GREEN after the production change: 3 passed.
- `dotnet test tests/ModelContextProtocol.AspNetCore.Tests/ModelContextProtocol.AspNetCore.Tests.csproj -f net10.0 --no-build --no-restore`
  - 377 passed, 18 skipped.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the MCP Documentation
- [x] My code follows the repository style guidelines
- [x] New and existing relevant tests pass locally
- [x] I have added appropriate regression coverage
- [x] Documentation updates were not needed for this header-only behavior fix