### PR TITLE
fix: ignore empty Streamable HTTP JSON responses

### DIFF
--- a/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs
@@ -115,7 +115,10 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
         if (response.Content.Headers.ContentType?.MediaType == "application/json")
         {
             var responseContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            rpcResponseOrError = await ProcessMessageAsync(responseContent, rpcRequest, cancellationToken).ConfigureAwait(false);
+            if (responseContent.Length > 0)
+            {
+                rpcResponseOrError = await ProcessMessageAsync(responseContent, rpcRequest, cancellationToken).ConfigureAwait(false);
+            }
         }
         else if (response.Content.Headers.ContentType?.MediaType == "text/event-stream")
         {

--- a/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportTests.cs
@@ -148,6 +148,40 @@ public class HttpClientTransportTests : LoggedTest
     }
 
     [Fact]
+    public async Task StreamableHttp_NotificationWithEmptyAcceptedJsonResponse_DoesNotLogParseFailure()
+    {
+        var options = new HttpClientTransportOptions
+        {
+            Endpoint = new Uri("http://localhost:8080/mcp"),
+            TransportMode = HttpTransportMode.StreamableHttp,
+        };
+
+        using var mockHttpHandler = new MockHttpHandler();
+        using var httpClient = new HttpClient(mockHttpHandler);
+        await using var transport = new HttpClientTransport(options, httpClient, LoggerFactory);
+
+        mockHttpHandler.RequestHandler = request =>
+        {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("http://localhost:8080/mcp", request.RequestUri?.AbsoluteUri);
+
+            return Task.FromResult(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Accepted,
+                Content = new StringContent("", Encoding.UTF8, "application/json"),
+            });
+        };
+
+        await using var session = await transport.ConnectAsync(TestContext.Current.CancellationToken);
+        await session.SendMessageAsync(
+            new JsonRpcNotification { Method = "notifications/initialized" },
+            TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(MockLoggerProvider.LogMessages, log =>
+            log.Message.Contains("transport message parsing failed", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task SendMessageAsync_Throws_HttpRequestException_With_ResponseBody_On_ErrorStatusCode()
     {
         using var mockHttpHandler = new MockHttpHandler();


### PR DESCRIPTION
Fixes #1132.

## Summary

This avoids a noisy JSON parse failure when a Streamable HTTP notification POST receives a successful empty JSON response.

## Changes

- Skip JSON-RPC parsing for empty Streamable HTTP `application/json` response bodies.
- Add regression coverage for notification POSTs that receive `202 Accepted` with an empty JSON body.
- Preserve the existing request behavior where a completed POST without a reply still fails as a missing reply.

## Verification

```bash
dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj --framework net10.0 --filter 'FullyQualifiedName~HttpClientTransportTests.StreamableHttp_NotificationWithEmptyAcceptedJsonResponse_DoesNotLogParseFailure'
dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj --framework net10.0 --filter 'FullyQualifiedName~HttpClientTransportTests' --no-restore
dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj --framework net10.0 --filter 'FullyQualifiedName~HttpClientTransportAutoDetectTests' --no-restore
dotnet test tests/ModelContextProtocol.AspNetCore.Tests/ModelContextProtocol.AspNetCore.Tests.csproj --framework net10.0 --filter 'FullyQualifiedName~StreamableHttpClientConformanceTests'
dotnet build src/ModelContextProtocol.Core/ModelContextProtocol.Core.csproj --framework net10.0 --no-restore
dotnet build tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj --framework net10.0 --no-restore
```
