### PR TITLE
Fix invalid initialize request handling

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -45,6 +45,7 @@ internal sealed class StreamableHttpHandler(
 
     private static readonly JsonTypeInfo<JsonRpcMessage> s_messageTypeInfo = GetRequiredJsonTypeInfo<JsonRpcMessage>();
     private static readonly JsonTypeInfo<JsonRpcError> s_errorTypeInfo = GetRequiredJsonTypeInfo<JsonRpcError>();
+    private static readonly JsonTypeInfo<InitializeRequestParams> s_initializeRequestParamsTypeInfo = GetRequiredJsonTypeInfo<InitializeRequestParams>();
 
     private static bool AllowNewSessionForNonInitializeRequests { get; } =
         AppContext.TryGetSwitch("ModelContextProtocol.AspNetCore.AllowNewSessionForNonInitializeRequests", out var enabled) && enabled;
@@ -143,6 +144,28 @@ internal sealed class StreamableHttpHandler(
                 $"Method '{removedMethodRequest.Method}' is not available on protocol version '{context.Request.Headers[McpProtocolVersionHeaderName]}'.",
                 StatusCodes.Status404NotFound, (int)McpErrorCode.MethodNotFound, requestId);
             return;
+        }
+
+        if (message is JsonRpcRequest { Method: RequestMethods.Initialize } initializeRequest)
+        {
+            try
+            {
+                var initializeParams = JsonSerializer.Deserialize(initializeRequest.Params, s_initializeRequestParamsTypeInfo);
+                if (initializeParams is null)
+                {
+                    await WriteJsonRpcErrorAsync(context,
+                        "Bad Request: The initialize request parameters were invalid.",
+                        StatusCodes.Status400BadRequest, (int)McpErrorCode.InvalidParams, requestId);
+                    return;
+                }
+            }
+            catch (JsonException ex)
+            {
+                await WriteJsonRpcErrorAsync(context,
+                    $"Bad Request: The initialize request parameters were invalid. {ex.Message}",
+                    StatusCodes.Status400BadRequest, (int)McpErrorCode.InvalidParams, requestId);
+                return;
+            }
         }
 
         var session = await GetOrCreateSessionAsync(context, message, requestId);

--- a/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerConformanceTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/StreamableHttpServerConformanceTests.cs
@@ -319,6 +319,40 @@ public class StreamableHttpServerConformanceTests(ITestOutputHelper outputHelper
     }
 
     [Fact]
+    public async Task InitializeWithMissingClientVersion_Returns400_InvalidParams_WithRequestId()
+    {
+        await StartAsync();
+
+        const string request = """
+            {"jsonrpc":"2.0","id":7,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"IntegrationTestClient"}}}
+            """;
+
+        using var response = await HttpClient.PostAsync("", JsonContent(request), TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.False(response.Headers.Contains("mcp-session-id"));
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(7, doc.RootElement.GetProperty("id").GetInt64());
+        Assert.Equal((int)McpErrorCode.InvalidParams, doc.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Contains("version", doc.RootElement.GetProperty("error").GetProperty("message").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("{\"jsonrpc\":\"2.0\",\"id\":8,\"method\":\"initialize\"}")]
+    [InlineData("{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"initialize\",\"params\":null}")]
+    public async Task InitializeWithMissingOrNullParams_Returns400_InvalidParams_WithoutCreatingSession(string request)
+    {
+        await StartAsync();
+
+        using var response = await HttpClient.PostAsync("", JsonContent(request), TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.False(response.Headers.Contains("mcp-session-id"));
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        Assert.Equal((int)McpErrorCode.InvalidParams, doc.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Fact]
     public async Task PostRequestWithExplicitNullId_Returns400_InvalidRequest_WithNullId()
     {
         await StartAsync();


### PR DESCRIPTION
## Summary
- validate initialize request parameters before creating an HTTP session
- return HTTP 400 with JSON-RPC InvalidParams and the original request ID
- cover a missing clientInfo.version payload

## Testing
- dotnet build
- ASP.NET Core test suite on net8.0, net9.0, and net10.0

Fixes #788