### PR TITLE
Allow setting token endpoint auth method on ClientOAuthOptions (#1612)

### DIFF
--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthOptions.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthOptions.cs
@@ -24,6 +24,19 @@ public sealed class ClientOAuthOptions
     public string? ClientSecret { get; set; }
 
     /// <summary>
+    /// Gets or sets the token endpoint authentication method (<c>token_endpoint_auth_method</c>) to use when
+    /// requesting tokens, for example <c>"none"</c>, <c>"client_secret_basic"</c>, or <c>"client_secret_post"</c>.
+    /// </summary>
+    /// <remarks>
+    /// When not set, the method is inferred from the dynamic client registration response (when DCR is used), and
+    /// otherwise from the first entry in the authorization server's <c>token_endpoint_auth_methods_supported</c>.
+    /// Set this explicitly when that inference is incorrect — most notably for a public client identified by a
+    /// <see cref="ClientMetadataDocumentUri">Client ID Metadata Document</see>, which must authenticate with
+    /// <c>"none"</c> (relying on PKCE) even when the authorization server advertises a different method first.
+    /// </remarks>
+    public string? TokenEndpointAuthMethod { get; set; }
+
+    /// <summary>
     /// Gets or sets the HTTPS URL pointing to this client's metadata document.
     /// </summary>
     /// <remarks>

--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthOptions.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthOptions.cs
@@ -25,14 +25,16 @@ public sealed class ClientOAuthOptions
 
     /// <summary>
     /// Gets or sets the token endpoint authentication method (<c>token_endpoint_auth_method</c>) to use when
-    /// requesting tokens, for example <c>"none"</c>, <c>"client_secret_basic"</c>, or <c>"client_secret_post"</c>.
+    /// requesting tokens.
     /// </summary>
     /// <remarks>
-    /// When not set, the method is inferred from the dynamic client registration response (when DCR is used), and
-    /// otherwise from the first entry in the authorization server's <c>token_endpoint_auth_methods_supported</c>.
-    /// Set this explicitly when that inference is incorrect — most notably for a public client identified by a
-    /// <see cref="ClientMetadataDocumentUri">Client ID Metadata Document</see>, which must authenticate with
-    /// <c>"none"</c> (relying on PKCE) even when the authorization server advertises a different method first.
+    /// Supported values are <c>none</c>, <c>client_secret_basic</c>, and <c>client_secret_post</c>.
+    /// When not set, the method is inferred from the dynamic client registration response (when DCR is used),
+    /// and otherwise from the first entry in the authorization server's
+    /// <c>token_endpoint_auth_methods_supported</c>. For DCR, this value is requested during registration,
+    /// but the method returned by the authorization server is authoritative.
+    /// Set this explicitly when inference is incorrect, most notably for a public client identified by a
+    /// <see cref="ClientMetadataDocumentUri">Client ID Metadata Document</see>, which commonly uses <c>none</c>.
     /// </remarks>
     public string? TokenEndpointAuthMethod { get; set; }
 

--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
@@ -75,6 +75,7 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
 
         _clientId = options.ClientId;
         _clientSecret = options.ClientSecret;
+        _tokenEndpointAuthMethod = options.TokenEndpointAuthMethod;
         _redirectUri = options.RedirectUri ?? throw new ArgumentException("ClientOAuthOptions.RedirectUri must configured.", nameof(options));
         _configuredScopes = options.Scopes is null ? null : string.Join(" ", options.Scopes);
         _scopeSelector = options.ScopeSelector;
@@ -698,9 +699,11 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
             _clientSecret = registrationResponse.ClientSecret;
         }
 
+        // Honor an explicitly configured ClientOAuthOptions.TokenEndpointAuthMethod over the value returned by
+        // dynamic client registration.
         if (!string.IsNullOrEmpty(registrationResponse.TokenEndpointAuthMethod))
         {
-            _tokenEndpointAuthMethod = registrationResponse.TokenEndpointAuthMethod;
+            _tokenEndpointAuthMethod ??= registrationResponse.TokenEndpointAuthMethod;
         }
 
         LogDynamicClientRegistrationSuccessful(_clientId!);

--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
@@ -100,6 +100,7 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
         _clientId = options.ClientId;
         _configuredClientId = options.ClientId;
         _clientSecret = options.ClientSecret;
+        _tokenEndpointAuthMethod = options.TokenEndpointAuthMethod;
         _redirectUri = options.RedirectUri ?? throw new ArgumentException("ClientOAuthOptions.RedirectUri must configured.", nameof(options));
         _configuredScopes = options.Scopes is null ? null : string.Join(" ", options.Scopes);
         _scopeSelector = options.ScopeSelector;
@@ -983,9 +984,11 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
             _clientSecret = registrationResponse.ClientSecret;
         }
 
+        // Honor an explicitly configured ClientOAuthOptions.TokenEndpointAuthMethod over the value returned by
+        // dynamic client registration.
         if (!string.IsNullOrEmpty(registrationResponse.TokenEndpointAuthMethod))
         {
-            _tokenEndpointAuthMethod = registrationResponse.TokenEndpointAuthMethod;
+            _tokenEndpointAuthMethod ??= registrationResponse.TokenEndpointAuthMethod;
         }
 
         LogDynamicClientRegistrationSuccessful(_clientId!);

--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
@@ -36,6 +36,7 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
     private readonly bool _validateAuthorizationResponseIssuer;
     private readonly Uri? _clientMetadataDocumentUri;
     private readonly string? _configuredClientId;
+    private readonly string? _configuredTokenEndpointAuthMethod;
 
     // _dcrClientName, _dcrClientUri, _dcrInitialAccessToken, _dcrConfiguredApplicationType and _dcrResponseDelegate are used for dynamic client registration (RFC 7591)
     private readonly string? _dcrClientName;
@@ -97,10 +98,19 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
             throw new ArgumentNullException(nameof(options));
         }
 
+        if (options.TokenEndpointAuthMethod is not null &&
+            !IsSupportedTokenEndpointAuthMethod(options.TokenEndpointAuthMethod))
+        {
+            throw new ArgumentException(
+                $"{nameof(options.TokenEndpointAuthMethod)} must be 'client_secret_basic', 'client_secret_post', or 'none'.",
+                $"{nameof(options)}.{nameof(options.TokenEndpointAuthMethod)}");
+        }
+
         _clientId = options.ClientId;
         _configuredClientId = options.ClientId;
         _clientSecret = options.ClientSecret;
-        _tokenEndpointAuthMethod = options.TokenEndpointAuthMethod;
+        _configuredTokenEndpointAuthMethod = options.TokenEndpointAuthMethod;
+        _tokenEndpointAuthMethod = _configuredTokenEndpointAuthMethod;
         _redirectUri = options.RedirectUri ?? throw new ArgumentException("ClientOAuthOptions.RedirectUri must configured.", nameof(options));
         _configuredScopes = options.Scopes is null ? null : string.Join(" ", options.Scopes);
         _scopeSelector = options.ScopeSelector;
@@ -848,11 +858,16 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
             // Public client: include client_id in the body but no secret.
             formFields["client_id"] = clientId;
         }
-        else
+        else if (_tokenEndpointAuthMethod is null or "client_secret_post")
         {
             // Default to client_secret_post: include credentials in the body.
             formFields["client_id"] = clientId;
             formFields["client_secret"] = _clientSecret ?? string.Empty;
+        }
+        else
+        {
+            ThrowFailedToHandleUnauthorizedResponse(
+                $"Token endpoint authentication method '{_tokenEndpointAuthMethod}' is not supported.");
         }
 
         request.Content = new FormUrlEncodedContent(formFields);
@@ -935,7 +950,7 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
             RedirectUris = [_redirectUri.ToString()],
             GrantTypes = ["authorization_code", "refresh_token"],
             ResponseTypes = ["code"],
-            TokenEndpointAuthMethod = "client_secret_post",
+            TokenEndpointAuthMethod = _configuredTokenEndpointAuthMethod ?? "client_secret_post",
             ClientName = _dcrClientName,
             ClientUri = _dcrClientUri?.ToString(),
             Scope = ComputeEffectiveScope(protectedResourceMetadata, authServerMetadata),
@@ -984,11 +999,23 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
             _clientSecret = registrationResponse.ClientSecret;
         }
 
-        // Honor an explicitly configured ClientOAuthOptions.TokenEndpointAuthMethod over the value returned by
-        // dynamic client registration.
-        if (!string.IsNullOrEmpty(registrationResponse.TokenEndpointAuthMethod))
+        // The response describes the registration the server created and is authoritative. Some servers omit the
+        // field, in which case use the method requested during registration.
+        var registeredTokenEndpointAuthMethod = registrationResponse.TokenEndpointAuthMethod;
+        if (!string.IsNullOrEmpty(registeredTokenEndpointAuthMethod))
         {
-            _tokenEndpointAuthMethod ??= registrationResponse.TokenEndpointAuthMethod;
+            if (!IsSupportedTokenEndpointAuthMethod(registeredTokenEndpointAuthMethod!))
+            {
+                ThrowFailedToHandleUnauthorizedResponse(
+                    $"Dynamic client registration returned unsupported token endpoint authentication method " +
+                    $"'{registeredTokenEndpointAuthMethod}'.");
+            }
+
+            _tokenEndpointAuthMethod = registeredTokenEndpointAuthMethod;
+        }
+        else
+        {
+            _tokenEndpointAuthMethod = registrationRequest.TokenEndpointAuthMethod;
         }
 
         LogDynamicClientRegistrationSuccessful(_clientId!);
@@ -1010,6 +1037,9 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
         }
         return "native";
     }
+
+    private static bool IsSupportedTokenEndpointAuthMethod(string tokenEndpointAuthMethod) =>
+        tokenEndpointAuthMethod is "client_secret_basic" or "client_secret_post" or "none";
 
     private static string? GetResourceUri(ProtectedResourceMetadata protectedResourceMetadata)
         => protectedResourceMetadata.Resource;
@@ -1528,7 +1558,16 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
         // Assign _clientId last. Callers treat a non-empty _clientId as "registration complete", so the
         // secret and auth method must already be in place before _clientId becomes observable.
         _clientSecret ??= cached.ClientSecret;
-        _tokenEndpointAuthMethod ??= cached.TokenEndpointAuthMethod;
+        if (string.Equals(cached.ClientId, _clientMetadataDocumentUri?.AbsoluteUri, StringComparison.Ordinal))
+        {
+            // Configured intent controls CIMD clients.
+            _tokenEndpointAuthMethod ??= cached.TokenEndpointAuthMethod;
+        }
+        else
+        {
+            // A DCR response is authoritative for the registration and must survive a cold start.
+            _tokenEndpointAuthMethod = cached.TokenEndpointAuthMethod ?? _configuredTokenEndpointAuthMethod;
+        }
         _clientId = cached.ClientId;
         _clientCredentialsAuthorizationServer = cached.AuthorizationServer;
     }
@@ -1557,7 +1596,7 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
 
         _clientId = null;
         _clientSecret = null;
-        _tokenEndpointAuthMethod = null;
+        _tokenEndpointAuthMethod = _configuredTokenEndpointAuthMethod;
         _authServerMetadata = null;
         _clientCredentialsAuthorizationServer = null;
     }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
@@ -132,6 +132,59 @@ public class AuthTests : OAuthTestBase
     }
 
     [Fact]
+    public async Task CannotAuthenticate_WithClientMetadataDocument_WhenServerAdvertisesClientSecretBasicFirst()
+    {
+        // Mimic authorization servers (e.g. Auth0) that advertise client_secret_basic ahead of "none".
+        // A CIMD client is a public client, but without an explicit TokenEndpointAuthMethod the client falls back to
+        // the first advertised method (client_secret_basic) and authenticates with the client id and an empty secret
+        // in the Authorization header rather than placing the client id in the body — which a public client cannot
+        // satisfy, so the token exchange fails.
+        TestOAuthServer.SupportedTokenEndpointAuthMethods = ["client_secret_basic", "client_secret_post", "none"];
+
+        await using var app = await StartMcpServerAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new ClientOAuthOptions()
+            {
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationRedirectDelegate = HandleAuthorizationUrlAsync,
+                ClientMetadataDocumentUri = new Uri(ClientMetadataDocumentUrl),
+            },
+        }, HttpClient, LoggerFactory);
+
+        await Assert.ThrowsAnyAsync<HttpRequestException>(() => McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CanAuthenticate_WithClientMetadataDocument_AndExplicitNoneAuthMethod()
+    {
+        // Same Auth0-like server that advertises client_secret_basic first, but the client explicitly declares the
+        // public-client "none" method. The token request must then carry the client id in the body (no secret) and
+        // succeed, proving ClientOAuthOptions.TokenEndpointAuthMethod overrides the server-advertised default.
+        TestOAuthServer.SupportedTokenEndpointAuthMethods = ["client_secret_basic", "client_secret_post", "none"];
+
+        await using var app = await StartMcpServerAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new ClientOAuthOptions()
+            {
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationRedirectDelegate = HandleAuthorizationUrlAsync,
+                ClientMetadataDocumentUri = new Uri(ClientMetadataDocumentUrl),
+                TokenEndpointAuthMethod = "none",
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task UsesDynamicClientRegistration_WhenCimdNotSupported()
     {
         // Disable CIMD support on the test OAuth server so the client

--- a/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
@@ -440,6 +440,59 @@ public class AuthTests : OAuthTestBase
     }
 
     [Fact]
+    public async Task CannotAuthenticate_WithClientMetadataDocument_WhenServerAdvertisesClientSecretBasicFirst()
+    {
+        // Mimic authorization servers (e.g. Auth0) that advertise client_secret_basic ahead of "none".
+        // A CIMD client is a public client, but without an explicit TokenEndpointAuthMethod the client falls back to
+        // the first advertised method (client_secret_basic) and authenticates with the client id and an empty secret
+        // in the Authorization header rather than placing the client id in the body — which a public client cannot
+        // satisfy, so the token exchange fails.
+        TestOAuthServer.SupportedTokenEndpointAuthMethods = ["client_secret_basic", "client_secret_post", "none"];
+
+        await using var app = await StartMcpServerAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new ClientOAuthOptions()
+            {
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationRedirectDelegate = HandleAuthorizationUrlAsync,
+                ClientMetadataDocumentUri = new Uri(ClientMetadataDocumentUrl),
+            },
+        }, HttpClient, LoggerFactory);
+
+        await Assert.ThrowsAnyAsync<HttpRequestException>(() => McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CanAuthenticate_WithClientMetadataDocument_AndExplicitNoneAuthMethod()
+    {
+        // Same Auth0-like server that advertises client_secret_basic first, but the client explicitly declares the
+        // public-client "none" method. The token request must then carry the client id in the body (no secret) and
+        // succeed, proving ClientOAuthOptions.TokenEndpointAuthMethod overrides the server-advertised default.
+        TestOAuthServer.SupportedTokenEndpointAuthMethods = ["client_secret_basic", "client_secret_post", "none"];
+
+        await using var app = await StartMcpServerAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new ClientOAuthOptions()
+            {
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationRedirectDelegate = HandleAuthorizationUrlAsync,
+                ClientMetadataDocumentUri = new Uri(ClientMetadataDocumentUrl),
+                TokenEndpointAuthMethod = "none",
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task UsesDynamicClientRegistration_WhenCimdNotSupported()
     {
         // Disable CIMD support on the test OAuth server so the client

--- a/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
@@ -50,6 +50,32 @@ public class AuthTests : OAuthTestBase
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
+    [Theory]
+    [InlineData("client_secret_basic")]
+    [InlineData("client_secret_post")]
+    public async Task CanAuthenticate_WithExplicitTokenEndpointAuthMethod(string tokenEndpointAuthMethod)
+    {
+        await using var app = await StartMcpServerAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new()
+            {
+                ClientId = "demo-client",
+                ClientSecret = "demo-secret",
+                TokenEndpointAuthMethod = tokenEndpointAuthMethod,
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationCallbackHandler = HandleAuthorizationUrlAsync,
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(tokenEndpointAuthMethod, TestOAuthServer.LastTokenEndpointAuthMethod);
+    }
+
     [Fact]
     public async Task AuthorizationCallbackHandler_ReceivesConfiguredRedirectUri()
     {
@@ -174,6 +200,28 @@ public class AuthTests : OAuthTestBase
 #pragma warning disable MCP9007 // The obsolete property name should be included in the diagnostic.
         Assert.Contains(nameof(ClientOAuthOptions.AuthorizationRedirectDelegate), ex.Message);
 #pragma warning restore MCP9007
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("None")]
+    [InlineData("private_key_jwt")]
+    public void HttpClientTransport_RejectsUnsupportedTokenEndpointAuthMethod(string tokenEndpointAuthMethod)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new HttpClientTransport(
+            new()
+            {
+                Endpoint = new(McpServerUrl),
+                OAuth = new()
+                {
+                    RedirectUri = new Uri("http://localhost:1179/callback"),
+                    TokenEndpointAuthMethod = tokenEndpointAuthMethod,
+                },
+            },
+            HttpClient,
+            LoggerFactory));
+
+        Assert.Equal("options.TokenEndpointAuthMethod", ex.ParamName);
     }
 
     [Fact]
@@ -309,6 +357,80 @@ public class AuthTests : OAuthTestBase
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("native", TestOAuthServer.LastApplicationType);
+        Assert.Equal("client_secret_post", TestOAuthServer.LastRegistrationTokenEndpointAuthMethod);
+    }
+
+    [Fact]
+    public async Task DynamicClientRegistration_ResponseTokenEndpointAuthMethodIsAuthoritative()
+    {
+        TestOAuthServer.DynamicRegistrationTokenEndpointAuthMethod = "client_secret_post";
+        await using var app = await StartMcpServerAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new()
+            {
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                TokenEndpointAuthMethod = "client_secret_basic",
+                AuthorizationCallbackHandler = HandleAuthorizationUrlAsync,
+                DynamicClientRegistration = new(),
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("client_secret_basic", TestOAuthServer.LastRegistrationTokenEndpointAuthMethod);
+        Assert.Equal("client_secret_post", TestOAuthServer.LastTokenEndpointAuthMethod);
+    }
+
+    [Fact]
+    public async Task DynamicClientRegistration_UsesRequestedMethodWhenResponseOmitsIt()
+    {
+        TestOAuthServer.DynamicRegistrationTokenEndpointAuthMethod = null;
+        await using var app = await StartMcpServerAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new()
+            {
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                TokenEndpointAuthMethod = "client_secret_basic",
+                AuthorizationCallbackHandler = HandleAuthorizationUrlAsync,
+                DynamicClientRegistration = new(),
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("client_secret_basic", TestOAuthServer.LastRegistrationTokenEndpointAuthMethod);
+        Assert.Equal("client_secret_basic", TestOAuthServer.LastTokenEndpointAuthMethod);
+    }
+
+    [Fact]
+    public async Task DynamicClientRegistration_RejectsUnsupportedResponseTokenEndpointAuthMethod()
+    {
+        TestOAuthServer.DynamicRegistrationTokenEndpointAuthMethod = "private_key_jwt";
+        await using var app = await StartMcpServerAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new()
+            {
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationCallbackHandler = HandleAuthorizationUrlAsync,
+                DynamicClientRegistration = new(),
+            },
+        }, HttpClient, LoggerFactory);
+
+        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Contains("private_key_jwt", ex.Message);
     }
 
     [Fact]
@@ -457,7 +579,7 @@ public class AuthTests : OAuthTestBase
             OAuth = new ClientOAuthOptions()
             {
                 RedirectUri = new Uri("http://localhost:1179/callback"),
-                AuthorizationRedirectDelegate = HandleAuthorizationUrlAsync,
+                AuthorizationCallbackHandler = HandleAuthorizationUrlAsync,
                 ClientMetadataDocumentUri = new Uri(ClientMetadataDocumentUrl),
             },
         }, HttpClient, LoggerFactory);
@@ -482,7 +604,7 @@ public class AuthTests : OAuthTestBase
             OAuth = new ClientOAuthOptions()
             {
                 RedirectUri = new Uri("http://localhost:1179/callback"),
-                AuthorizationRedirectDelegate = HandleAuthorizationUrlAsync,
+                AuthorizationCallbackHandler = HandleAuthorizationUrlAsync,
                 ClientMetadataDocumentUri = new Uri(ClientMetadataDocumentUrl),
                 TokenEndpointAuthMethod = "none",
             },
@@ -490,6 +612,77 @@ public class AuthTests : OAuthTestBase
 
         await using var client = await McpClient.CreateAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ClientMetadataDocument_PreservesConfiguredMethodAfterAuthorizationServerMigration()
+    {
+        TestOAuthServer.SupportedTokenEndpointAuthMethods = ["client_secret_basic", "none"];
+        var selectedAuthorizationServer = OAuthServerUrl;
+        var migrationChallengeSent = 0;
+
+        Builder.Services.Configure<McpAuthenticationOptions>(McpAuthenticationDefaults.AuthenticationScheme, options =>
+        {
+            options.Events.OnResourceMetadataRequest = async context =>
+            {
+                context.HandleResponse();
+                var metadata = new ProtectedResourceMetadata
+                {
+                    Resource = McpServerUrl,
+                    AuthorizationServers = { selectedAuthorizationServer },
+                    ScopesSupported = ["mcp:tools"],
+                };
+                await Results.Json(metadata, McpJsonUtilities.DefaultOptions).ExecuteAsync(context.HttpContext);
+            };
+        });
+
+        await using var app = await StartMcpServerAsync(configureMiddleware: app =>
+        {
+            app.Use(async (context, next) =>
+            {
+                if (context.Request.Method == HttpMethods.Post && context.Request.Path == "/")
+                {
+                    context.Request.EnableBuffering();
+                    var message = await JsonSerializer.DeserializeAsync(
+                        context.Request.Body,
+                        McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcMessage)),
+                        context.RequestAborted) as JsonRpcMessage;
+                    context.Request.Body.Position = 0;
+
+                    if (message is JsonRpcRequest { Method: "ping" } &&
+                        Interlocked.CompareExchange(ref migrationChallengeSent, 1, 0) == 0)
+                    {
+                        selectedAuthorizationServer = $"{OAuthServerUrl}/tenant";
+                        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                        context.Response.Headers.WWWAuthenticate =
+                            $"{JwtBearerDefaults.AuthenticationScheme} resource_metadata=\"{McpServerUrl}/.well-known/oauth-protected-resource\"";
+                        return;
+                    }
+                }
+
+                await next(context);
+            });
+        });
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new()
+            {
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationCallbackHandler = HandleAuthorizationUrlAsync,
+                ClientMetadataDocumentUri = new Uri(ClientMetadataDocumentUrl),
+                TokenEndpointAuthMethod = "none",
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+
+        await client.PingAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("none", TestOAuthServer.LastTokenEndpointAuthMethod);
+        Assert.Contains("/.well-known/oauth-authorization-server/tenant", TestOAuthServer.MetadataRequests);
     }
 
     [Fact]

--- a/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/TokenCacheTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/TokenCacheTests.cs
@@ -379,6 +379,7 @@ public class TokenCacheTests : OAuthTestBase
             OAuth = new()
             {
                 RedirectUri = new Uri("http://localhost:1179/callback"),
+                TokenEndpointAuthMethod = "client_secret_basic",
                 DynamicClientRegistration = new()
                 {
                     ClientName = "Test MCP Client",
@@ -404,6 +405,8 @@ public class TokenCacheTests : OAuthTestBase
         Assert.False(
             string.IsNullOrEmpty(tokenCache.LastStoredToken.ClientId),
             "The dynamically registered client ID should be persisted alongside the tokens");
+        Assert.Equal("client_secret_basic", TestOAuthServer.LastRegistrationTokenEndpointAuthMethod);
+        Assert.Equal("client_secret_post", tokenCache.LastStoredToken.TokenEndpointAuthMethod);
         Assert.Equal(OAuthServerUrl, tokenCache.LastStoredToken.AuthorizationServer);
 
         // Simulate a cold start: the access token is no longer valid, but the refresh token persists.
@@ -418,6 +421,7 @@ public class TokenCacheTests : OAuthTestBase
             OAuth = new()
             {
                 RedirectUri = new Uri("http://localhost:1179/callback"),
+                TokenEndpointAuthMethod = "client_secret_basic",
                 DynamicClientRegistration = new()
                 {
                     ClientName = "Test MCP Client",
@@ -437,11 +441,14 @@ public class TokenCacheTests : OAuthTestBase
         Assert.False(authDelegateCalledAgain, "Authorization callback should not be called when the persisted refresh token can be used");
         Assert.True(TestOAuthServer.HasRefreshedToken, "Token should have been refreshed using the persisted client credentials");
         Assert.NotEqual("invalid-token", tokenCache.LastStoredToken.AccessToken);
+        Assert.Equal("client_secret_post", TestOAuthServer.LastTokenEndpointAuthMethod);
+        Assert.Equal("client_secret_post", tokenCache.LastStoredToken.TokenEndpointAuthMethod);
     }
 
     [Fact]
     public async Task GetTokenAsync_ColdStartWithCredentialsFromDifferentAuthorizationServer_Reregisters()
     {
+        TestOAuthServer.DynamicRegistrationTokenEndpointAuthMethod = null;
         await using var app = await StartMcpServerAsync();
 
         var tokenCache = new TestTokenCache();
@@ -451,6 +458,7 @@ public class TokenCacheTests : OAuthTestBase
             OAuth = new()
             {
                 RedirectUri = new Uri("http://localhost:1179/callback"),
+                TokenEndpointAuthMethod = "client_secret_basic",
                 DynamicClientRegistration = new() { ClientName = "Test MCP Client" },
                 AuthorizationCallbackHandler = HandleAuthorizationUrlAsync,
                 TokenCache = tokenCache,
@@ -465,6 +473,7 @@ public class TokenCacheTests : OAuthTestBase
         }
 
         Assert.NotNull(tokenCache.LastStoredToken);
+        Assert.Equal("client_secret_basic", tokenCache.LastStoredToken.TokenEndpointAuthMethod);
         tokenCache.LastStoredToken.AccessToken = "invalid-token";
         tokenCache.LastStoredToken.AuthorizationServer = "https://different-authorization-server.example.com";
         var authorizationCallbackCalled = false;
@@ -475,6 +484,7 @@ public class TokenCacheTests : OAuthTestBase
             OAuth = new()
             {
                 RedirectUri = new Uri("http://localhost:1179/callback"),
+                TokenEndpointAuthMethod = "client_secret_basic",
                 DynamicClientRegistration = new() { ClientName = "Test MCP Client" },
                 AuthorizationCallbackHandler = (context, ct) =>
                 {
@@ -492,6 +502,9 @@ public class TokenCacheTests : OAuthTestBase
 
         Assert.True(authorizationCallbackCalled);
         Assert.False(TestOAuthServer.HasRefreshedToken);
+        Assert.Equal("client_secret_basic", TestOAuthServer.LastRegistrationTokenEndpointAuthMethod);
+        Assert.Equal("client_secret_basic", TestOAuthServer.LastTokenEndpointAuthMethod);
+        Assert.Equal("client_secret_basic", tokenCache.LastStoredToken.TokenEndpointAuthMethod);
         Assert.Equal(OAuthServerUrl, tokenCache.LastStoredToken.AuthorizationServer);
     }
 

--- a/tests/ModelContextProtocol.TestOAuthServer/ClientInfo.cs
+++ b/tests/ModelContextProtocol.TestOAuthServer/ClientInfo.cs
@@ -23,6 +23,11 @@ internal sealed class ClientInfo
     public string? ClientSecret { get; init; }
 
     /// <summary>
+    /// Gets or sets the token endpoint authentication method assigned to this client.
+    /// </summary>
+    public string? TokenEndpointAuthMethod { get; init; }
+
+    /// <summary>
     /// Gets or sets the list of redirect URIs allowed for this client.
     /// </summary>
     public List<string> RedirectUris { get; init; } = [];

--- a/tests/ModelContextProtocol.TestOAuthServer/Program.cs
+++ b/tests/ModelContextProtocol.TestOAuthServer/Program.cs
@@ -88,6 +88,16 @@ public sealed class Program
     /// </remarks>
     public bool IncludeOfflineAccessInMetadata { get; set; }
 
+    /// <summary>
+    /// Gets or sets the authentication methods advertised in the discovery document's
+    /// <c>token_endpoint_auth_methods_supported</c>. Tests can set this to mimic authorization servers
+    /// (such as Auth0) that advertise <c>client_secret_basic</c> ahead of <c>none</c>.
+    /// </summary>
+    /// <remarks>
+    /// The default value is <c>["client_secret_post"]</c>.
+    /// </remarks>
+    public List<string> SupportedTokenEndpointAuthMethods { get; set; } = ["client_secret_post"];
+
     public HashSet<string> DisabledMetadataPaths { get; } = new(StringComparer.OrdinalIgnoreCase);
     public IReadOnlyCollection<string> MetadataRequests => _metadataRequests.ToArray();
 
@@ -204,7 +214,7 @@ public sealed class Program
                 ScopesSupported = IncludeOfflineAccessInMetadata
                     ? ["openid", "profile", "email", "mcp:tools", "offline_access"]
                     : ["openid", "profile", "email", "mcp:tools"],
-                TokenEndpointAuthMethodsSupported = ["client_secret_post"],
+                TokenEndpointAuthMethodsSupported = SupportedTokenEndpointAuthMethods,
                 ClaimsSupported = ["sub", "iss", "name", "email", "aud"],
                 CodeChallengeMethodsSupported = ["S256"],
                 GrantTypesSupported = ["authorization_code", "refresh_token"],

--- a/tests/ModelContextProtocol.TestOAuthServer/Program.cs
+++ b/tests/ModelContextProtocol.TestOAuthServer/Program.cs
@@ -135,6 +135,16 @@ public sealed class Program
     /// </summary>
     public HashSet<string> MetadataPathsWithoutPkceSupport { get; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Gets or sets the authentication methods advertised in the discovery document's
+    /// <c>token_endpoint_auth_methods_supported</c>. Tests can set this to mimic authorization servers
+    /// (such as Auth0) that advertise <c>client_secret_basic</c> ahead of <c>none</c>.
+    /// </summary>
+    /// <remarks>
+    /// The default value is <c>["client_secret_post"]</c>.
+    /// </remarks>
+    public List<string> SupportedTokenEndpointAuthMethods { get; set; } = ["client_secret_post"];
+
     public HashSet<string> DisabledMetadataPaths { get; } = new(StringComparer.OrdinalIgnoreCase);
     public IReadOnlyCollection<string> MetadataRequests => _metadataRequests.ToArray();
 
@@ -276,7 +286,7 @@ public sealed class Program
                 ScopesSupported = IncludeOfflineAccessInMetadata
                     ? ["openid", "profile", "email", "mcp:tools", "offline_access"]
                     : ["openid", "profile", "email", "mcp:tools"],
-                TokenEndpointAuthMethodsSupported = ["client_secret_post"],
+                TokenEndpointAuthMethodsSupported = SupportedTokenEndpointAuthMethods,
                 ClaimsSupported = ["sub", "iss", "name", "email", "aud"],
                 CodeChallengeMethodsSupported = MetadataPathsWithoutPkceSupport.Contains(context.Request.Path)
                     ? null

--- a/tests/ModelContextProtocol.TestOAuthServer/Program.cs
+++ b/tests/ModelContextProtocol.TestOAuthServer/Program.cs
@@ -145,6 +145,12 @@ public sealed class Program
     /// </remarks>
     public List<string> SupportedTokenEndpointAuthMethods { get; set; } = ["client_secret_post"];
 
+    /// <summary>
+    /// Gets or sets the token endpoint authentication method returned by dynamic client registration.
+    /// Set to <see langword="null"/> to omit the method from the response.
+    /// </summary>
+    public string? DynamicRegistrationTokenEndpointAuthMethod { get; set; } = "client_secret_post";
+
     public HashSet<string> DisabledMetadataPaths { get; } = new(StringComparer.OrdinalIgnoreCase);
     public IReadOnlyCollection<string> MetadataRequests => _metadataRequests.ToArray();
 
@@ -156,6 +162,12 @@ public sealed class Program
 
     /// <summary>Gets the <c>application_type</c> field from the most recent Dynamic Client Registration request.</summary>
     public string? LastApplicationType { get; private set; }
+
+    /// <summary>Gets the <c>token_endpoint_auth_method</c> field from the most recent Dynamic Client Registration request.</summary>
+    public string? LastRegistrationTokenEndpointAuthMethod { get; private set; }
+
+    /// <summary>Gets the authentication method used by the most recent successful token request.</summary>
+    public string? LastTokenEndpointAuthMethod { get; private set; }
 
     /// <summary>
     /// Entry point for the application.
@@ -231,6 +243,7 @@ public sealed class Program
             ClientId = _clientMetadataDocumentUrl,
 
             RequiresClientSecret = false,
+            TokenEndpointAuthMethod = "none",
             RedirectUris = ["http://localhost:1179/callback"],
         };
 
@@ -725,6 +738,7 @@ public sealed class Program
 
             LastRegistrationScope = registrationRequest.Scope;
             LastApplicationType = registrationRequest.ApplicationType;
+            LastRegistrationTokenEndpointAuthMethod = registrationRequest.TokenEndpointAuthMethod;
 
             // Validate redirect URIs are provided
             if (registrationRequest.RedirectUris.Count == 0)
@@ -752,15 +766,21 @@ public sealed class Program
 
             // Generate client credentials
             var clientId = $"dyn-{Guid.NewGuid():N}";
-            var clientSecret = GenerateRandomToken();
+            var registeredTokenEndpointAuthMethod =
+                DynamicRegistrationTokenEndpointAuthMethod ??
+                registrationRequest.TokenEndpointAuthMethod ??
+                "client_secret_post";
+            var requiresClientSecret = registeredTokenEndpointAuthMethod != "none";
+            var clientSecret = requiresClientSecret ? GenerateRandomToken() : null;
             var issuedAt = DateTimeOffset.UtcNow;
 
             // Store the registered client
             _clients[clientId] = new ClientInfo
             {
                 ClientId = clientId,
-                RequiresClientSecret = true,
+                RequiresClientSecret = requiresClientSecret,
                 ClientSecret = clientSecret,
+                TokenEndpointAuthMethod = registeredTokenEndpointAuthMethod,
                 RedirectUris = registrationRequest.RedirectUris,
             };
 
@@ -772,7 +792,7 @@ public sealed class Program
                 RedirectUris = registrationRequest.RedirectUris,
                 GrantTypes = ["authorization_code", "refresh_token"],
                 ResponseTypes = ["code"],
-                TokenEndpointAuthMethod = "client_secret_post",
+                TokenEndpointAuthMethod = DynamicRegistrationTokenEndpointAuthMethod,
             };
 
             return Results.Ok(registrationResponse);
@@ -812,6 +832,31 @@ public sealed class Program
     {
         var clientId = form["client_id"].ToString();
         var clientSecret = form["client_secret"].ToString();
+        var tokenEndpointAuthMethod = string.IsNullOrEmpty(clientSecret) ? "none" : "client_secret_post";
+
+        var authorization = context.Request.Headers.Authorization.ToString();
+        if (authorization.StartsWith("Basic ", StringComparison.Ordinal))
+        {
+            string decodedCredentials;
+            try
+            {
+                decodedCredentials = Encoding.UTF8.GetString(Convert.FromBase64String(authorization["Basic ".Length..]));
+            }
+            catch (FormatException)
+            {
+                return null;
+            }
+
+            var separatorIndex = decodedCredentials.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                return null;
+            }
+
+            clientId = Uri.UnescapeDataString(decodedCredentials[..separatorIndex]);
+            clientSecret = Uri.UnescapeDataString(decodedCredentials[(separatorIndex + 1)..]);
+            tokenEndpointAuthMethod = "client_secret_basic";
+        }
 
         if (string.IsNullOrEmpty(clientId) || !_clients.TryGetValue(clientId, out var client))
         {
@@ -823,6 +868,13 @@ public sealed class Program
             return null;
         }
 
+        if (client.TokenEndpointAuthMethod is not null &&
+            !string.Equals(client.TokenEndpointAuthMethod, tokenEndpointAuthMethod, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        LastTokenEndpointAuthMethod = tokenEndpointAuthMethod;
         return client;
     }
 


### PR DESCRIPTION
Add ClientOAuthOptions.TokenEndpointAuthMethod to override the token_endpoint_auth_method otherwise inferred from DCR or the server's advertised methods. Needed for CIMD public clients that must use "none" even when the server advertises client_secret_basic first (e.g. Auth0). An explicit value now takes precedence over the DCR-returned method.

  ## Motivation and Context
  When a client does not explicitly configure a token endpoint authentication method, `ClientOAuthProvider` infers it — from the dynamic client registration (DCR) response when DCR is used, otherwise from the first entry in the authorization server's `token_endpoint_auth_methods_supported`.

  That inference is wrong for a public client identified by a Client ID Metadata Document (CIMD). Such a client has no secret and must authenticate with `"none"` (relying on PKCE). But some authorization servers (e.g. Auth0) advertise `client_secret_basic` ahead of `none`, so the client falls back to `client_secret_basic`, sends the client id with an empty secret in the `Authorization` header instead of placing the client id in the body, and the token exchange fails. This makes CIMD against such servers impossible today.

  There was previously no way for the caller to override this. This PR adds `ClientOAuthOptions.TokenEndpointAuthMethod` so the method can be set explicitly, and makes an explicitly-configured value take precedence over the value returned by DCR.

  ## How Has This Been Tested?
  Tested with our real application which uses CIMD and Auth0 as it's authorization server.

  Added two integration tests in `AuthTests` exercising a CIMD client against a test OAuth server configured (Auth0-like) to advertise `client_secret_basic` ahead of `none`:
  - `CannotAuthenticate_WithClientMetadataDocument_WhenServerAdvertisesClientSecretBasicFirst` — confirms the failure when no explicit method is set.
  - `CanAuthenticate_WithClientMetadataDocument_AndExplicitNoneAuthMethod` — confirms success when `TokenEndpointAuthMethod = "none"` is set explicitly.

  The test OAuth server gained a configurable `SupportedTokenEndpointAuthMethods` property to mimic these servers. All 40 `OAuth.AuthTests` pass locally on net8.0, net9.0, and net10.0.

  ## Breaking Changes
  None. The new property is optional and defaults to `null`, preserving the existing inference behavior. The DCR code path now uses `??=` so it only applies the registration-returned method when no explicit value was configured — unchanged for callers who don't set the new property.

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update

  ## Checklist
  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
  - [x] My code follows the repository's style guidelines
  - [x] New and existing tests pass locally
  - [x] I have added appropriate error handling (none needed — the token request path already defaults unrecognized auth methods to client_secret_post; this change adds no new failure
  modes)
  - [x] I have added or updated documentation as needed

  ## Additional context
  Fixes #1612.

  The override is implemented in `PerformDynamicClientRegistrationAsync` by changing the assignment of the registration-returned method from `=` to `??=`, and by seeding `_tokenEndpointAuthMethod` from `options.TokenEndpointAuthMethod` in the constructor. The new property's XML docs describe the inference fallback and call out the CIMD/public-client case explicitly.