### PR TITLE
Release v1.4.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <PackageProjectUrl>https://csharp.sdk.modelcontextprotocol.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/modelcontextprotocol/csharp-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.4.1</VersionPrefix>
     <Authors>ModelContextProtocol</Authors>
     <Copyright>© Model Context Protocol a Series of LF Projects, LLC.</Copyright>
     <PackageTags>ModelContextProtocol;mcp;ai;llm</PackageTags>

--- a/src/PACKAGE.md
+++ b/src/PACKAGE.md
@@ -4,6 +4,8 @@
 
 The official C# SDK for the [Model Context Protocol](https://modelcontextprotocol.io/), enabling .NET applications, services, and libraries to implement and interact with MCP clients and servers. Please visit the [API documentation](https://csharp.sdk.modelcontextprotocol.io/api/ModelContextProtocol.html) for more details on available functionality.
 
+See the [release notes](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v1.4.1) for what's new in this version.
+
 ## Packages
 
 This SDK consists of three main packages:


### PR DESCRIPTION
# Release v1.4.1

This release backports a memory-leak fix for HTTP/SSE-based MCP servers.
`StreamableHttpServerTransport` now releases its Server-Sent Events response
stream reference as soon as a GET request ends, instead of holding it until the
session is disposed via explicit DELETE or idle timeout. Long-lived SSE clients
that disconnect without sending DELETE no longer pin the underlying Kestrel
connection and its associated memory-pool buffers (~20 MiB per session),
preventing the sustained memory growth that could accumulate under
connect/disconnect churn.

## Release Notes

### What's Changed

* Release SSE response stream reference when GET request ends #1628 by @halter73 (co-authored by @joelmforsyth @Copilot)

### Acknowledgements

* @slomangino123 submitted issue #766 (resolved by #1628)

**Full Changelog**: https://github.com/modelcontextprotocol/csharp-sdk/compare/v1.4.0...v1.4.1

---

## API Compatibility Report

✅ All packages pass API compatibility validation against v1.0.0.

## API Diff Report

No public API changes between v1.4.0 and v1.4.1.

### ModelContextProtocol.Core
_No API changes._

### ModelContextProtocol
_No API changes._

### ModelContextProtocol.AspNetCore
_No API changes._
