### PR TITLE
Typo: missing space before unit "ms".

### DIFF
--- a/src/ModelContextProtocol.Core/McpSessionHandler.cs
+++ b/src/ModelContextProtocol.Core/McpSessionHandler.cs
@@ -1097,10 +1097,10 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
     [LoggerMessage(Level = LogLevel.Information, Message = "{EndpointName} method '{Method}' request handler called.")]
     private partial void LogRequestHandlerCalled(string endpointName, string method);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "{EndpointName} method '{Method}' request handler completed in {ElapsedMilliseconds}ms.")]
+    [LoggerMessage(Level = LogLevel.Information, Message = "{EndpointName} method '{Method}' request handler completed in {ElapsedMilliseconds} ms.")]
     private partial void LogRequestHandlerCompleted(string endpointName, string method, double elapsedMilliseconds);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "{EndpointName} method '{Method}' request handler failed in {ElapsedMilliseconds}ms.")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{EndpointName} method '{Method}' request handler failed in {ElapsedMilliseconds} ms.")]
     private partial void LogRequestHandlerException(string endpointName, string method, double elapsedMilliseconds, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "{EndpointName} received request for unknown request ID '{RequestId}'.")]


### PR DESCRIPTION
The message omits a space leading to text such as "105.3573ms." in:

```json
{
  "Timestamp": "2026-06-16 17:18:19",
  "EventId": 1867955179,
  "LogLevel": "Information",
  "Category": "ModelContextProtocol.Server.McpServer",
  "Message": "Server (Invantive.Mcp.Server 26.0.120.0), Client (Anthropic/ClaudeAI 1.0.0) method \u0027tools/call\u0027 request handler completed in 105.3573ms.",
  "State": {
    "EndpointName": "Server (Invantive.Mcp.Server 26.0.120.0), Client (Anthropic/ClaudeAI 1.0.0)",
    "Method": "tools/call",
    "ElapsedMilliseconds": 105.3573,
    "{OriginalFormat}": "{EndpointName} method \u0027{Method}\u0027 request handler completed in {ElapsedMilliseconds}ms."
  }
}
```

## Motivation and Context
Adding space makes logging better readable.

## How Has This Been Tested?
No, not tested.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
