### PR TITLE
Fix main build: remove dangling Tool.Execution reference in BuildLegacyWireProtocolTool

### DIFF
--- a/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
@@ -262,7 +262,6 @@ internal sealed partial class AIFunctionMcpServerTool : McpServerTool
             InputSchema = ProtocolTool.InputSchema,
             OutputSchema = legacyOutputSchema,
             Annotations = ProtocolTool.Annotations,
-            Execution = ProtocolTool.Execution,
             Icons = ProtocolTool.Icons,
             Meta = ProtocolTool.Meta,
         };


### PR DESCRIPTION
## The break

`main` currently does not compile, and its own **Build and Test** CI run is red. This blocks PR #1484 and every other PR, because they inherit the broken `main` when they merge it.

The error comes from `src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs`, inside `BuildLegacyWireProtocolTool()`:

```
AIFunctionMcpServerTool.cs(265,13): error CS0117: 'Tool' does not contain a definition for 'Execution'
AIFunctionMcpServerTool.cs(265,38): error CS1061: 'Tool' does not contain a definition for 'Execution'
```

across all target frameworks (net10.0/net9.0/net8.0/netstandard2.0). Because `TreatWarningsAsErrors=true`, the build fails outright.

## Root cause — a semantic (logical) merge conflict

- The **SEP-2663 Tasks Extension** PR (#1579, commit `dbb7a20`) intentionally **removed** the entire old `Tool.Execution` / `ToolExecution` surface (task support moved to the new Tasks capability). The removal is baselined in `src/ModelContextProtocol.Core/CompatibilitySuppressions.xml`.
- The **SEP-2106 outputSchema** PR (#1568, commit `0663b7c8`, the current `main` tip) **added** `BuildLegacyWireProtocolTool()`, which clones the `Tool` and copies every property — including the now-removed `Execution`. #1568 was based on an older `main` that still had `Tool.Execution`.

When #1568 merged on top of #1579, the result was a semantic merge conflict: a dangling `Execution = ProtocolTool.Execution,` line referencing a property that no longer exists. No textual git conflict was raised, so it merged red.

## The fix

Remove the single dangling line from the object initializer in `BuildLegacyWireProtocolTool()`:

```diff
             Annotations = ProtocolTool.Annotations,
-            Execution = ProtocolTool.Execution,
             Icons = ProtocolTool.Icons,
             Meta = ProtocolTool.Meta,
```

`Tool.Execution` is **not** re-added — its removal was the intentional SEP-2663 design, and re-adding it would resurrect a deliberately-removed API and break the compatibility baseline. A full `src/` grep confirms no other compiled references to a `.Execution` member on `Tool` or to the removed `ToolExecution` type remain (the only remaining hits are the `CompatibilitySuppressions.xml` baseline entries and unrelated names like `ExecutionContext` / `TryGetOuterToolExecutionActivity`).

## Verification

- `dotnet build -c Debug` — **succeeds for all target frameworks, 0 warnings / 0 errors**.
- SEP-2106 legacy-wire back-compat tests (`Sep2106ListToolsBackCompatTests`, which exercise `BuildLegacyWireProtocolTool`) — **21/21 pass**.
- Full `tests/ModelContextProtocol.Tests` (net10.0) — all **2070** non-environment tests pass. The only failures are pre-existing, environment-dependent tests unrelated to this change (stdio tests that spawn `TestServer.exe`, which isn't on `PATH` here, and a Docker-dependent test).

This unblocks PR #1484 and all other PRs by getting `main` green again.