### PR TITLE
Fix flaky AddIncomingMessageFilter_Multiple_Filters_Execute_In_Order test

### DIFF
--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsMessageFilterTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsMessageFilterTests.cs
@@ -100,6 +100,12 @@ public class McpServerBuilderExtensionsMessageFilterTests(ITestOutputHelper test
     [Fact]
     public async Task AddIncomingMessageFilter_Multiple_Filters_Execute_In_Order()
     {
+        // The client sends notifications/initialized fire-and-forget, so unlike the initialize and
+        // tools/list request/response exchanges it has no synchronization point the test can await.
+        // Signal once the outermost filter finishes processing it so the strict counts below observe a
+        // complete, stable log instead of racing the still-in-flight notification.
+        var initializedNotificationProcessed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
         McpServerBuilder
             .WithMessageFilters(filters =>
             {
@@ -109,6 +115,11 @@ public class McpServerBuilderExtensionsMessageFilterTests(ITestOutputHelper test
                     logger.LogInformation("MessageFilter1 before");
                     await next(context, cancellationToken);
                     logger.LogInformation("MessageFilter1 after");
+
+                    if (context.JsonRpcMessage is JsonRpcNotification { Method: NotificationMethods.InitializedNotification })
+                    {
+                        initializedNotificationProcessed.TrySetResult(true);
+                    }
                 });
 
                 filters.AddIncomingFilter((next) => async (context, cancellationToken) =>
@@ -126,6 +137,10 @@ public class McpServerBuilderExtensionsMessageFilterTests(ITestOutputHelper test
         await using McpClient client = await CreateMcpClientForServer();
 
         await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Wait for the fire-and-forget initialized notification to flow through the filter pipeline
+        // before snapshotting the log; otherwise the strict counts below can race the notification.
+        await initializedNotificationProcessed.Task.WaitAsync(TestConstants.DefaultTimeout, TestContext.Current.CancellationToken);
 
         var logMessages = MockLoggerProvider.LogMessages
             .Where(m => m.Category.StartsWith("MessageFilter"))


### PR DESCRIPTION
## Summary

Fixes a flaky test: `McpServerBuilderExtensionsMessageFilterTests.AddIncomingMessageFilter_Multiple_Filters_Execute_In_Order`. It intermittently fails on CI with `Assert.Equal() Failure: Expected: 3, Actual: 2` (observed on the net8.0 leg, but the race is framework-independent).

## Root cause

The test asserts each incoming message filter runs exactly three times, once per message: `initialize`, `notifications/initialized`, and `tools/list`.

- `initialize` and `tools/list` are request/response exchanges, so awaiting the corresponding client calls guarantees their filter passes have completed.
- `notifications/initialized` is sent **fire-and-forget** by the client. It has no synchronization point, so it can still be in flight when `ListToolsAsync` returns. When that happens the strict counts are only `2` and the test fails.

## Fix

Add a `TaskCompletionSource` that the outermost filter completes once it has finished processing the initialized notification, and await it before snapshotting the log. This mirrors the existing `TaskCompletionSource` pattern already used elsewhere in this test file (`AddOutgoingMessageFilter_Can_Send_Additional_Messages`), keeps the strict count assertions intact, and introduces no timing-based delays.

## Verification

- Ran the affected test 8x in a row on net8.0: all pass.
- Full `McpServerBuilderExtensionsMessageFilterTests` class passes on net8.0, net9.0, net10.0, and net472 (21/21 each).
