### PR TITLE
Cancel background task runners on server disposal

### DIFF
--- a/src/ModelContextProtocol.Core/Server/DestinationBoundMcpServer.cs
+++ b/src/ModelContextProtocol.Core/Server/DestinationBoundMcpServer.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Nodes;
 namespace ModelContextProtocol.Server;
 
 #pragma warning disable MCPEXP002
-internal sealed class DestinationBoundMcpServer(McpServerImpl server, ITransport? transport, JsonRpcMessageContext? requestContext = null) : McpServer
+internal sealed class DestinationBoundMcpServer(McpServerImpl server, ITransport? transport, JsonRpcMessageContext? requestContext = null) : McpServer, IMcpServerLifetimeFeature
 #pragma warning restore MCPEXP002
 {
     private readonly bool _isJuly2026OrLaterRequest = server.IsJuly2026OrLaterProtocolRequest(requestContext);
@@ -72,6 +72,12 @@ internal sealed class DestinationBoundMcpServer(McpServerImpl server, ITransport
     internal MrtrContext? ActiveMrtrContext { get; set; }
 
     public override bool IsMrtrSupported => server.IsMrtrSupported;
+
+    CancellationToken IMcpServerLifetimeFeature.BackgroundTaskCancellationToken =>
+        ((IMcpServerLifetimeFeature)server).BackgroundTaskCancellationToken;
+
+    void IMcpServerLifetimeFeature.RegisterBackgroundTask(Task backgroundTask) =>
+        ((IMcpServerLifetimeFeature)server).RegisterBackgroundTask(backgroundTask);
 
     public override ValueTask DisposeAsync() => server.DisposeAsync();
 

--- a/src/ModelContextProtocol.Core/Server/DestinationBoundMcpServer.cs
+++ b/src/ModelContextProtocol.Core/Server/DestinationBoundMcpServer.cs
@@ -73,11 +73,11 @@ internal sealed class DestinationBoundMcpServer(McpServerImpl server, ITransport
 
     public override bool IsMrtrSupported => server.IsMrtrSupported;
 
-    CancellationToken IMcpServerLifetimeFeature.BackgroundTaskCancellationToken =>
-        ((IMcpServerLifetimeFeature)server).BackgroundTaskCancellationToken;
+    CancellationToken IMcpServerLifetimeFeature.ServerCancellationToken =>
+        ((IMcpServerLifetimeFeature)server).ServerCancellationToken;
 
-    void IMcpServerLifetimeFeature.RegisterBackgroundTask(Task backgroundTask) =>
-        ((IMcpServerLifetimeFeature)server).RegisterBackgroundTask(backgroundTask);
+    IDisposable IMcpServerLifetimeFeature.RegisterForDisposeAsync(IAsyncDisposable disposable) =>
+        ((IMcpServerLifetimeFeature)server).RegisterForDisposeAsync(disposable);
 
     public override ValueTask DisposeAsync() => server.DisposeAsync();
 

--- a/src/ModelContextProtocol.Core/Server/IMcpServerLifetimeFeature.cs
+++ b/src/ModelContextProtocol.Core/Server/IMcpServerLifetimeFeature.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel;
+
+namespace ModelContextProtocol.Server;
+
+/// <summary>
+/// Provides server-lifetime services used by MCP extension infrastructure.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface IMcpServerLifetimeFeature
+{
+    /// <summary>Gets the token that should cancel background work owned by this server.</summary>
+    /// <remarks>
+    /// The token is <see cref="CancellationToken.None"/> when background work intentionally outlives
+    /// the server instance, as it does for per-request servers in stateless HTTP mode.
+    /// </remarks>
+    CancellationToken BackgroundTaskCancellationToken { get; }
+
+    /// <summary>Registers background work that server disposal must await.</summary>
+    /// <param name="backgroundTask">The background work to track.</param>
+    /// <remarks>This is a no-op when background work intentionally outlives the server instance.</remarks>
+    void RegisterBackgroundTask(Task backgroundTask);
+}

--- a/src/ModelContextProtocol.Core/Server/IMcpServerLifetimeFeature.cs
+++ b/src/ModelContextProtocol.Core/Server/IMcpServerLifetimeFeature.cs
@@ -8,15 +8,19 @@ namespace ModelContextProtocol.Server;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public interface IMcpServerLifetimeFeature
 {
-    /// <summary>Gets the token that should cancel background work owned by this server.</summary>
+    /// <summary>Gets the token that is cancelled when this server starts disposing.</summary>
     /// <remarks>
-    /// The token is <see cref="CancellationToken.None"/> when background work intentionally outlives
-    /// the server instance, as it does for per-request servers in stateless HTTP mode.
+    /// The token is <see cref="CancellationToken.None"/> when work intentionally outlives the server,
+    /// as it does for per-request servers in stateless HTTP mode.
     /// </remarks>
-    CancellationToken BackgroundTaskCancellationToken { get; }
+    CancellationToken ServerCancellationToken { get; }
 
-    /// <summary>Registers background work that server disposal must await.</summary>
-    /// <param name="backgroundTask">The background work to track.</param>
-    /// <remarks>This is a no-op when background work intentionally outlives the server instance.</remarks>
-    void RegisterBackgroundTask(Task backgroundTask);
+    /// <summary>Registers an asynchronously disposable resource that server disposal must await.</summary>
+    /// <param name="disposable">The resource to dispose when this server is disposed.</param>
+    /// <returns>A handle that unregisters the resource without disposing it.</returns>
+    /// <remarks>
+    /// Dispose the returned handle when the resource completes independently so the server does not
+    /// retain it until shutdown. Registration is a no-op when the server does not own the resource.
+    /// </remarks>
+    IDisposable RegisterForDisposeAsync(IAsyncDisposable disposable);
 }

--- a/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
@@ -32,8 +32,8 @@ internal sealed partial class McpServerImpl : McpServer, IMcpServerLifetimeFeatu
     private readonly string[] _perRequestMetadataProtocolVersions;
     private readonly SemaphoreSlim _disposeLock = new(1, 1);
     private readonly CancellationTokenSource _serverLifetimeCts = new();
-    private readonly object _backgroundTasksLock = new();
-    private readonly ConcurrentDictionary<Task, byte> _backgroundTasks = new();
+    private readonly object _serverLifetimeRegistrationsLock = new();
+    private readonly HashSet<ServerLifetimeRegistration> _serverLifetimeRegistrations = [];
     private readonly ConcurrentDictionary<string, MrtrContinuation> _mrtrContinuations = new();
     private readonly ConcurrentDictionary<RequestId, MrtrContext> _mrtrContextsByRequestId = new();
     private static readonly string[] s_perRequestMetadataKeys =
@@ -58,7 +58,7 @@ internal sealed partial class McpServerImpl : McpServer, IMcpServerLifetimeFeatu
     private int _started;
 
     private bool _disposed;
-    private bool _backgroundTaskRegistrationClosed;
+    private bool _serverLifetimeRegistrationClosed;
 
     /// <summary>Holds a boxed <see cref="LoggingLevel"/> value for the server.</summary>
     /// <remarks>
@@ -601,36 +601,40 @@ internal sealed partial class McpServerImpl : McpServer, IMcpServerLifetimeFeatu
     public override IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler)
         => _sessionHandler.RegisterNotificationHandler(method, handler);
 
-    CancellationToken IMcpServerLifetimeFeature.BackgroundTaskCancellationToken =>
+    CancellationToken IMcpServerLifetimeFeature.ServerCancellationToken =>
         HasStatefulTransport() ? _serverLifetimeCts.Token : CancellationToken.None;
 
-    void IMcpServerLifetimeFeature.RegisterBackgroundTask(Task backgroundTask)
+    IDisposable IMcpServerLifetimeFeature.RegisterForDisposeAsync(IAsyncDisposable disposable)
     {
-        Throw.IfNull(backgroundTask);
+        Throw.IfNull(disposable);
 
         // Stateless HTTP servers are request-scoped, while Tasks runners intentionally outlive
         // the originating request and are governed by tasks/cancel and task-store retention.
         if (!HasStatefulTransport())
         {
-            return;
+            return NoopRegistration.Instance;
         }
 
-        lock (_backgroundTasksLock)
+        var registration = new ServerLifetimeRegistration(this, disposable);
+        lock (_serverLifetimeRegistrationsLock)
         {
-            if (_backgroundTaskRegistrationClosed)
+            if (_serverLifetimeRegistrationClosed)
             {
                 throw new ObjectDisposedException(nameof(McpServer));
             }
 
-            _backgroundTasks.TryAdd(backgroundTask, 0);
+            _serverLifetimeRegistrations.Add(registration);
         }
 
-        _ = backgroundTask.ContinueWith(
-            static (task, state) => ((ConcurrentDictionary<Task, byte>)state!).TryRemove(task, out _),
-            _backgroundTasks,
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
+        return registration;
+    }
+
+    private void UnregisterServerLifetime(ServerLifetimeRegistration registration)
+    {
+        lock (_serverLifetimeRegistrationsLock)
+        {
+            _serverLifetimeRegistrations.Remove(registration);
+        }
     }
 
     /// <inheritdoc/>
@@ -653,11 +657,11 @@ internal sealed partial class McpServerImpl : McpServer, IMcpServerLifetimeFeatu
         _disposables.ForEach(d => d());
         await _sessionHandler.DisposeAsync().ConfigureAwait(false);
 
-        Task[] backgroundTasks;
-        lock (_backgroundTasksLock)
+        ServerLifetimeRegistration[] serverLifetimeRegistrations;
+        lock (_serverLifetimeRegistrationsLock)
         {
-            _backgroundTaskRegistrationClosed = true;
-            backgroundTasks = [.. _backgroundTasks.Keys];
+            _serverLifetimeRegistrationClosed = true;
+            serverLifetimeRegistrations = [.. _serverLifetimeRegistrations];
         }
 
         // Cancel all orphaned MRTR handlers still suspended in continuations (waiting for
@@ -682,9 +686,34 @@ internal sealed partial class McpServerImpl : McpServer, IMcpServerLifetimeFeatu
             await _allMrtrHandlersCompleted.Task.ConfigureAwait(false);
         }
 
-        if (backgroundTasks.Length > 0)
+        if (serverLifetimeRegistrations.Length > 0)
         {
-            await Task.WhenAll(backgroundTasks).ConfigureAwait(false);
+            await Task.WhenAll(
+                serverLifetimeRegistrations.Select(static registration => registration.DisposeResourceAsync().AsTask())
+            ).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class ServerLifetimeRegistration(
+        McpServerImpl server,
+        IAsyncDisposable resource) : IDisposable
+    {
+        private McpServerImpl? _server = server;
+
+        public ValueTask DisposeResourceAsync() => resource.DisposeAsync();
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _server, null)?.UnregisterServerLifetime(this);
+        }
+    }
+
+    private sealed class NoopRegistration : IDisposable
+    {
+        public static NoopRegistration Instance { get; } = new();
+
+        public void Dispose()
+        {
         }
     }
 

--- a/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
@@ -12,7 +12,7 @@ namespace ModelContextProtocol.Server;
 
 /// <inheritdoc />
 #pragma warning disable MCPEXP001, MCPEXP002
-internal sealed partial class McpServerImpl : McpServer
+internal sealed partial class McpServerImpl : McpServer, IMcpServerLifetimeFeature
 {
     internal static Implementation DefaultImplementation { get; } = new()
     {
@@ -31,6 +31,9 @@ internal sealed partial class McpServerImpl : McpServer
     private readonly string[] _initializeHandshakeProtocolVersions;
     private readonly string[] _perRequestMetadataProtocolVersions;
     private readonly SemaphoreSlim _disposeLock = new(1, 1);
+    private readonly CancellationTokenSource _serverLifetimeCts = new();
+    private readonly object _backgroundTasksLock = new();
+    private readonly ConcurrentDictionary<Task, byte> _backgroundTasks = new();
     private readonly ConcurrentDictionary<string, MrtrContinuation> _mrtrContinuations = new();
     private readonly ConcurrentDictionary<RequestId, MrtrContext> _mrtrContextsByRequestId = new();
     private static readonly string[] s_perRequestMetadataKeys =
@@ -55,6 +58,7 @@ internal sealed partial class McpServerImpl : McpServer
     private int _started;
 
     private bool _disposed;
+    private bool _backgroundTaskRegistrationClosed;
 
     /// <summary>Holds a boxed <see cref="LoggingLevel"/> value for the server.</summary>
     /// <remarks>
@@ -597,6 +601,38 @@ internal sealed partial class McpServerImpl : McpServer
     public override IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler)
         => _sessionHandler.RegisterNotificationHandler(method, handler);
 
+    CancellationToken IMcpServerLifetimeFeature.BackgroundTaskCancellationToken =>
+        HasStatefulTransport() ? _serverLifetimeCts.Token : CancellationToken.None;
+
+    void IMcpServerLifetimeFeature.RegisterBackgroundTask(Task backgroundTask)
+    {
+        Throw.IfNull(backgroundTask);
+
+        // Stateless HTTP servers are request-scoped, while Tasks runners intentionally outlive
+        // the originating request and are governed by tasks/cancel and task-store retention.
+        if (!HasStatefulTransport())
+        {
+            return;
+        }
+
+        lock (_backgroundTasksLock)
+        {
+            if (_backgroundTaskRegistrationClosed)
+            {
+                throw new ObjectDisposedException(nameof(McpServer));
+            }
+
+            _backgroundTasks.TryAdd(backgroundTask, 0);
+        }
+
+        _ = backgroundTask.ContinueWith(
+            static (task, state) => ((ConcurrentDictionary<Task, byte>)state!).TryRemove(task, out _),
+            _backgroundTasks,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
     /// <inheritdoc/>
     public override async ValueTask DisposeAsync()
     {
@@ -608,6 +644,7 @@ internal sealed partial class McpServerImpl : McpServer
         }
 
         _disposed = true;
+        _serverLifetimeCts.Cancel();
 
         // Dispose the session handler - cancels message processing and waits for all
         // in-flight request handlers (including retries in AwaitMrtrHandlerAsync) to complete.
@@ -615,6 +652,13 @@ internal sealed partial class McpServerImpl : McpServer
         // can be created, so _mrtrContinuations is effectively frozen.
         _disposables.ForEach(d => d());
         await _sessionHandler.DisposeAsync().ConfigureAwait(false);
+
+        Task[] backgroundTasks;
+        lock (_backgroundTasksLock)
+        {
+            _backgroundTaskRegistrationClosed = true;
+            backgroundTasks = [.. _backgroundTasks.Keys];
+        }
 
         // Cancel all orphaned MRTR handlers still suspended in continuations (waiting for
         // retries that will never arrive now that the session handler is disposed).
@@ -636,6 +680,11 @@ internal sealed partial class McpServerImpl : McpServer
         if (Interlocked.Decrement(ref _mrtrInFlightCount) != 0)
         {
             await _allMrtrHandlersCompleted.Task.ConfigureAwait(false);
+        }
+
+        if (backgroundTasks.Length > 0)
+        {
+            await Task.WhenAll(backgroundTasks).ConfigureAwait(false);
         }
     }
 
@@ -2379,6 +2428,9 @@ internal sealed partial class McpServerImpl : McpServer
             // is thread-safe with itself, and not disposing avoids deadlock risks from
             // calling Cancel/Dispose inside locks or Interlocked guards.
             var handlerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var serverLifetimeRegistration = _serverLifetimeCts.Token.Register(
+                static state => ((CancellationTokenSource)state!).Cancel(),
+                handlerCts);
 
             // Store the MrtrContext so CreateDestinationBoundServer can pick it up and set it
             // on the per-request DestinationBoundMcpServer. This is picked up synchronously
@@ -2388,6 +2440,11 @@ internal sealed partial class McpServerImpl : McpServer
             try
             {
                 handlerTask = originalHandler(request, handlerCts.Token);
+            }
+            catch
+            {
+                serverLifetimeRegistration.Dispose();
+                throw;
             }
             finally
             {
@@ -2401,7 +2458,7 @@ internal sealed partial class McpServerImpl : McpServer
             // exceptions and decrements _mrtrInFlightCount when the handler completes,
             // mirroring how McpSessionHandler tracks in-flight handlers.
             Interlocked.Increment(ref _mrtrInFlightCount);
-            _ = ObserveHandlerCompletionAsync(handlerTask);
+            _ = ObserveHandlerCompletionAsync(handlerTask, serverLifetimeRegistration);
 
             return await AwaitMrtrHandlerAsync(
                 handlerTask, continuation, mrtrContext.InitialExchangeTask, cancellationToken).ConfigureAwait(false);
@@ -2460,7 +2517,9 @@ internal sealed partial class McpServerImpl : McpServer
     /// double-reporting at Error) and decrements <see cref="_mrtrInFlightCount"/> when the
     /// handler completes, following the same in-flight tracking pattern as <see cref="McpSessionHandler"/>.
     /// </summary>
-    private async Task ObserveHandlerCompletionAsync(Task<JsonNode?> handlerTask)
+    private async Task ObserveHandlerCompletionAsync(
+        Task<JsonNode?> handlerTask,
+        CancellationTokenRegistration serverLifetimeRegistration)
     {
         try
         {
@@ -2480,6 +2539,8 @@ internal sealed partial class McpServerImpl : McpServer
         }
         finally
         {
+            serverLifetimeRegistration.Dispose();
+
             if (Interlocked.Decrement(ref _mrtrInFlightCount) == 0)
             {
                 _allMrtrHandlersCompleted.TrySetResult(true);

--- a/src/ModelContextProtocol.Extensions.Tasks/Server/McpTasksBuilderExtensions.cs
+++ b/src/ModelContextProtocol.Extensions.Tasks/Server/McpTasksBuilderExtensions.cs
@@ -82,7 +82,7 @@ public static class McpTasksBuilderExtensions
         private readonly IServiceScopeFactory _serviceScopeFactory = serviceScopeFactory;
         private readonly ILogger _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<McpTasksConfigureOptions>();
         private readonly McpTasksOptions _taskOptions = taskOptions;
-        private readonly ConcurrentDictionary<string, CancellationTokenSource> _cancellationSources = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, TaskCancellationState> _cancellationStates = new(StringComparer.Ordinal);
 
         public void Configure(McpServerOptions options)
         {
@@ -183,15 +183,27 @@ public static class McpTasksBuilderExtensions
 
             var taskId = taskInfo.TaskId;
             executionRequest.Server = request.Server.WithMcpTaskOutgoingRequestInterceptor(taskId, _store);
-            var cts = new CancellationTokenSource();
-            _cancellationSources[taskId] = cts;
+            var serverLifetime = request.Server as IMcpServerLifetimeFeature;
+            var cancellationState = new TaskCancellationState(
+                serverLifetime?.ServerCancellationToken ?? CancellationToken.None);
+            _cancellationStates[taskId] = cancellationState;
 
-            // Capture the token before dispatching. Cancellation can remove and dispose the source
-            // before the background delegate starts.
-            var taskCancellationToken = cts.Token;
-            _ = Task.Run(
+            var taskCancellationToken = cancellationState.Token;
+            var backgroundTask = Task.Run(
                 () => ExecuteTaskAsync(next, executionRequest, taskId, taskCancellationToken, executionScope),
                 CancellationToken.None);
+            cancellationState.SetBackgroundTask(backgroundTask);
+            try
+            {
+                cancellationState.SetServerLifetimeRegistration(
+                    serverLifetime?.RegisterForDisposeAsync(cancellationState));
+            }
+            catch
+            {
+                cancellationState.Cancel();
+                await backgroundTask.ConfigureAwait(false);
+                throw;
+            }
 
             return ResultOrAlternate<CallToolResult>.FromAlternate(
                 ToCreateTaskResult(taskInfo),
@@ -235,9 +247,9 @@ public static class McpTasksBuilderExtensions
             }
             finally
             {
-                if (_cancellationSources.TryRemove(taskId, out var registeredCts))
+                if (_cancellationStates.TryRemove(taskId, out var registeredState))
                 {
-                    registeredCts.Dispose();
+                    registeredState.UnregisterServerLifetime();
                 }
             }
         }
@@ -354,13 +366,72 @@ public static class McpTasksBuilderExtensions
 
             await _store.SetCancelledAsync(requestParams.TaskId, cancellationToken).ConfigureAwait(false);
 
-            if (_cancellationSources.TryRemove(requestParams.TaskId, out var cts))
+            if (_cancellationStates.TryGetValue(requestParams.TaskId, out var cancellationState))
             {
-                cts.Cancel();
-                cts.Dispose();
+                cancellationState.Cancel();
             }
 
             return JsonSerializer.SerializeToNode(new CancelTaskResult(), McpTasksJsonContext.Default.CancelTaskResult);
+        }
+
+        private sealed class TaskCancellationState : IAsyncDisposable
+        {
+            private readonly CancellationTokenSource _source = new();
+            private readonly CancellationTokenRegistration _serverLifetimeRegistration;
+            private Task? _backgroundTask;
+            private IDisposable? _serverLifetimeUnregistration;
+            private int _completed;
+
+            public TaskCancellationState(CancellationToken serverLifetimeToken)
+            {
+                _serverLifetimeRegistration = serverLifetimeToken.Register(
+                    static state => ((TaskCancellationState)state!).Cancel(),
+                    this);
+            }
+
+            public CancellationToken Token => _source.Token;
+
+            public void Cancel() => _source.Cancel();
+
+            public void SetBackgroundTask(Task backgroundTask) => _backgroundTask = backgroundTask;
+
+            public void SetServerLifetimeRegistration(IDisposable? registration)
+            {
+                if (registration is null)
+                {
+                    return;
+                }
+
+                if (Volatile.Read(ref _completed) != 0)
+                {
+                    registration.Dispose();
+                    return;
+                }
+
+                Interlocked.CompareExchange(ref _serverLifetimeUnregistration, registration, null);
+                if (Volatile.Read(ref _completed) != 0)
+                {
+                    Interlocked.Exchange(ref _serverLifetimeUnregistration, null)?.Dispose();
+                }
+            }
+
+            public void UnregisterServerLifetime()
+            {
+                // Cancellation can arrive concurrently from tasks/cancel and server disposal.
+                // Once the dictionary entry and server registration are gone, the CTS is collectible.
+                Interlocked.Exchange(ref _completed, 1);
+                _serverLifetimeRegistration.Dispose();
+                Interlocked.Exchange(ref _serverLifetimeUnregistration, null)?.Dispose();
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                Cancel();
+                if (_backgroundTask is { } backgroundTask)
+                {
+                    await backgroundTask.ConfigureAwait(false);
+                }
+            }
         }
 
         private static void GateToJuly2026OrLaterProtocol(JsonRpcRequest request, string method)

--- a/tests/ModelContextProtocol.Tests/Server/TaskCancellationIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/TaskCancellationIntegrationTests.cs
@@ -110,6 +110,218 @@ public class TaskCancellationIntegrationTests : ClientServerTestBase
 }
 
 /// <summary>
+/// Tests for task-store runner cleanup during server disposal.
+/// </summary>
+public class TaskRunnerLifecycleTests : ClientServerTestBase
+{
+    private readonly TaskCompletionSource<bool> _toolStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _toolCancellationFired = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _releaseCancellationCleanup = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _forceToolExit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _toolExited = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _runnerRegistrationBlocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _releaseRunnerRegistration = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly BlockingCancellationTaskStore _taskStore = new();
+    private bool _delayRunnerRegistration;
+
+    public TaskRunnerLifecycleTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+#if !NET
+        Assert.SkipWhen(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "https://github.com/modelcontextprotocol/csharp-sdk/issues/587");
+#endif
+    }
+
+    protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
+    {
+#pragma warning disable MCPEXP002
+        services.Configure<McpServerOptions>(options =>
+            options.Filters.Request.CallToolWithAlternateFilters.Add(next => async (request, cancellationToken) =>
+            {
+                if (_delayRunnerRegistration && request.Params?.Name == "lifecycle-tool")
+                {
+                    _runnerRegistrationBlocked.TrySetResult(true);
+                    await _releaseRunnerRegistration.Task;
+                }
+
+                return await next(request, cancellationToken);
+            }));
+#pragma warning restore MCPEXP002
+
+        mcpServerBuilder
+            .WithTasks(_taskStore)
+            .WithTools([McpServerTool.Create(
+            async (CancellationToken ct) =>
+            {
+                _toolStarted.TrySetResult(true);
+                try
+                {
+                    var cancellationTask = Task.Delay(Timeout.Infinite, ct);
+                    var completedTask = await Task.WhenAny(cancellationTask, _forceToolExit.Task);
+                    await completedTask;
+                    return "forced test cleanup";
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    _toolCancellationFired.TrySetResult(true);
+                    await _releaseCancellationCleanup.Task;
+                    throw;
+                }
+                finally
+                {
+                    _toolExited.TrySetResult(true);
+                }
+            },
+            new McpServerToolCreateOptions
+            {
+                Name = "lifecycle-tool",
+                Description = "A tool used to verify task runner lifecycle"
+            })]);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CancelsAndWaitsForTaskStoreRunner()
+    {
+        await using var client = await CreateMcpClientForServer();
+        var ct = TestContext.Current.CancellationToken;
+
+        var augmented = await client.CallToolAsTaskAsync(
+            new CallToolRequestParams { Name = "lifecycle-tool" }, ct);
+        Assert.True(augmented.IsTask);
+
+        await _toolStarted.Task.WaitAsync(TestConstants.DefaultTimeout, ct);
+        Task disposeTask = Server.DisposeAsync().AsTask();
+
+        try
+        {
+            Task firstCompleted = await Task.WhenAny(_toolCancellationFired.Task, disposeTask)
+                .WaitAsync(TestConstants.DefaultTimeout, ct);
+
+            Assert.Same(_toolCancellationFired.Task, firstCompleted);
+            Assert.False(disposeTask.IsCompleted, "DisposeAsync should wait for the runner's cancellation cleanup.");
+
+            _releaseCancellationCleanup.TrySetResult(true);
+            await disposeTask.WaitAsync(TestConstants.DefaultTimeout, ct);
+        }
+        finally
+        {
+            _releaseCancellationCleanup.TrySetResult(true);
+            _forceToolExit.TrySetResult(true);
+            await _toolExited.Task.WaitAsync(TestConstants.DefaultTimeout, ct);
+        }
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CancelsAndWaitsForRunnerRegisteredDuringDisposal()
+    {
+        await using var client = await CreateMcpClientForServer();
+        var ct = TestContext.Current.CancellationToken;
+        _delayRunnerRegistration = true;
+        _taskStore.PauseCancellationRecording();
+
+        var callTask = client.CallToolAsTaskAsync(
+            new CallToolRequestParams { Name = "lifecycle-tool" }, ct).AsTask();
+        _ = callTask.ContinueWith(
+            static task => _ = task.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+        await _runnerRegistrationBlocked.Task.WaitAsync(TestConstants.DefaultTimeout, ct);
+
+        var serverLifetime = Assert.IsAssignableFrom<IMcpServerLifetimeFeature>(Server);
+        var serverCancellationFired = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = serverLifetime.BackgroundTaskCancellationToken.Register(
+            static state => ((TaskCompletionSource<bool>)state!).TrySetResult(true), serverCancellationFired);
+
+        Task disposeTask = Server.DisposeAsync().AsTask();
+
+        try
+        {
+            await serverCancellationFired.Task.WaitAsync(TestConstants.DefaultTimeout, ct);
+            _releaseRunnerRegistration.TrySetResult(true);
+
+            await _taskStore.CancellationRecordingStarted.WaitAsync(TestConstants.DefaultTimeout, ct);
+            Assert.False(disposeTask.IsCompleted, "DisposeAsync should wait for a runner registered during disposal.");
+
+            _taskStore.ReleaseCancellationRecording();
+            await disposeTask.WaitAsync(TestConstants.DefaultTimeout, ct);
+        }
+        finally
+        {
+            _releaseRunnerRegistration.TrySetResult(true);
+            _releaseCancellationCleanup.TrySetResult(true);
+            _taskStore.ReleaseCancellationRecording();
+            _forceToolExit.TrySetResult(true);
+
+            if (_toolStarted.Task.IsCompleted)
+            {
+                await _toolExited.Task.WaitAsync(TestConstants.DefaultTimeout, ct);
+            }
+        }
+    }
+
+    private sealed class BlockingCancellationTaskStore : InMemoryMcpTaskStore, IMcpTaskStore
+    {
+        private readonly TaskCompletionSource<bool> _cancellationRecordingStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _releaseCancellationRecording = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _pauseCancellationRecording;
+
+        public Task CancellationRecordingStarted => _cancellationRecordingStarted.Task;
+
+        public void PauseCancellationRecording() => _pauseCancellationRecording = true;
+
+        public void ReleaseCancellationRecording() => _releaseCancellationRecording.TrySetResult(true);
+
+        async Task<bool> IMcpTaskStore.SetCancelledAsync(string taskId, CancellationToken cancellationToken)
+        {
+            if (_pauseCancellationRecording)
+            {
+                _cancellationRecordingStarted.TrySetResult(true);
+                await _releaseCancellationRecording.Task;
+            }
+
+            return await base.SetCancelledAsync(taskId, cancellationToken);
+        }
+    }
+}
+
+public class McpServerLifetimeFeatureTests(ITestOutputHelper testOutputHelper) : LoggedTest(testOutputHelper)
+{
+    [Fact]
+    public async Task DisposeAsync_DoesNotCancelOrWaitForStatelessBackgroundTask()
+    {
+        await using var transport = new StreamableHttpServerTransport { Stateless = true };
+        await using var statelessServer = McpServer.Create(
+            transport,
+            new McpServerOptions
+            {
+                ServerInfo = new Implementation { Name = "test-server", Version = "1.0" },
+            },
+            LoggerFactory);
+        var serverLifetime = Assert.IsAssignableFrom<IMcpServerLifetimeFeature>(statelessServer);
+        var releaseBackgroundTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task backgroundTask = releaseBackgroundTask.Task;
+
+        serverLifetime.RegisterBackgroundTask(backgroundTask);
+
+        try
+        {
+            await statelessServer.DisposeAsync().AsTask()
+                .WaitAsync(TestConstants.DefaultTimeout, TestContext.Current.CancellationToken);
+
+            Assert.False(serverLifetime.BackgroundTaskCancellationToken.CanBeCanceled);
+            Assert.False(backgroundTask.IsCompleted,
+                "A stateless per-request server should not own background work that outlives the request.");
+        }
+        finally
+        {
+            releaseBackgroundTask.TrySetResult(true);
+            await backgroundTask;
+        }
+    }
+}
+
+/// <summary>
 /// Tests for task cancellation with multiple concurrent tasks.
 /// </summary>
 public class TaskCancellationConcurrencyTests : ClientServerTestBase

--- a/tests/ModelContextProtocol.Tests/Server/TaskCancellationIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/TaskCancellationIntegrationTests.cs
@@ -136,7 +136,7 @@ public class TaskRunnerLifecycleTests : ClientServerTestBase
     {
 #pragma warning disable MCPEXP002
         services.Configure<McpServerOptions>(options =>
-            options.Filters.Request.CallToolWithAlternateFilters.Add(next => async (request, cancellationToken) =>
+            options.Filters.Request.CallToolWithAlternateFilters.Add(async (request, next, cancellationToken) =>
             {
                 if (_delayRunnerRegistration && request.Params?.Name == "lifecycle-tool")
                 {
@@ -177,6 +177,45 @@ public class TaskRunnerLifecycleTests : ClientServerTestBase
                 Name = "lifecycle-tool",
                 Description = "A tool used to verify task runner lifecycle"
             })]);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesAndWaitsForRegisteredLifetimeResource()
+    {
+        await using var client = await CreateMcpClientForServer();
+        var ct = TestContext.Current.CancellationToken;
+        var serverLifetime = Assert.IsAssignableFrom<IMcpServerLifetimeFeature>(Server);
+        var resource = new BlockingAsyncDisposable();
+        using var registration = serverLifetime.RegisterForDisposeAsync(resource);
+
+        Task disposeTask = Server.DisposeAsync().AsTask();
+
+        try
+        {
+            await resource.DisposeStarted.WaitAsync(TestConstants.DefaultTimeout, ct);
+            Assert.False(disposeTask.IsCompleted, "DisposeAsync should await the registered resource.");
+
+            resource.Release();
+            await disposeTask.WaitAsync(TestConstants.DefaultTimeout, ct);
+        }
+        finally
+        {
+            resource.Release();
+        }
+    }
+
+    [Fact]
+    public async Task LifetimeRegistration_DisposeUnregistersResource()
+    {
+        await using var client = await CreateMcpClientForServer();
+        var serverLifetime = Assert.IsAssignableFrom<IMcpServerLifetimeFeature>(Server);
+        var resource = new RecordingAsyncDisposable();
+        using var registration = serverLifetime.RegisterForDisposeAsync(resource);
+
+        registration.Dispose();
+        await Server.DisposeAsync();
+
+        Assert.False(resource.IsDisposed);
     }
 
     [Fact]
@@ -230,7 +269,7 @@ public class TaskRunnerLifecycleTests : ClientServerTestBase
 
         var serverLifetime = Assert.IsAssignableFrom<IMcpServerLifetimeFeature>(Server);
         var serverCancellationFired = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var registration = serverLifetime.BackgroundTaskCancellationToken.Register(
+        using var registration = serverLifetime.ServerCancellationToken.Register(
             static state => ((TaskCompletionSource<bool>)state!).TrySetResult(true), serverCancellationFired);
 
         Task disposeTask = Server.DisposeAsync().AsTask();
@@ -283,6 +322,33 @@ public class TaskRunnerLifecycleTests : ClientServerTestBase
             return await base.SetCancelledAsync(taskId, cancellationToken);
         }
     }
+
+    private sealed class BlockingAsyncDisposable : IAsyncDisposable
+    {
+        private readonly TaskCompletionSource<bool> _disposeStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task DisposeStarted => _disposeStarted.Task;
+
+        public void Release() => _release.TrySetResult(true);
+
+        public async ValueTask DisposeAsync()
+        {
+            _disposeStarted.TrySetResult(true);
+            await _release.Task;
+        }
+    }
+
+    private sealed class RecordingAsyncDisposable : IAsyncDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            return default;
+        }
+    }
 }
 
 public class McpServerLifetimeFeatureTests(ITestOutputHelper testOutputHelper) : LoggedTest(testOutputHelper)
@@ -299,24 +365,26 @@ public class McpServerLifetimeFeatureTests(ITestOutputHelper testOutputHelper) :
             },
             LoggerFactory);
         var serverLifetime = Assert.IsAssignableFrom<IMcpServerLifetimeFeature>(statelessServer);
-        var releaseBackgroundTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        Task backgroundTask = releaseBackgroundTask.Task;
+        var backgroundResource = new RecordingAsyncDisposable();
 
-        serverLifetime.RegisterBackgroundTask(backgroundTask);
+        using var registration = serverLifetime.RegisterForDisposeAsync(backgroundResource);
 
-        try
+        await statelessServer.DisposeAsync().AsTask()
+            .WaitAsync(TestConstants.DefaultTimeout, TestContext.Current.CancellationToken);
+
+        Assert.False(serverLifetime.ServerCancellationToken.CanBeCanceled);
+        Assert.False(backgroundResource.IsDisposed,
+            "A stateless per-request server should not own background work that outlives the request.");
+    }
+
+    private sealed class RecordingAsyncDisposable : IAsyncDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public ValueTask DisposeAsync()
         {
-            await statelessServer.DisposeAsync().AsTask()
-                .WaitAsync(TestConstants.DefaultTimeout, TestContext.Current.CancellationToken);
-
-            Assert.False(serverLifetime.BackgroundTaskCancellationToken.CanBeCanceled);
-            Assert.False(backgroundTask.IsCompleted,
-                "A stateless per-request server should not own background work that outlives the request.");
-        }
-        finally
-        {
-            releaseBackgroundTask.TrySetResult(true);
-            await backgroundTask;
+            IsDisposed = true;
+            return default;
         }
     }
 }


### PR DESCRIPTION
## Summary

Background Tasks runners used cancellation sources independent of the owning
server and discarded their Task handles. As a result, server disposal could
finish before a runner was cancelled, including when the runner registered
during disposal.

## Changes

- Add a general server-lifetime cancellation and `IAsyncDisposable`
  registration seam for extension infrastructure, with an unregistration
  handle so completed work is not retained.
- Cancel the lifetime at the start of stateful server disposal, close
  registration after request handlers drain, and await the remaining runners.
- Let each Tasks runner state own cancellation and completion awaiting, while
  long-lived MRTR handlers remain linked to the server lifetime and completed
  registrations are removed.
- Keep stateless HTTP request servers non-owning so Tasks can continue across
  independent requests.
- Add deterministic coverage for cancellation, awaiting, late registration,
  and the stateless ownership boundary.

The change does not alter protocol messages, task-store contracts, polling, or
explicit tasks/cancel behavior.

## Verification

```bash
dotnet test tests/ModelContextProtocol.Tests/
dotnet test tests/ModelContextProtocol.Analyzers.Tests/
dotnet build
dotnet pack
dotnet docfx docs/docfx.json --warningsAsErrors true
```

The current lifetime-registration focus passed on net10.0, net9.0, and net8.0
(5 tests on each framework). The merged net10.0 lifecycle and Tasks
execution-mode focus passed 61 tests. The full Core suite passed with 2328 passed and 5
skipped; the analyzer suite passed with 57 passed. The Release solution build
completed with 0 warnings and 0 errors, package validation produced all
packages, and DocFX completed with 0 warnings and 0 errors.

Closes #1707
