### PR TITLE
Allow Streamable HTTP GET reconnection

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -243,6 +243,10 @@ internal sealed class StreamableHttpHandler(
             // RequestAborted always triggers when the client disconnects before a complete response body is written,
             // but this is how SSE connections are typically closed.
         }
+        finally
+        {
+            session.EndGetRequest();
+        }
     }
 
 #pragma warning disable MCP9006 // Stateful Streamable HTTP resumability types are obsolete but still wired up internally.

--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpSession.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpSession.cs
@@ -100,6 +100,7 @@ internal sealed class StreamableHttpSession(
     }
 
     public bool TryStartGetRequest() => Interlocked.Exchange(ref _getRequestStarted, 1) == 0;
+    public void EndGetRequest() => Volatile.Write(ref _getRequestStarted, 0);
     public bool HasSameUserId(ClaimsPrincipal user) => userId == StreamableHttpHandler.GetUserIdClaim(user);
 
     public async ValueTask DisposeAsync()

--- a/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
@@ -185,6 +185,14 @@ public sealed partial class StreamableHttpServerTransport : ITransport
                     _httpSseWriter = null;
                     writer.Dispose();
                 }
+
+                // Event-store sessions retain this state so notifications can be persisted
+                // for Last-Event-ID replay while the client is disconnected.
+                if (_storeSseWriter is null)
+                {
+                    _httpResponseTcs = null;
+                    _getHttpRequestStarted = false;
+                }
             }
         }
     }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStreamableHttpTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStreamableHttpTests.cs
@@ -73,6 +73,82 @@ public class MapMcpStreamableHttpTests(ITestOutputHelper outputHelper) : MapMcpT
     }
 
     [Fact]
+    public async Task GetStream_CanReconnectAfterPreviousRequestEnds()
+    {
+        Assert.SkipWhen(Stateless, "Unsolicited GET streams are not supported in stateless mode.");
+
+        Builder.Services.AddMcpServer().WithHttpTransport(ConfigureStateless);
+        await using var app = Builder.Build();
+
+        var firstGetCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondGetCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completedGetCount = 0;
+        app.Use(async (context, next) =>
+        {
+            try
+            {
+                await next(context);
+            }
+            finally
+            {
+                if (context.Request.Method == HttpMethods.Get)
+                {
+                    if (Interlocked.Increment(ref completedGetCount) == 1)
+                    {
+                        firstGetCompleted.TrySetResult();
+                    }
+                    else
+                    {
+                        secondGetCompleted.TrySetResult();
+                    }
+                }
+            }
+        });
+        app.MapMcp();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        const string initializeRequest = """
+            {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}
+            """;
+        using var initRequest = new HttpRequestMessage(HttpMethod.Post, "/")
+        {
+            Content = new StringContent(initializeRequest, System.Text.Encoding.UTF8, "application/json"),
+        };
+        initRequest.Headers.Accept.ParseAdd("application/json");
+        initRequest.Headers.Accept.ParseAdd("text/event-stream");
+        using var initResponse = await HttpClient.SendAsync(initRequest, TestContext.Current.CancellationToken);
+        Assert.True(initResponse.IsSuccessStatusCode);
+        var sessionId = Assert.Single(initResponse.Headers.GetValues("Mcp-Session-Id"));
+
+        using (var firstResponse = await HttpClient.SendAsync(
+            CreateGetRequest(sessionId),
+            HttpCompletionOption.ResponseHeadersRead,
+            TestContext.Current.CancellationToken))
+        {
+            Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+        }
+        await firstGetCompleted.Task.WaitAsync(TestConstants.DefaultTimeout, TestContext.Current.CancellationToken);
+
+        using (var secondResponse = await HttpClient.SendAsync(
+            CreateGetRequest(sessionId),
+            HttpCompletionOption.ResponseHeadersRead,
+            TestContext.Current.CancellationToken))
+        {
+            Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        }
+        await secondGetCompleted.Task.WaitAsync(TestConstants.DefaultTimeout, TestContext.Current.CancellationToken);
+
+        static HttpRequestMessage CreateGetRequest(string sessionId)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Accept.ParseAdd("text/event-stream");
+            request.Headers.Add("Mcp-Session-Id", sessionId);
+            request.Headers.Add("MCP-Protocol-Version", "2025-11-25");
+            return request;
+        }
+    }
+
+    [Fact]
     public async Task AutoDetectMode_Works_WithRootEndpoint()
     {
         Builder.Services.AddMcpServer(options =>

--- a/tests/ModelContextProtocol.Tests/Transport/StreamableHttpServerTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StreamableHttpServerTransportTests.cs
@@ -7,6 +7,18 @@ namespace ModelContextProtocol.Tests.Transport;
 public class StreamableHttpServerTransportTests(ITestOutputHelper testOutputHelper) : LoggedTest(testOutputHelper)
 {
     [Fact]
+    public async Task HandleGetRequestAsync_CanStartAgainAfterPreviousRequestEnds()
+    {
+        await using var transport = new StreamableHttpServerTransport()
+        {
+            SessionId = "test-session",
+        };
+
+        await RunGetRequestAndCancelAsync(transport);
+        await RunGetRequestAndCancelAsync(transport);
+    }
+
+    [Fact]
     public async Task SendMessageAsync_AfterGetRequestEnds_DoesNotWriteToResponseStream()
     {
         // Regression test for the SSE response stream being retained after the GET request
@@ -41,6 +53,18 @@ public class StreamableHttpServerTransportTests(ITestOutputHelper testOutputHelp
             TestContext.Current.CancellationToken);
 
         Assert.Equal(writeCountBeforeCancel, responseStream.WriteCount);
+    }
+
+    private static async Task RunGetRequestAndCancelAsync(StreamableHttpServerTransport transport)
+    {
+        var responseStream = new RecordingStream();
+        using var cts = new CancellationTokenSource();
+        var getTask = transport.HandleGetRequestAsync(responseStream, cts.Token);
+
+        await responseStream.FirstActivity.WaitAsync(TestConstants.DefaultTimeout, TestContext.Current.CancellationToken);
+
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => getTask);
     }
 
     private sealed class RecordingStream : Stream


### PR DESCRIPTION
Fixes #1239.

## Summary

- release the stateful session GET guard when an unsolicited SSE request ends
- release the underlying transport GET/TCS guard for non-resumable sessions so the client can open a replacement GET stream
- preserve event-store-backed state so notifications continue to be persisted for `Last-Event-ID` replay while disconnected
- add transport-level and end-to-end HTTP regression coverage for sequential GET streams on the same session

This fixes reconnection after proxies/load balancers close an idle SSE connection. Server keep-alive comments can remain a separate hardening improvement; reconnecting no longer receives the permanent HTTP 400 described in the issue.

## Tests

- `StreamableHttpServerTransportTests` (6 passed across target frameworks)
- `GetStream_CanReconnectAfterPreviousRequestEnds` (3 passed)
- existing resumability reconnect tests (6 passed)
- ASP.NET Core tests excluding the unavailable Node conformance executable (1,389 passed)
- `dotnet build ModelContextProtocol.slnx` (36 projects, 0 warnings)
- targeted `dotnet format --verify-no-changes`

The unfiltered ASP.NET Core run cannot execute conformance cases locally because `node_modules/.bin/conformance` is absent.