### PR TITLE
Allow HttpClient BaseAddress as transport endpoint

### DIFF
--- a/src/ModelContextProtocol.Core/Client/AutoDetectingClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/AutoDetectingClientSessionTransport.cs
@@ -14,17 +14,19 @@ namespace ModelContextProtocol.Client;
 internal sealed partial class AutoDetectingClientSessionTransport : ITransport
 {
     private readonly HttpClientTransportOptions _options;
+    private readonly Uri _endpoint;
     private readonly McpHttpClient _httpClient;
     private readonly ILoggerFactory? _loggerFactory;
     private readonly ILogger _logger;
     private readonly string _name;
     private readonly Channel<JsonRpcMessage> _messageChannel;
 
-    public AutoDetectingClientSessionTransport(string endpointName, HttpClientTransportOptions transportOptions, McpHttpClient httpClient, ILoggerFactory? loggerFactory)
+    public AutoDetectingClientSessionTransport(string endpointName, Uri endpoint, HttpClientTransportOptions transportOptions, McpHttpClient httpClient, ILoggerFactory? loggerFactory)
     {
         Throw.IfNull(transportOptions);
         Throw.IfNull(httpClient);
 
+        _endpoint = endpoint;
         _options = transportOptions;
         _httpClient = httpClient;
         _loggerFactory = loggerFactory;
@@ -62,7 +64,7 @@ internal sealed partial class AutoDetectingClientSessionTransport : ITransport
     private async Task InitializeAsync(JsonRpcMessage message, CancellationToken cancellationToken)
     {
         // Try StreamableHttp first
-        var streamableHttpTransport = new StreamableHttpClientSessionTransport(_name, _options, _httpClient, _messageChannel, _loggerFactory);
+        var streamableHttpTransport = new StreamableHttpClientSessionTransport(_name, _endpoint, _options, _httpClient, _messageChannel, _loggerFactory);
 
         try
         {
@@ -126,7 +128,7 @@ internal sealed partial class AutoDetectingClientSessionTransport : ITransport
             throw new InvalidOperationException("Streamable HTTP transport is required to resume an existing session.");
         }
 
-        var sseTransport = new SseClientSessionTransport(_name, _options, _httpClient, _messageChannel, _loggerFactory);
+        var sseTransport = new SseClientSessionTransport(_name, _endpoint, _options, _httpClient, _messageChannel, _loggerFactory);
 
         try
         {
@@ -193,7 +195,6 @@ internal sealed partial class AutoDetectingClientSessionTransport : ITransport
 
     [LoggerMessage(Level = LogLevel.Information, Message = "{EndpointName} using SSE transport.")]
     private partial void LogUsingSSE(string endpointName);
-
     [LoggerMessage(Level = LogLevel.Warning, Message = "{EndpointName} SSE fallback failed after Streamable HTTP also failed; surfacing both errors.")]
     private partial void LogSseFallbackFailedAfterStreamableHttp(string endpointName, Exception sseError);
 }

--- a/src/ModelContextProtocol.Core/Client/HttpClientTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/HttpClientTransport.cs
@@ -18,6 +18,7 @@ public sealed class HttpClientTransport : IClientTransport, IAsyncDisposable
     private readonly HttpClientTransportOptions _options;
     private readonly McpHttpClient _mcpHttpClient;
     private readonly ILoggerFactory? _loggerFactory;
+    private readonly Uri _endpoint;
 
     private readonly HttpClient? _ownedHttpClient;
 
@@ -49,11 +50,15 @@ public sealed class HttpClientTransport : IClientTransport, IAsyncDisposable
 
         _options = transportOptions;
         _loggerFactory = loggerFactory;
-        Name = transportOptions.Name ?? transportOptions.Endpoint.ToString();
+        _endpoint = transportOptions.Endpoint ?? httpClient.BaseAddress ??
+            throw new ArgumentException(
+                $"Either '{nameof(HttpClientTransportOptions)}.{nameof(HttpClientTransportOptions.Endpoint)}' or '{nameof(HttpClient)}.{nameof(HttpClient.BaseAddress)}' must be set.",
+                nameof(transportOptions));
+        Name = transportOptions.Name ?? _endpoint.ToString();
 
         if (transportOptions.OAuth is { } clientOAuthOptions)
         {
-            _mcpHttpClient = new ClientOAuthProvider(_options.Endpoint, clientOAuthOptions, httpClient, loggerFactory);
+            _mcpHttpClient = new ClientOAuthProvider(_endpoint, clientOAuthOptions, httpClient, loggerFactory);
         }
         else
         {
@@ -79,8 +84,8 @@ public sealed class HttpClientTransport : IClientTransport, IAsyncDisposable
 
         return _options.TransportMode switch
         {
-            HttpTransportMode.AutoDetect => new AutoDetectingClientSessionTransport(Name, _options, _mcpHttpClient, _loggerFactory),
-            HttpTransportMode.StreamableHttp => new StreamableHttpClientSessionTransport(Name, _options, _mcpHttpClient, messageChannel: null, _loggerFactory),
+            HttpTransportMode.AutoDetect => new AutoDetectingClientSessionTransport(Name, _endpoint, _options, _mcpHttpClient, _loggerFactory),
+            HttpTransportMode.StreamableHttp => new StreamableHttpClientSessionTransport(Name, _endpoint, _options, _mcpHttpClient, messageChannel: null, _loggerFactory),
             HttpTransportMode.Sse => await ConnectSseTransportAsync(cancellationToken).ConfigureAwait(false),
             _ => throw new InvalidOperationException($"Unsupported transport mode: {_options.TransportMode}"),
         };
@@ -88,7 +93,7 @@ public sealed class HttpClientTransport : IClientTransport, IAsyncDisposable
 
     private async Task<ITransport> ConnectSseTransportAsync(CancellationToken cancellationToken)
     {
-        var sessionTransport = new SseClientSessionTransport(Name, _options, _mcpHttpClient, messageChannel: null, _loggerFactory);
+        var sessionTransport = new SseClientSessionTransport(Name, _endpoint, _options, _mcpHttpClient, messageChannel: null, _loggerFactory);
 
         try
         {

--- a/src/ModelContextProtocol.Core/Client/HttpClientTransportOptions.cs
+++ b/src/ModelContextProtocol.Core/Client/HttpClientTransportOptions.cs
@@ -8,24 +8,23 @@ namespace ModelContextProtocol.Client;
 public sealed class HttpClientTransportOptions
 {
     /// <summary>
-    /// Gets or sets the base address of the server for SSE connections.
+    /// Gets or sets the base address of the server for HTTP connections.
     /// </summary>
-    /// <exception cref="ArgumentNullException">The value is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">The value is not an absolute URI, or does not use the HTTP or HTTPS scheme.</exception>
-    public required Uri Endpoint
+    /// <remarks>
+    /// This can be omitted when constructing the transport with an <see cref="HttpClient"/> that has a
+    /// <see cref="HttpClient.BaseAddress"/>. An explicitly configured endpoint takes precedence over the client base address.
+    /// </remarks>
+    public Uri? Endpoint
     {
         get;
         set
         {
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value), "Endpoint cannot be null.");
-            }
-            if (!value.IsAbsoluteUri)
+            if (value is not null && !value.IsAbsoluteUri)
             {
                 throw new ArgumentException("Endpoint must be an absolute URI.", nameof(value));
             }
-            if (value.Scheme != Uri.UriSchemeHttp && value.Scheme != Uri.UriSchemeHttps)
+            if (value is not null && value.Scheme != Uri.UriSchemeHttp && value.Scheme != Uri.UriSchemeHttps)
             {
                 throw new ArgumentException("Endpoint must use HTTP or HTTPS scheme.", nameof(value));
             }

--- a/src/ModelContextProtocol.Core/Client/SseClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/SseClientSessionTransport.cs
@@ -30,6 +30,7 @@ internal sealed partial class SseClientSessionTransport : TransportBase
     /// </summary>
     public SseClientSessionTransport(
         string endpointName,
+        Uri endpoint,
         HttpClientTransportOptions transportOptions,
         McpHttpClient httpClient,
         Channel<JsonRpcMessage>? messageChannel,
@@ -40,7 +41,7 @@ internal sealed partial class SseClientSessionTransport : TransportBase
         Throw.IfNull(httpClient);
 
         _options = transportOptions;
-        _sseEndpoint = transportOptions.Endpoint;
+        _sseEndpoint = endpoint;
         _httpClient = httpClient;
         _connectionCts = new CancellationTokenSource();
         _logger = (ILogger?)loggerFactory?.CreateLogger<HttpClientTransport>() ?? NullLogger.Instance;

--- a/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs
@@ -20,6 +20,7 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
     private static readonly MediaTypeWithQualityHeaderValue s_textEventStreamMediaType = new("text/event-stream");
 
     private readonly McpHttpClient _httpClient;
+    private readonly Uri _endpoint;
     private readonly HttpClientTransportOptions _options;
     private readonly CancellationTokenSource _connectionCts = new();
     private readonly ILogger _logger;
@@ -34,6 +35,7 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
 
     public StreamableHttpClientSessionTransport(
         string endpointName,
+        Uri endpoint,
         HttpClientTransportOptions transportOptions,
         McpHttpClient httpClient,
         Channel<JsonRpcMessage>? messageChannel,
@@ -43,6 +45,7 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
         Throw.IfNull(transportOptions);
         Throw.IfNull(httpClient);
 
+        _endpoint = endpoint;
         _options = transportOptions;
         _httpClient = httpClient;
         _logger = (ILogger?)loggerFactory?.CreateLogger<HttpClientTransport>() ?? NullLogger.Instance;
@@ -155,7 +158,7 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
         using var sendCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _connectionCts.Token);
         cancellationToken = sendCts.Token;
 
-        using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, _options.Endpoint)
+        using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, _endpoint)
         {
             Headers =
             {
@@ -377,7 +380,7 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
             }
             shouldDelay = true;
 
-            using var request = new HttpRequestMessage(HttpMethod.Get, _options.Endpoint);
+            using var request = new HttpRequestMessage(HttpMethod.Get, _endpoint);
             request.Headers.Accept.Add(s_textEventStreamMediaType);
             CopyAdditionalHeaders(request.Headers, _options.AdditionalHeaders, SessionId, _negotiatedProtocolVersion, state.LastEventId);
 
@@ -516,7 +519,7 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
 
     private async Task SendDeleteRequest()
     {
-        using var deleteRequest = new HttpRequestMessage(HttpMethod.Delete, _options.Endpoint);
+        using var deleteRequest = new HttpRequestMessage(HttpMethod.Delete, _endpoint);
         CopyAdditionalHeaders(deleteRequest.Headers, _options.AdditionalHeaders, SessionId, _negotiatedProtocolVersion);
 
         // Do not validate we get a successful status code, because server support for the DELETE request is optional

--- a/tests/ModelContextProtocol.AspNetCore.Tests/HttpServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/HttpServerIntegrationTests.cs
@@ -58,8 +58,10 @@ public abstract class HttpServerIntegrationTests : LoggedTest, IClassFixture<Sse
         Assert.NotNull(client.ServerInfo);
         Assert.NotNull(client.NegotiatedProtocolVersion);
 
-        if (ClientTransportOptions.Endpoint.AbsolutePath.EndsWith("/sse") ||
-            ClientTransportOptions.Endpoint.AbsolutePath.EndsWith("/stateless"))
+        var endpoint = Assert.IsType<Uri>(ClientTransportOptions.Endpoint);
+
+        if (endpoint.AbsolutePath.EndsWith("/sse") ||
+            endpoint.AbsolutePath.EndsWith("/stateless"))
         {
             // In SSE and in Streamable HTTP's stateless mode, no protocol-defined session IDs are used.:w
             Assert.Null(client.SessionId);

--- a/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportTests.cs
@@ -41,6 +41,75 @@ public class HttpClientTransportTests : LoggedTest
     }
 
     [Fact]
+    public void Constructor_Throws_When_No_Endpoint_Is_Available()
+    {
+        var options = new HttpClientTransportOptions();
+        using var httpClient = new HttpClient();
+
+        var exception = Assert.Throws<ArgumentException>(() => new HttpClientTransport(options, httpClient, LoggerFactory));
+
+        Assert.Equal("transportOptions", exception.ParamName);
+        Assert.Contains(nameof(HttpClient.BaseAddress), exception.Message);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_Uses_Injected_HttpClient_BaseAddress_When_Endpoint_Is_Omitted()
+    {
+        var options = new HttpClientTransportOptions
+        {
+            TransportMode = HttpTransportMode.Sse,
+        };
+        using var mockHttpHandler = new MockHttpHandler();
+        using var httpClient = new HttpClient(mockHttpHandler)
+        {
+            BaseAddress = new Uri("https://mcp-server/sse"),
+        };
+        await using var transport = new HttpClientTransport(options, httpClient, LoggerFactory);
+
+        mockHttpHandler.RequestHandler = request =>
+        {
+            Assert.Equal(httpClient.BaseAddress, request.RequestUri);
+            return Task.FromResult(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("event: endpoint\r\ndata: /messages\r\n\r\n"),
+            });
+        };
+
+        await using var session = await transport.ConnectAsync(TestContext.Current.CancellationToken);
+        Assert.NotNull(session);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_Prefers_Explicit_Endpoint_Over_HttpClient_BaseAddress()
+    {
+        var options = new HttpClientTransportOptions
+        {
+            Endpoint = new Uri("https://explicit.example/sse"),
+            TransportMode = HttpTransportMode.Sse,
+        };
+        using var mockHttpHandler = new MockHttpHandler();
+        using var httpClient = new HttpClient(mockHttpHandler)
+        {
+            BaseAddress = new Uri("https://base-address.example/sse"),
+        };
+        await using var transport = new HttpClientTransport(options, httpClient, LoggerFactory);
+
+        mockHttpHandler.RequestHandler = request =>
+        {
+            Assert.Equal(options.Endpoint, request.RequestUri);
+            return Task.FromResult(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("event: endpoint\r\ndata: /messages\r\n\r\n"),
+            });
+        };
+
+        await using var session = await transport.ConnectAsync(TestContext.Current.CancellationToken);
+        Assert.NotNull(session);
+    }
+
+    [Fact]
     public async Task ConnectAsync_Should_Connect_Successfully()
     {
         using var mockHttpHandler = new MockHttpHandler();


### PR DESCRIPTION
## Summary

- allow `HttpClientTransportOptions.Endpoint` to be omitted when an injected `HttpClient` has a `BaseAddress`
- pass the resolved endpoint explicitly through auto-detect, SSE, and Streamable HTTP session transports
- preserve explicit endpoint precedence and support Aspire-style logical base-address schemes handled by custom HTTP handlers

## Testing

- `dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj --filter FullyQualifiedName~HttpClientTransportTests`
- `dotnet build tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj --no-restore`

Fixes #515