### PR TITLE
Apply default tool annotation hints from McpServerToolAttribute

### DIFF
--- a/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
@@ -167,25 +167,10 @@ internal sealed partial class AIFunctionMcpServerTool : McpServerTool
             newOptions.Name ??= toolAttr.Name;
             newOptions.Title ??= toolAttr.Title;
 
-            if (toolAttr._destructive is bool destructive)
-            {
-                newOptions.Destructive ??= destructive;
-            }
-
-            if (toolAttr._idempotent is bool idempotent)
-            {
-                newOptions.Idempotent ??= idempotent;
-            }
-
-            if (toolAttr._openWorld is bool openWorld)
-            {
-                newOptions.OpenWorld ??= openWorld;
-            }
-
-            if (toolAttr._readOnly is bool readOnly)
-            {
-                newOptions.ReadOnly ??= readOnly;
-            }
+            newOptions.Destructive ??= toolAttr.Destructive;
+            newOptions.Idempotent ??= toolAttr.Idempotent;
+            newOptions.OpenWorld ??= toolAttr.OpenWorld;
+            newOptions.ReadOnly ??= toolAttr.ReadOnly;
 
             if (newOptions.Icons is null && toolAttr.IconSource is { Length: > 0 } iconSource)
             {

--- a/tests/ModelContextProtocol.Tests/Client/McpClientTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientTests.cs
@@ -367,15 +367,15 @@ public class McpClientTests : ClientServerTestBase
 
         var valuesSetViaAttr = tools.Single(t => t.Name == "ValuesSetViaAttr");
         Assert.Null(valuesSetViaAttr.ProtocolTool.Annotations?.Title);
-        Assert.Null(valuesSetViaAttr.ProtocolTool.Annotations?.ReadOnlyHint);
-        Assert.Null(valuesSetViaAttr.ProtocolTool.Annotations?.IdempotentHint);
+        Assert.False(valuesSetViaAttr.ProtocolTool.Annotations?.ReadOnlyHint);
+        Assert.False(valuesSetViaAttr.ProtocolTool.Annotations?.IdempotentHint);
         Assert.False(valuesSetViaAttr.ProtocolTool.Annotations?.DestructiveHint);
         Assert.True(valuesSetViaAttr.ProtocolTool.Annotations?.OpenWorldHint);
 
         var valuesSetViaOptions = tools.Single(t => t.Name == "ValuesSetViaOptions");
         Assert.Null(valuesSetViaOptions.ProtocolTool.Annotations?.Title);
         Assert.True(valuesSetViaOptions.ProtocolTool.Annotations?.ReadOnlyHint);
-        Assert.Null(valuesSetViaOptions.ProtocolTool.Annotations?.IdempotentHint);
+        Assert.False(valuesSetViaOptions.ProtocolTool.Annotations?.IdempotentHint);
         Assert.True(valuesSetViaOptions.ProtocolTool.Annotations?.DestructiveHint);
         Assert.False(valuesSetViaOptions.ProtocolTool.Annotations?.OpenWorldHint);
     }

--- a/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Configuration/McpServerBuilderExtensionsToolsTests.cs
@@ -698,10 +698,10 @@ public partial class McpServerBuilderExtensionsToolsTests : ClientServerTestBase
         var annotations = tool.ProtocolTool.Annotations;
         Assert.NotNull(annotations);
         Assert.Null(annotations.Title);
-        Assert.Null(annotations.DestructiveHint);
+        Assert.True(annotations.DestructiveHint);
         Assert.False(annotations.IdempotentHint);
-        Assert.Null(annotations.OpenWorldHint);
-        Assert.Null(annotations.ReadOnlyHint);
+        Assert.True(annotations.OpenWorldHint);
+        Assert.False(annotations.ReadOnlyHint);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Apply the documented default values for tool annotation hints when tools are created from `McpServerToolAttribute`.

## Motivation and Context
Fixes #1673.

`McpServerToolAttribute` exposes default values for `Destructive`, `Idempotent`, `OpenWorld`, and `ReadOnly`, but tool creation only copied values from the attribute's nullable backing fields. That meant default hint values were not included in the generated tool annotations unless the attribute explicitly set each property.

This change derives those hints from the attribute's public properties, while keeping explicit `McpServerToolCreateOptions` values as overrides.

## How Has This Been Tested?
- `dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj -f net10.0 --filter FullyQualifiedName~McpServerBuilderExtensionsToolsTests.Create_ExtractsToolAnnotations_SomeSet`
- `dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj -f net10.0 --filter FullyQualifiedName~McpClientTests.ListToolsAsync_AllToolsReturned`
- `dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj -f net10.0 --no-restore`

The full `net10.0` test project passed locally: 2219 passed, 5 skipped.

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
No documentation update is included because this change aligns runtime behavior with the existing documented defaults. No new error handling is needed for this annotation derivation change.
