### PR TITLE
Add McpClientOptions.InitializeMeta to set _meta on the initialize request

### DIFF
--- a/src/ModelContextProtocol.Core/Client/McpClientImpl.cs
+++ b/src/ModelContextProtocol.Core/Client/McpClientImpl.cs
@@ -556,6 +556,7 @@ internal sealed partial class McpClientImpl : McpClient
                         ProtocolVersion = requestProtocol,
                         Capabilities = _options.Capabilities ?? new ClientCapabilities(),
                         ClientInfo = _options.ClientInfo ?? DefaultImplementation,
+                        Meta = _options.InitializeMeta,
                     },
                     McpJsonUtilities.JsonContext.Default.InitializeRequestParams,
                     McpJsonUtilities.JsonContext.Default.InitializeResult,

--- a/src/ModelContextProtocol.Core/Client/McpClientOptions.cs
+++ b/src/ModelContextProtocol.Core/Client/McpClientOptions.cs
@@ -1,5 +1,6 @@
 using ModelContextProtocol.Protocol;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
 
 namespace ModelContextProtocol.Client;
 
@@ -30,6 +31,21 @@ public sealed class McpClientOptions
     /// Gets or sets the client capabilities to advertise to the server.
     /// </summary>
     public ClientCapabilities? Capabilities { get; set; }
+
+    /// <summary>
+    /// Gets or sets the metadata to include in the <c>_meta</c> field of the <see cref="RequestMethods.Initialize"/> request.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When set, this value is sent as <see cref="RequestParams.Meta"/> on the <see cref="InitializeRequestParams"/> during the initialization handshake.
+    /// This allows passing implementation-specific data to the server alongside the standard <c>initialize</c> parameters,
+    /// such as authentication context a server validates before completing the handshake.
+    /// </para>
+    /// <para>
+    /// When <see langword="null"/>, no <c>_meta</c> field is sent.
+    /// </para>
+    /// </remarks>
+    public JsonObject? InitializeMeta { get; set; }
 
     /// <summary>
     /// Gets or sets the protocol version to request from the server, using a date-based versioning scheme.

--- a/tests/ModelContextProtocol.Tests/Client/McpClientMetaTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientMetaTests.cs
@@ -8,6 +8,8 @@ namespace ModelContextProtocol.Tests.Client;
 
 public class McpClientMetaTests : ClientServerTestBase
 {
+    private readonly TaskCompletionSource<JsonNode?> _initializeMeta = new();
+
     public McpClientMetaTests(ITestOutputHelper outputHelper)
         : base(outputHelper)
     {
@@ -28,6 +30,48 @@ public class McpClientMetaTests : ClientServerTestBase
             o.ResourceCollection = new ();
             o.PromptCollection = new ();
         });
+
+        // Capture the _meta the server receives on the initialize request so tests can
+        // assert that McpClientOptions.InitializeMeta is threaded through the handshake.
+        mcpServerBuilder.WithMessageFilters(filters =>
+            filters.AddIncomingFilter(next => async (context, cancellationToken) =>
+            {
+                if (context.JsonRpcMessage is JsonRpcRequest { Method: RequestMethods.Initialize } request)
+                {
+                    _initializeMeta.TrySetResult(request.Params?["_meta"]);
+                }
+
+                await next(context, cancellationToken);
+            }));
+    }
+
+    [Fact]
+    public async Task InitializeMeta_IsSentToServer_WhenSet()
+    {
+        var clientOptions = new McpClientOptions
+        {
+            InitializeMeta = new JsonObject
+            {
+                { "foo", "bar baz" }
+            }
+        };
+
+        await using McpClient client = await CreateMcpClientForServer(clientOptions);
+
+        var meta = await _initializeMeta.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(meta);
+        Assert.Equal("bar baz", meta["foo"]?.ToString());
+    }
+
+    [Fact]
+    public async Task InitializeMeta_IsOmitted_WhenNotSet()
+    {
+        await using McpClient client = await CreateMcpClientForServer();
+
+        var meta = await _initializeMeta.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(meta);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1593.

## Problem

`InitializeRequestParams` inherits `Meta` (`[JsonPropertyName("_meta")]`) from `RequestParams`, in line with the 2025-11-25 schema, but `McpClientImpl.ConnectAsync` constructs the params without reading from `McpClientOptions`. So the type supports `_meta` on `initialize` while the public client API offers no way to populate it. The current workaround is a custom `IClientTransport` that writes out-of-band data before the handshake, which couples the mechanism to the transport layer the SDK is meant to abstract.

## Fix

Add an `InitializeMeta` property to `McpClientOptions` and pass it as `Meta` when building the `InitializeRequestParams`. The protocol layer already models the field, so this is options-to-params plumbing only. When `InitializeMeta` is null, no `_meta` is sent, so existing behavior is unchanged.

## Testing

Added two tests to `McpClientMetaTests` that use a server-side incoming message filter to capture the `initialize` request:
- `InitializeMeta_IsSentToServer_WhenSet` asserts the value set on `McpClientOptions` arrives in the server's `initialize` `_meta`.
- `InitializeMeta_IsOmitted_WhenNotSet` asserts no `_meta` is sent by default.

`dotnet build` of `ModelContextProtocol.Core` is clean (warnings-as-errors). The full `McpClientMetaTests` class passes (5/5) on net10.0.