### PR TITLE
Add MCP Apps to NativeAOT coverage

### DIFF
--- a/tests/ModelContextProtocol.AotCompatibility.TestApp/ModelContextProtocol.AotCompatibility.TestApp.csproj
+++ b/tests/ModelContextProtocol.AotCompatibility.TestApp/ModelContextProtocol.AotCompatibility.TestApp.csproj
@@ -7,18 +7,20 @@
     <TargetFrameworks></TargetFrameworks>
     <PublishAot>true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
-    <!-- Suppress the experimental tasks warning -->
-    <NoWarn>$(NoWarn);MCPEXP001</NoWarn>
+    <!-- Suppress warnings for the experimental tasks and Apps APIs exercised by this test app. -->
+    <NoWarn>$(NoWarn);MCPEXP001;MCPEXP003</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ModelContextProtocol.Core\ModelContextProtocol.Core.csproj" />
     <ProjectReference Include="..\..\src\ModelContextProtocol\ModelContextProtocol.csproj" />
     <ProjectReference Include="..\..\src\ModelContextProtocol.AspNetCore\ModelContextProtocol.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\ModelContextProtocol.Extensions.Apps\ModelContextProtocol.Extensions.Apps.csproj" />
 
     <TrimmerRootAssembly Include="ModelContextProtocol.Core" />
     <TrimmerRootAssembly Include="ModelContextProtocol" />
     <TrimmerRootAssembly Include="ModelContextProtocol.AspNetCore" />
+    <TrimmerRootAssembly Include="ModelContextProtocol.Extensions.Apps" />
   </ItemGroup>
 
 </Project>

--- a/tests/ModelContextProtocol.AotCompatibility.TestApp/ModelContextProtocol.AotCompatibility.TestApp.csproj
+++ b/tests/ModelContextProtocol.AotCompatibility.TestApp/ModelContextProtocol.AotCompatibility.TestApp.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks></TargetFrameworks>
     <PublishAot>true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
-    <!-- Suppress warnings for the experimental tasks and Apps APIs exercised by this test app. -->
+    <!-- Suppress warnings for the experimental APIs exercised by this test app. -->
     <NoWarn>$(NoWarn);MCPEXP001;MCPEXP003</NoWarn>
   </PropertyGroup>
 

--- a/tests/ModelContextProtocol.AotCompatibility.TestApp/Program.cs
+++ b/tests/ModelContextProtocol.AotCompatibility.TestApp/Program.cs
@@ -1,17 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Client;
+using ModelContextProtocol.Extensions.Apps;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using System.IO.Pipelines;
 
 Pipe clientToServerPipe = new(), serverToClientPipe = new();
 
-// Create a server using a stream-based transport over an in-memory pipe.
-await using McpServer server = McpServer.Create(
-    new StreamServerTransport(clientToServerPipe.Reader.AsStream(), serverToClientPipe.Writer.AsStream()),
-    new McpServerOptions()
-    {
-        ToolCollection = [McpServerTool.Create((string arg) => $"Echo: {arg}", new() { Name = "Echo" })]
-    });
+var services = new ServiceCollection();
+services.AddMcpServer()
+    .WithStreamServerTransport(clientToServerPipe.Reader.AsStream(), serverToClientPipe.Writer.AsStream())
+    .WithTools<AotTools>()
+    .WithMcpApps();
+
+await using var serviceProvider = services.BuildServiceProvider();
+var server = serviceProvider.GetRequiredService<McpServer>();
 _ = server.RunAsync();
 
 // Connect a client using a stream-based transport over the same in-memory pipe.
@@ -20,13 +23,18 @@ await using McpClient client = await McpClient.CreateAsync(
 
 // List all tools.
 var tools = await client.ListToolsAsync();
-if (tools.Count == 0)
+var echo = tools.FirstOrDefault(t => t.Name == "Echo");
+if (echo is null)
 {
-    throw new Exception("Expected at least one tool.");
+    throw new Exception("Expected the Echo tool.");
 }
 
-// Invoke a tool.
-var echo = tools.First(t => t.Name == "Echo");
+var ui = echo.ProtocolTool.Meta?["ui"]?.AsObject();
+if (ui?["resourceUri"]?.GetValue<string>() != "ui://aot/echo")
+{
+    throw new Exception($"Unexpected app UI metadata: {ui}");
+}
+
 var result = await echo.InvokeAsync(new() { ["arg"] = "Hello World" });
 if (result is null || !result.ToString()!.Contains("Echo: Hello World"))
 {
@@ -34,3 +42,11 @@ if (result is null || !result.ToString()!.Contains("Echo: Hello World"))
 }
 
 Console.WriteLine("Success!");
+
+[McpServerToolType]
+internal sealed class AotTools
+{
+    [McpServerTool(Name = "Echo")]
+    [McpAppUi(ResourceUri = "ui://aot/echo")]
+    public static string Echo(string arg) => $"Echo: {arg}";
+}


### PR DESCRIPTION
## Summary

- reference and root `ModelContextProtocol.Extensions.Apps` in the NativeAOT test application
- register an `[McpAppUi]` tool through `WithTools<T>().WithMcpApps()` so the extension cannot be trimmed as unused
- verify `_meta.ui` survives a client/server `ListToolsAsync()` round trip before invoking the tool

## Testing

- `LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib:/opt/homebrew/opt/brotli/lib make test-aot CONFIGURATION=Release`
- published NativeAOT executable completed with `Success!`

Fixes #1659