### PR TITLE
Accept "type":"number" as a valid x-mcp-header primitive per SEP-2243

### DIFF
--- a/src/ModelContextProtocol.Core/Client/McpHeaderExtractor.cs
+++ b/src/ModelContextProtocol.Core/Client/McpHeaderExtractor.cs
@@ -267,16 +267,16 @@ internal static class McpHeaderExtractor
                 return false;
             }
 
-            // MUST only be applied to parameters with primitive types (string, integer, boolean).
-            // Parameters with type "number" (or any other non-primitive type) are not permitted.
-            // The "type" keyword may be omitted (treated as unknown, not rejected, since many valid
-            // schemas constrain the value via enum/const/$ref instead) or expressed as a JSON Schema
-            // union array such as ["string", "null"]; only an explicitly disallowed or malformed type
+            // MUST only be applied to parameters with primitive types (number, string, boolean) per
+            // SEP-2243. We also accept "integer" as a JSON Schema refinement of "number". The "type"
+            // keyword may be omitted (treated as unknown, not rejected, since many valid schemas
+            // constrain the value via enum/const/$ref instead) or expressed as a JSON Schema union
+            // array such as ["string", "null"]; only an explicitly disallowed or malformed type
             // causes rejection.
             if (property.Value.TryGetProperty("type", out var typeElement) &&
                 !IsAllowedHeaderType(typeElement))
             {
-                rejectionReason = $"Tool '{tool.Name}': x-mcp-header on property '{property.Name}' has unsupported type '{typeElement}'. Only 'string', 'integer', and 'boolean' are allowed.";
+                rejectionReason = $"Tool '{tool.Name}': x-mcp-header on property '{property.Name}' has unsupported type '{typeElement}'. Only 'string', 'integer', 'number', and 'boolean' are allowed.";
                 return false;
             }
         }
@@ -286,10 +286,11 @@ internal static class McpHeaderExtractor
 
     /// <summary>
     /// Determines whether a JSON Schema <c>type</c> keyword is compatible with <c>x-mcp-header</c>,
-    /// which per SEP-2243 may only be applied to <c>string</c>, <c>integer</c>, or <c>boolean</c>
-    /// parameters. A union array (e.g., <c>["string", "null"]</c>) is allowed as long as it contains
-    /// at least one allowed primitive; <c>"null"</c> is tolerated only as an additional union member.
-    /// Any other shape (a disallowed type name, a non-string array element, an empty array, or a
+    /// which per SEP-2243 may only be applied to <c>number</c>, <c>string</c>, or <c>boolean</c>
+    /// parameters. We additionally accept <c>integer</c> as a JSON Schema refinement of <c>number</c>.
+    /// A union array (e.g., <c>["string", "null"]</c>) is allowed as long as it contains at least
+    /// one allowed primitive; <c>"null"</c> is tolerated only as an additional union member. Any
+    /// other shape (a disallowed type name, a non-string array element, an empty array, or a
     /// non-string/non-array value) is treated as incompatible.
     /// </summary>
     private static bool IsAllowedHeaderType(JsonElement typeElement)
@@ -331,7 +332,7 @@ internal static class McpHeaderExtractor
     }
 
     private static bool IsAllowedPrimitiveTypeName(string? typeName) =>
-        typeName is "string" or "integer" or "boolean";
+        typeName is "string" or "integer" or "number" or "boolean";
 
     // Valid HTTP token characters (tchar) per RFC 9110 Section 5.6.2:
     // tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /

--- a/tests/ModelContextProtocol.AspNetCore.Tests/AddKnownToolsHeaderTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/AddKnownToolsHeaderTests.cs
@@ -342,6 +342,74 @@ public class AddKnownToolsHeaderTests(ITestOutputHelper outputHelper) : KestrelI
         Assert.Empty(headers);
     }
 
+    private static Tool CreateToolWithNumberHeaders()
+    {
+        // Schema using "type": "number" for both an integer-valued and a fractional-valued
+        // header parameter. Per SEP-2243 the "number" primitive type is permitted alongside
+        // "string" and "boolean"; unlike "integer", values aren't canonicalized — they are
+        // emitted using their raw JSON representation.
+        var schemaJson = """
+            {
+                "type": "object",
+                "properties": {
+                    "priority": {
+                        "type": "number",
+                        "x-mcp-header": "Priority"
+                    },
+                    "ratio": {
+                        "type": "number",
+                        "x-mcp-header": "Ratio"
+                    }
+                },
+                "required": ["priority", "ratio"]
+            }
+            """;
+
+        return new Tool
+        {
+            Name = "number_tool",
+            InputSchema = JsonDocument.Parse(schemaJson).RootElement.Clone(),
+        };
+    }
+
+    [Theory]
+    [InlineData("2", "0.5", "2", "0.5")]
+    [InlineData("42", "3.14", "42", "3.14")]
+    [InlineData("-7", "-0.25", "-7", "-0.25")]
+    public async Task CallTool_NumberType_EmitsRawJsonNumberHeader(
+        string priorityValue,
+        string ratioValue,
+        string expectedPriorityHeader,
+        string expectedRatioHeader)
+    {
+        await StartAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new("http://localhost:5000/mcp"),
+            TransportMode = HttpTransportMode.StreamableHttp,
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(transport, loggerFactory: LoggerFactory,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        client.AddKnownTools([CreateToolWithNumberHeaders()]);
+
+        var result = await client.CallToolAsync(
+            "number_tool",
+            new Dictionary<string, object?>
+            {
+                ["priority"] = JsonDocument.Parse(priorityValue).RootElement,
+                ["ratio"] = JsonDocument.Parse(ratioValue).RootElement,
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        var headers = _capturedHeaders.Values.First();
+        Assert.Equal(expectedPriorityHeader, headers["Mcp-Param-Priority"]);
+        Assert.Equal(expectedRatioHeader, headers["Mcp-Param-Ratio"]);
+    }
+
     private static Tool CreateToolWithSingleHeader(string toolName, string headerName)
     {
         var schemaJson = $$"""

--- a/tests/ModelContextProtocol.Tests/Client/McpHeaderExtractorValidationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpHeaderExtractorValidationTests.cs
@@ -10,7 +10,8 @@ namespace ModelContextProtocol.Tests.Client;
 /// <summary>
 /// Tests for SEP-2243 x-mcp-header validation changes:
 /// - RFC 9110 tchar validation for header names
-/// - "number" type rejection (only integer/string/boolean allowed)
+/// - "number" type acceptance (along with integer/string/boolean) per the SEP's
+///   "primitive types (number, string, boolean)" rule
 /// - Nested property support for x-mcp-header annotations
 /// </summary>
 public class McpHeaderExtractorValidationTests : ClientServerTestBase
@@ -27,7 +28,7 @@ public class McpHeaderExtractorValidationTests : ClientServerTestBase
             (string input) => $"echo {input}",
             new() { Name = "ValidTool" })]);
 
-        // Tool with "number" type (should be rejected per updated SEP-2243)
+        // Tool with "number" type (should be accepted per SEP-2243 "number, string, boolean" rule)
         var numberTool = McpServerTool.Create((string x) => x, new() { Name = "NumberTypeTool" });
         numberTool.ProtocolTool.InputSchema = JsonDocument.Parse("""
             { "type": "object", "properties": { "value": { "type": "number", "x-mcp-header": "Value" } } }
@@ -40,6 +41,13 @@ public class McpHeaderExtractorValidationTests : ClientServerTestBase
             { "type": "object", "properties": { "count": { "type": "integer", "x-mcp-header": "Count" } } }
             """).RootElement.Clone();
         mcpServerBuilder.WithTools([integerTool]);
+
+        // Tool with "array" type (should be rejected - not a primitive type)
+        var arrayTool = McpServerTool.Create((string x) => x, new() { Name = "ArrayTypeTool" });
+        arrayTool.ProtocolTool.InputSchema = JsonDocument.Parse("""
+            { "type": "object", "properties": { "value": { "type": "array", "items": { "type": "string" }, "x-mcp-header": "Value" } } }
+            """).RootElement.Clone();
+        mcpServerBuilder.WithTools([arrayTool]);
 
         // Tool with non-tchar header name (should be rejected)
         var nonTcharTool = McpServerTool.Create((string x) => x, new() { Name = "BadTcharTool" });
@@ -69,7 +77,7 @@ public class McpHeaderExtractorValidationTests : ClientServerTestBase
             """).RootElement.Clone();
         mcpServerBuilder.WithTools([duplicateTool]);
 
-        // Tool with nested "number" type (should be rejected)
+        // Tool with nested "number" type (should be accepted per SEP-2243)
         var nestedNumberTool = McpServerTool.Create((string x) => x, new() { Name = "NestedNumberTool" });
         nestedNumberTool.ProtocolTool.InputSchema = JsonDocument.Parse("""
             { "type": "object", "properties": { "config": { "type": "object", "properties": { "threshold": { "type": "number", "x-mcp-header": "Threshold" } } } } }
@@ -83,7 +91,7 @@ public class McpHeaderExtractorValidationTests : ClientServerTestBase
             """).RootElement.Clone();
         mcpServerBuilder.WithTools([nullableUnionTool]);
 
-        // Tool with a union type containing a disallowed type ["number", "null"] (should be rejected)
+        // Tool with a union type containing "number" and "null" (should be accepted)
         var numberUnionTool = McpServerTool.Create((string x) => x, new() { Name = "NumberUnionTool" });
         numberUnionTool.ProtocolTool.InputSchema = JsonDocument.Parse("""
             { "type": "object", "properties": { "value": { "type": ["number", "null"], "x-mcp-header": "Value" } } }
@@ -106,18 +114,13 @@ public class McpHeaderExtractorValidationTests : ClientServerTestBase
     }
 
     [Fact]
-    public async Task ListToolsAsync_NumberType_ExcludesTool()
+    public async Task ListToolsAsync_NumberType_AcceptsTool()
     {
         await using var client = await CreateMcpClientForServer();
         var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Contains(tools, t => t.Name == "ValidTool");
-        Assert.DoesNotContain(tools, t => t.Name == "NumberTypeTool");
-
-        Assert.Contains(MockLoggerProvider.LogMessages, log =>
-            log.LogLevel == LogLevel.Warning &&
-            log.Message.Contains("NumberTypeTool") &&
-            log.Message.Contains("excluded"));
+        Assert.Contains(tools, t => t.Name == "NumberTypeTool");
     }
 
     [Fact]
@@ -127,6 +130,21 @@ public class McpHeaderExtractorValidationTests : ClientServerTestBase
         var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Contains(tools, t => t.Name == "IntegerTypeTool");
+    }
+
+    [Fact]
+    public async Task ListToolsAsync_ArrayType_ExcludesTool()
+    {
+        await using var client = await CreateMcpClientForServer();
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Contains(tools, t => t.Name == "ValidTool");
+        Assert.DoesNotContain(tools, t => t.Name == "ArrayTypeTool");
+
+        Assert.Contains(MockLoggerProvider.LogMessages, log =>
+            log.LogLevel == LogLevel.Warning &&
+            log.Message.Contains("ArrayTypeTool") &&
+            log.Message.Contains("excluded"));
     }
 
     [Fact]
@@ -169,13 +187,12 @@ public class McpHeaderExtractorValidationTests : ClientServerTestBase
     }
 
     [Fact]
-    public async Task ListToolsAsync_NestedNumberType_ExcludesTool()
+    public async Task ListToolsAsync_NestedNumberType_AcceptsTool()
     {
         await using var client = await CreateMcpClientForServer();
         var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.Contains(tools, t => t.Name == "ValidTool");
-        Assert.DoesNotContain(tools, t => t.Name == "NestedNumberTool");
+        Assert.Contains(tools, t => t.Name == "NestedNumberTool");
     }
 
     [Fact]
@@ -188,13 +205,12 @@ public class McpHeaderExtractorValidationTests : ClientServerTestBase
     }
 
     [Fact]
-    public async Task ListToolsAsync_NumberUnionType_ExcludesTool()
+    public async Task ListToolsAsync_NumberUnionType_AcceptsTool()
     {
         await using var client = await CreateMcpClientForServer();
         var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.Contains(tools, t => t.Name == "ValidTool");
-        Assert.DoesNotContain(tools, t => t.Name == "NumberUnionTool");
+        Assert.Contains(tools, t => t.Name == "NumberUnionTool");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Accept `"type":"number"` as a valid `x-mcp-header` primitive per SEP-2243.

## Bug

The SEP-2243 spec (`docs/specification/draft/server/tools.mdx:340`) defines the allowed `x-mcp-header` primitive types as:

> **MUST** only be applied to parameters with primitive types (**number**, string, boolean)

Our `McpHeaderExtractor.ValidateToolSchema` was rejecting tools whose `x-mcp-header` annotation targeted a property with `"type":"number"`, contradicting the spec. The upstream conformance scenario `http-custom-headers` declares `priority` and `float_val` as `"type":"number"` and expects them to be emitted as `Mcp-Param-Priority` / `Mcp-Param-FloatVal` headers. Because the validator rejected those tools, the client never cached them, so when the test then called them by name the client sent the request with no `Mcp-Param-*` headers at all — failing the conformance scenario.

This was only visible after the `@modelcontextprotocol/conformance` npm pin is bumped past `0.1.16` (work being done on top of `main` in PR #1610) — on the currently-pinned suite the SEP-2243 scenarios are gated out.

## Fix

One-line behavioral change in `IsAllowedPrimitiveTypeName`:

```diff
- typeName is "string" or "integer" or "boolean";
+ typeName is "string" or "integer" or "number" or "boolean";
```

`McpHeaderEncoder.ConvertToHeaderValue` already handles `JsonValueKind.Number` by emitting `element.GetRawText()`, so number-typed values flow through the encoder unchanged — only the validator needed updating. Integer canonicalization (per the SEP's JavaScript safe-integer rule) remains restricted to `"type":"integer"`; `"type":"number"` values are emitted using their raw JSON representation (e.g. `2.5`, `3.14`, `-7`), which is what the conformance suite expects.

## Test changes

- `McpHeaderExtractorValidationTests`:
  - Three previously-asserted-as-rejected number cases (`NumberTypeTool`, `NestedNumberTool`, `NumberUnionTool`) flipped to assert acceptance.
  - New `ArrayTypeTool` retains a negative-case coverage point so the validator still rejects clearly-invalid non-primitive types.
- `AddKnownToolsHeaderTests`:
  - New `CallTool_NumberType_EmitsRawJsonNumberHeader` theory drives an end-to-end Kestrel-backed scenario asserting integer and fractional `"type":"number"` values are emitted on the wire as `Mcp-Param-*` headers using their raw JSON representation.

## Validation

- `dotnet test tests/ModelContextProtocol.Tests --filter "FullyQualifiedName~McpHeaderExtractorValidationTests"` → 12/12 pass
- `dotnet test tests/ModelContextProtocol.AspNetCore.Tests --filter "FullyQualifiedName~AddKnownToolsHeaderTests"` → 20/20 pass (including the 3 new theory rows)
- Broader header-related tests in both projects → 98 + 97 pass / 0 fail / 6 skip (skips are conformance scenarios that need the `0.2.0-alpha.2` pin bump tracked in PR #1610)

## Related

Surfaced while validating PR #1610 against the upstream `@modelcontextprotocol/conformance` `compat/conformance-draft` suite. The bug exists on `main` but is masked there because the suite version pinned on `main` (`0.1.16`, March 2026) predates the SEP-2243 scenarios. This PR fixes it directly on `main` so the fix is independent of and lands before PR #1610.
