### PR TITLE
Enable netfx UI MCP clients

### DIFF
--- a/src/ModelContextProtocol.Core/Client/StdioClientTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/StdioClientTransport.cs
@@ -187,14 +187,29 @@ public sealed partial class StdioClientTransport : IClientTransport
             lock (s_consoleEncodingLock)
             {
                 Encoding originalInputEncoding = Console.InputEncoding;
+                bool encodingChanged = false;
                 try
                 {
-                    Console.InputEncoding = StreamClientSessionTransport.NoBomUtf8Encoding;
+                    try
+                    {
+                        Console.InputEncoding = StreamClientSessionTransport.NoBomUtf8Encoding;
+                        encodingChanged = true;
+                    }
+                    catch
+                    {
+                        // Host has no usable console (e.g. WPF/WinForms on .NET Framework with no
+                        // AllocConsole). The child inherits the current Console.InputEncoding;
+                        // non-ASCII stdin may be misencoded, but the connect itself proceeds.
+                    }
+
                     processStarted = process.Start();
                 }
                 finally
                 {
-                    Console.InputEncoding = originalInputEncoding;
+                    if (encodingChanged)
+                    {
+                        Console.InputEncoding = originalInputEncoding;
+                    }
                 }
             }
 #endif


### PR DESCRIPTION
## Motivation and Context
Fixes #1638 - allows netfx UI MCP clients to talk to stdio servers 

## How Has This Been Tested?
I built my own MCP.Code.dll and it worked

## Breaking Changes
none

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Earlier (incorrect) attempt at https://github.com/modelcontextprotocol/csharp-sdk/pull/694
