### PR TITLE
Reply with JSON-RPC parse error for over-nested stdio requests

### DIFF
--- a/src/ModelContextProtocol.Core/Server/StreamServerTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamServerTransport.cs
@@ -160,7 +160,8 @@ public class StreamServerTransport : TransportBase
                         }
                         catch (Exception sendEx) when (sendEx is not OperationCanceledException)
                         {
-                            LogTransportSendFailed(Name, id.ToString(), sendEx);
+                            // Swallow so a failed error-send does not tear down the read loop. No logging
+                            // here because SendMessageAsync already logs send failures before it throws.
                         }
                     }
                 }
@@ -249,9 +250,12 @@ public class StreamServerTransport : TransportBase
                 reader.Skip();
             }
         }
-        catch (JsonException)
+        catch (Exception)
         {
-            // The line was too malformed to even locate a top-level id; nothing to correlate.
+            // Recovery is best effort. Whether the line was too malformed to locate a top-level id or
+            // the reader failed for any other reason, swallow it here and return false. Letting an
+            // exception escape would propagate out of the read loop and disconnect the transport,
+            // turning a single bad message into a full session teardown.
         }
 
         return false;

--- a/src/ModelContextProtocol.Core/Server/StreamServerTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamServerTransport.cs
@@ -137,7 +137,32 @@ public class StreamServerTransport : TransportBase
                         LogTransportMessageParseFailed(Name, ex);
                     }
 
-                    // Continue reading even if we fail to parse a message
+                    // Deserializing the full message failed, for example because the params object was nested
+                    // more deeply than the JSON reader's MaxDepth allows. If the message still carried a request
+                    // id, reply with a JSON-RPC parse error using that id so the caller's pending request
+                    // completes instead of hanging until it times out. If no id can be recovered, the message
+                    // was either a notification or too malformed to correlate, so we just continue reading.
+                    if (TryRecoverRequestId(line, out RequestId id))
+                    {
+                        var errorResponse = new JsonRpcError
+                        {
+                            Id = id,
+                            Error = new JsonRpcErrorDetail
+                            {
+                                Code = (int)McpErrorCode.ParseError,
+                                Message = "Failed to parse the JSON-RPC request.",
+                            },
+                        };
+
+                        try
+                        {
+                            await SendMessageAsync(errorResponse, shutdownToken).ConfigureAwait(false);
+                        }
+                        catch (Exception sendEx) when (sendEx is not OperationCanceledException)
+                        {
+                            LogTransportSendFailed(Name, id.ToString(), sendEx);
+                        }
+                    }
                 }
             }
         }
@@ -154,6 +179,82 @@ public class StreamServerTransport : TransportBase
         {
             SetDisconnected(error);
         }
+    }
+
+    /// <summary>
+    /// Attempts to recover the JSON-RPC request id from a line that failed full deserialization.
+    /// </summary>
+    /// <remarks>
+    /// This walks only the top-level object looking for an "id" property and skips every other value,
+    /// using a large reader depth so a deeply nested "params" value cannot make recovery itself fail.
+    /// </remarks>
+    private static bool TryRecoverRequestId(string line, out RequestId id)
+    {
+        id = default;
+
+        try
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(line);
+            var reader = new Utf8JsonReader(utf8, new JsonReaderOptions
+            {
+                // Use the maximum reader depth so that an over-nested "params" value cannot make id
+                // recovery throw for the same reason the original parse did.
+                MaxDepth = int.MaxValue,
+            });
+
+            if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+            {
+                return false;
+            }
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    break;
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    continue;
+                }
+
+                bool isId = reader.ValueTextEquals("id"u8);
+
+                if (!reader.Read())
+                {
+                    break;
+                }
+
+                if (isId)
+                {
+                    switch (reader.TokenType)
+                    {
+                        case JsonTokenType.String:
+                            id = new RequestId(reader.GetString()!);
+                            return true;
+
+                        case JsonTokenType.Number when reader.TryGetInt64(out long longId):
+                            id = new RequestId(longId);
+                            return true;
+
+                        default:
+                            // An id that is neither a string nor an integer cannot be correlated, so
+                            // there is no point sending an error response for it.
+                            return false;
+                    }
+                }
+
+                // Skip the value of any property other than id, including a deeply nested params object.
+                reader.Skip();
+            }
+        }
+        catch (JsonException)
+        {
+            // The line was too malformed to even locate a top-level id; nothing to correlate.
+        }
+
+        return false;
     }
 
     /// <inheritdoc />

--- a/tests/ModelContextProtocol.Tests/Transport/StdioServerTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioServerTransportTests.cs
@@ -279,6 +279,51 @@ public class StdioServerTransportTests : LoggedTest
     }
 
     [Fact]
+    public async Task ReadMessagesAsync_Should_Respond_With_ParseError_For_Request_Exceeding_MaxDepth()
+    {
+        // Build a ping request whose params nest more deeply than System.Text.Json's default
+        // reader MaxDepth of 64, which is what makes full deserialization throw. The request still
+        // carries an id, so the transport should reply with a JSON-RPC parse error for that id rather
+        // than dropping the request and leaving the caller pending.
+        var nested = new StringBuilder();
+        const int depth = 100;
+        for (int i = 0; i < depth; i++)
+        {
+            nested.Append("{\"p").Append(i).Append("\":");
+        }
+        nested.Append("{\"leaf\":true}");
+        nested.Append('}', depth);
+
+        var requestLine = $"{{\"jsonrpc\":\"2.0\",\"id\":900100,\"method\":\"ping\",\"params\":{nested}}}";
+
+        Pipe inputPipe = new();
+        Pipe outputPipe = new();
+        using var input = inputPipe.Reader.AsStream();
+        using var output = outputPipe.Writer.AsStream();
+
+        await using var transport = new StreamServerTransport(
+            input,
+            output,
+            loggerFactory: LoggerFactory);
+
+        await inputPipe.Writer.WriteAsync(Encoding.UTF8.GetBytes($"{requestLine}\n"), TestContext.Current.CancellationToken);
+
+        // Read the single response line the transport writes back to the output stream.
+        using var responseReader = new StreamReader(outputPipe.Reader.AsStream(), Encoding.UTF8);
+        var responseLine = await responseReader.ReadLineAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(responseLine);
+
+        var response = JsonSerializer.Deserialize<JsonRpcMessage>(responseLine!, McpJsonUtilities.DefaultOptions);
+        var error = Assert.IsType<JsonRpcError>(response);
+        Assert.Equal("900100", error.Id.ToString());
+        Assert.Equal((int)McpErrorCode.ParseError, error.Error.Code);
+
+        // The transport should still be reading further messages after recovering from the bad one.
+        Assert.True(transport.IsConnected);
+    }
+
+    [Fact]
     public async Task ReadMessagesAsync_Should_Log_Received_At_Trace_Level()
     {
         // Arrange

--- a/tests/ModelContextProtocol.Tests/Transport/StdioServerTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioServerTransportTests.cs
@@ -310,7 +310,11 @@ public class StdioServerTransportTests : LoggedTest
 
         // Read the single response line the transport writes back to the output stream.
         using var responseReader = new StreamReader(outputPipe.Reader.AsStream(), Encoding.UTF8);
-        var responseLine = await responseReader.ReadLineAsync(TestContext.Current.CancellationToken);
+        var responseLine = await responseReader.ReadLineAsync(
+#if NET
+            TestContext.Current.CancellationToken
+#endif
+        );
 
         Assert.NotNull(responseLine);
 


### PR DESCRIPTION
Fixes #1614

A stdio JSON-RPC request whose params nest deeper than the JSON reader's default MaxDepth of 64 left the id-bearing request pending forever while the server stayed healthy. In StreamServerTransport.ReadMessagesAsync the whole line is deserialized in one shot, and the polymorphic JsonRpcMessage converter reads params as a JsonNode. Once nesting exceeds MaxDepth that read throws a JsonException, which the read loop logged and then swallowed with a continue. The request id was parsed off the wire but lost when the exception unwound, so no response ever reached the client and the caller waited until it timed out, even though later shallow requests still succeeded. The session-level error handling that normally turns a thrown JsonException into a parse-error response never runs here because the message never deserializes into a JsonRpcRequest, so it never reaches the session.

This change makes the read loop recover the request id from the raw line when full parsing fails and reply with a JSON-RPC parse error for that id, so the caller's pending request completes promptly instead of hanging. Id recovery walks only the top-level object with an elevated reader depth and skips every other value, including a deeply nested params, so recovery cannot fail for the same depth reason the original parse did. A message with no recoverable id, such as a notification or a line too malformed to correlate, keeps the previous behavior of logging and continuing.

This mirrors the prompt rejection the HTTP transports already give for the same payload, where depth 64 returns immediately rather than leaving the request pending.

Added a regression test in StdioServerTransportTests that feeds a ping request with params nested 100 levels deep and asserts the transport writes back a JsonRpcError carrying the original id and the ParseError code, and that the transport stays connected for further reads. Verified the test hangs to a timeout without the fix and passes with it. Ran the StdioServerTransportTests suite on net10.0, all 13 tests pass.