### PR TITLE
Stabilize task cancellation cleanup test

### DIFF
--- a/tests/ModelContextProtocol.Tests/Server/TaskCancellationIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/TaskCancellationIntegrationTests.cs
@@ -106,6 +106,7 @@ public class TaskCancellationIntegrationTests : ClientServerTestBase
 
         // Cleanup
         await client.CancelTaskAsync(taskId, ct);
+        await _toolCancellationFired.Task.WaitAsync(TestConstants.DefaultTimeout, ct);
     }
 }
 


### PR DESCRIPTION
Fixes #1701.

## Summary

`TaskTool_CancellationToken_GetTaskShowsWorkingBeforeCancel` cancelled its infinite-delay tool during cleanup but immediately began client/server teardown. Unlike the adjacent explicit-cancellation test, it never waited for the tool to observe cancellation, leaving teardown to race a still-running request.

This waits on the test’s existing `_toolCancellationFired` signal with `TestConstants.DefaultTimeout` and the xUnit cancellation token before disposal.

## Tests

- focused test run three consecutive times (9 target-framework executions passed)
- full `TaskCancellationIntegrationTests` class (6 passed)
- `dotnet build ModelContextProtocol.slnx` (36 projects, 0 warnings)
- targeted `dotnet format --verify-no-changes`
- full `ModelContextProtocol.Tests` project: 6,864 passed; the three failures are `DockerEverythingServerTests.Sampling_Sse_EverythingServer`, which reproduce on clean `upstream/main` because the local Everything Server container lacks `trigger-sampling-request`