### PR TITLE
Require Tool inputSchema during deserialization

### DIFF
--- a/src/ModelContextProtocol.Core/Protocol/Tool.cs
+++ b/src/ModelContextProtocol.Core/Protocol/Tool.cs
@@ -64,6 +64,7 @@ public sealed class Tool : IBaseMetadata
     /// </para>
     /// </remarks>
     [JsonPropertyName("inputSchema")]
+    [JsonRequired]
     public JsonElement InputSchema
     {
         get => field;

--- a/tests/ModelContextProtocol.Tests/Protocol/ToolTests.cs
+++ b/tests/ModelContextProtocol.Tests/Protocol/ToolTests.cs
@@ -105,6 +105,14 @@ public static class ToolTests
         Assert.Equal("object", typeElement.GetString());
     }
 
+    [Fact]
+    public static void ToolInputSchema_DeserializationRejectsMissingInputSchema()
+    {
+        const string json = """{"name":"test"}""";
+
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Tool>(json, McpJsonUtilities.DefaultOptions));
+    }
+
     [Theory]
     [InlineData("null")]
     [InlineData("false")]


### PR DESCRIPTION
## Motivation and Context

Fixes #1575.

`Tool.InputSchema` defaults to `{"type":"object"}` for code-created `Tool` instances. During JSON deserialization, that same default currently masks payloads that omit the required `inputSchema` property, allowing invalid tool definitions to deserialize successfully.

## Changes

- Mark `Tool.InputSchema` as JSON-required so missing `inputSchema` fails during deserialization.
- Add a regression test covering deserialization of a tool payload without `inputSchema`.
- Preserve the existing default schema behavior for code-created `Tool` instances.

## How Has This Been Tested?

- `PATH=/home/dragonfsky/.dotnet:$PATH /home/dragonfsky/.dotnet/dotnet build`
- `PATH=/home/dragonfsky/.dotnet:$PATH /home/dragonfsky/.dotnet/dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj -f net10.0 --filter FullyQualifiedName~ModelContextProtocol.Tests.Protocol.ToolTests`
- `PATH=/home/dragonfsky/.dotnet:$PATH /home/dragonfsky/.dotnet/dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj -f net10.0 --filter "FullyQualifiedName~ExperimentalPropertySerializationTests|FullyQualifiedName~ExperimentalInternalPropertyTests"`
- `PATH=/home/dragonfsky/.dotnet:$PATH /home/dragonfsky/.dotnet/dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj -f net10.0 --filter "FullyQualifiedName!~DockerEverythingServerTests"`