### PR TITLE
Compose alternate-result filters with typed server handlers

### DIFF
--- a/docs/concepts/filters.md
+++ b/docs/concepts/filters.md
@@ -30,6 +30,37 @@ The following request filter methods are available on `IMcpRequestFilterBuilder`
 - `AddUnsubscribeFromResourcesFilter` - Filter for resource unsubscription handlers
 - `AddSetLoggingLevelFilter` - Filter for logging level handlers
 
+### Alternate-Result Filters
+
+Extension packages can augment any typed server method with a filter that returns either the method's
+ordinary result or an alternate `Result` subtype. Register the filter by case-sensitive method name on
+`McpServerOptions`:
+
+```csharp
+services.Configure<McpServerOptions>(options =>
+    options.AddAlternateResultFilter<GetPromptRequestParams, GetPromptResult>(
+        RequestMethods.PromptsGet,
+        next => async (context, cancellationToken) =>
+        {
+            if (ShouldDefer(context.Params))
+            {
+                return ResultOrAlternate<GetPromptResult>.FromAlternate(
+                    CreateDeferredResult(),
+                    MyJsonContext.Default.DeferredResult);
+            }
+
+            return await next(context, cancellationToken);
+        }));
+```
+
+The parameter and ordinary result types must exactly match the configured typed handler for the method.
+The server reports unknown methods and type mismatches when it starts. Multiple filters for one method
+run in registration order, with the first registered filter outermost. The ordinary request-specific
+filters and handler execute inside the alternate-result filters.
+
+An explicit `CallToolWithAlternateHandler` remains a low-level replacement for `tools/call`; it cannot
+be combined with ordinary call-tool filters or a method-keyed alternate-result filter for that method.
+
 ## Message Filters
 
 In addition to the request-specific filters above, there are low-level message filters that intercept all JSON-RPC messages before they are routed to specific handlers.

--- a/docs/concepts/tasks/tasks.md
+++ b/docs/concepts/tasks/tasks.md
@@ -79,6 +79,16 @@ When tasks are enabled with `WithTasks` the SDK automatically:
 - Plumbs a `CancellationToken` through to the tool that fires when the client invokes
   `tasks/cancel`, so cancellation propagates cooperatively.
 
+The task wrapper runs outside the ordinary `tools/call` pipeline. For an opted-in call, the store creates
+the task record first and the ordinary request filters then run exactly once during background execution,
+with the matched tool available in `RequestContext.MatchedPrimitive`. Authorization and validation filters
+therefore still run before the tool body. If authorization fails, the task transitions to `failed` and the
+tool is not invoked; the task record already exists when that denial occurs.
+
+Background execution receives a new asynchronous dependency-injection scope before the initiating request
+completes. Scoped filter services and tool dependencies therefore remain available after an HTTP request scope
+has been disposed. The execution scope is disposed after the task reaches its recorded outcome.
+
 For production scenarios that need durability, session isolation, multi-process routing, or
 TTL-based cleanup, implement <xref:ModelContextProtocol.Extensions.Tasks.IMcpTaskStore> yourself
 (see [Implementing a custom task store](#implementing-a-custom-task-store) below).
@@ -111,15 +121,16 @@ options.Handlers.CallToolWithAlternateHandler = async (context, ct) =>
         PollIntervalMs = 1000,
     };
 
-    return new ResultOrAlternate<CallToolResult>(created, McpTasksJsonContext.Default.CreateTaskResult);
+    return ResultOrAlternate<CallToolResult>.FromAlternate(
+      created,
+      McpTasksJsonContext.Default.CreateTaskResult);
 };
 ```
 
 > This low-level handler is mutually exclusive with `WithTasks`. When a store is configured, the
-> SDK does the wrapping for you and throws `InvalidOperationException` if the alternate handler also
-> returns an alternate. Use one mechanism or the other. When you return a task this way you are also
-> responsible for serving `tasks/get`, `tasks/update`, and `tasks/cancel`, which the store provides
-> automatically.
+    > SDK does the wrapping for you and rejects an explicit alternate handler when the server starts.
+    > Use one mechanism or the other. When you return a task this way you are also responsible for serving
+    > `tasks/get`, `tasks/update`, and `tasks/cancel`, which the store provides automatically.
 
 > <xref:ModelContextProtocol.Server.McpServerHandlers.CallToolHandler?displayProperty=nameWithType>
 > and <xref:ModelContextProtocol.Server.McpServerHandlers.CallToolWithAlternateHandler?displayProperty=nameWithType>

--- a/src/ModelContextProtocol.Core/Server/McpRequestFilters.cs
+++ b/src/ModelContextProtocol.Core/Server/McpRequestFilters.cs
@@ -43,10 +43,15 @@ public sealed class McpRequestFilters
     /// <see cref="RequestMethods.ToolsCall"/> requests. The handler should implement logic to execute the requested tool and return appropriate results.
     /// </para>
     /// <para>
-    /// Cannot be used together with <see cref="CallToolWithAlternateFilters"/>. If both are non-empty at configuration time,
-    /// an <see cref="InvalidOperationException"/> will be thrown. This can happen indirectly when combining features that
-    /// register different tool-call filter styles, such as authorization filters (which use this collection) and the
-    /// tasks extension (which uses <see cref="CallToolWithAlternateFilters"/>).
+    /// These filters run inside <see cref="CallToolWithAlternateFilters"/> and any method-keyed alternate-result filters
+    /// registered through <see cref="McpServerOptions.AddAlternateResultFilter{TParams, TResult}(string, McpRequestFilter{TParams, ResultOrAlternate{TResult}})"/>.
+    /// Each ordinary filter runs exactly once when an alternate-result filter invokes the ordinary tool pipeline.
+    /// For task-backed calls, that invocation occurs in the background after the task record is created and before the
+    /// matched tool is executed.
+    /// </para>
+    /// <para>
+    /// These filters cannot be used with an explicit <see cref="McpServerHandlers.CallToolWithAlternateHandler"/>, which
+    /// replaces the ordinary tool-call pipeline rather than augmenting it.
     /// </para>
     /// </remarks>
     public IList<McpRequestFilter<CallToolRequestParams, CallToolResult>> CallToolFilters
@@ -71,10 +76,9 @@ public sealed class McpRequestFilters
     /// subtype for asynchronous execution.
     /// </para>
     /// <para>
-    /// Cannot be used together with <see cref="CallToolFilters"/>. If both are non-empty at configuration time,
-    /// an <see cref="InvalidOperationException"/> will be thrown. This can happen indirectly when combining features that
-    /// register different tool-call filter styles, such as the tasks extension (which uses this collection) and
-    /// authorization filters (which use <see cref="CallToolFilters"/>).
+    /// These filters compose outside <see cref="CallToolFilters"/>. The ordinary pipeline, including primitive matching
+    /// and ordinary filters, is adapted to <see cref="ResultOrAlternate{TResult}"/> before these filters are applied.
+    /// The first alternate-result filter added is the outermost filter.
     /// </para>
     /// </remarks>
     [Experimental(Experimentals.Subclassing_DiagnosticId, UrlFormat = Experimentals.Subclassing_Url)]

--- a/src/ModelContextProtocol.Core/Server/McpServerHandlers.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerHandlers.cs
@@ -72,7 +72,10 @@ public sealed class McpServerHandlers
     /// a <see cref="CallToolResult"/> for immediate results or an alternate <see cref="Result"/> subtype.
     /// </para>
     /// <para>
-    /// Cannot be set if <see cref="CallToolHandler"/> is already set.
+    /// This is a low-level full replacement for the ordinary tool-call pipeline. It cannot be set if
+    /// <see cref="CallToolHandler"/> is already set, and it cannot be composed with ordinary
+    /// <see cref="McpRequestFilters.CallToolFilters"/> or a method-keyed alternate-result filter for
+    /// <see cref="RequestMethods.ToolsCall"/>.
     /// </para>
     /// </remarks>
     /// <exception cref="InvalidOperationException"><see cref="CallToolHandler"/> is already set.</exception>

--- a/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
@@ -26,6 +26,7 @@ internal sealed partial class McpServerImpl : McpServer
     private readonly List<Action> _disposables = [];
     private readonly NotificationHandlers _notificationHandlers;
     private readonly RequestHandlers _requestHandlers;
+    private readonly HashSet<string> _configuredAlternateResultFilterMethods = new(StringComparer.Ordinal);
     private readonly McpSessionHandler _sessionHandler;
     private readonly string[] _supportedProtocolVersions;
     private readonly string[] _initializeHandshakeProtocolVersions;
@@ -108,6 +109,7 @@ internal sealed partial class McpServerImpl : McpServer
         ConfigureCompletion(options);
         ConfigureSubscriptions(options);
         ConfigureExperimentalAndExtensions(options);
+        ValidateAlternateResultFilters(options);
         ConfigureMrtr();
         ConfigureCustomRequestHandlers(options);
 
@@ -996,6 +998,19 @@ internal sealed partial class McpServerImpl : McpServer
         ServerCapabilities.Extensions = options.Capabilities?.Extensions;
     }
 
+    private void ValidateAlternateResultFilters(McpServerOptions options)
+    {
+        foreach (var method in options.AlternateResultFilterMethods)
+        {
+            if (!_configuredAlternateResultFilterMethods.Contains(method))
+            {
+                throw new InvalidOperationException(
+                    $"An alternate-result filter was registered for method '{method}', but the server has no matching typed handler. " +
+                    $"Configure the built-in handler and capability for that method, and ensure the registered parameter and result types match it.");
+            }
+        }
+    }
+
     private void ConfigureCustomRequestHandlers(McpServerOptions options)
     {
 #pragma warning disable MCPEXP002
@@ -1321,20 +1336,21 @@ internal sealed partial class McpServerImpl : McpServer
         var callToolFilters = options.Filters.Request.CallToolFilters;
         var callToolWithAlternateFilters = options.Filters.Request.CallToolWithAlternateFilters;
 
-        // Validate: cannot mix non-alternate filters/handler with alternate filters/handler.
-        bool hasNonAlternatePath = callToolHandler is not null || callToolFilters.Count > 0;
-        bool hasAlternatePath = callToolWithAlternateHandler is not null || callToolWithAlternateFilters.Count > 0;
-
-        if (hasNonAlternatePath && hasAlternatePath)
+        if (callToolWithAlternateHandler is not null && callToolFilters.Count > 0)
         {
             throw new InvalidOperationException(
-                $"Cannot mix non-alternate ({nameof(McpServerHandlers.CallToolHandler)}/{nameof(McpRequestFilters.CallToolFilters)}) " +
-                $"with alternate-based ({nameof(McpServerHandlers.CallToolWithAlternateHandler)}/{nameof(McpRequestFilters.CallToolWithAlternateFilters)}) tool-call filters or handlers. " +
-                $"These two styles cannot currently be composed on the same server. " +
-                $"This most commonly happens when combining features that register different tool-call filter styles, " +
-                $"for example AddAuthorizationFilters() (which registers a {nameof(McpRequestFilters.CallToolFilters)} filter) together with " +
-                $"WithTasks() (which registers a {nameof(McpRequestFilters.CallToolWithAlternateFilters)} filter). " +
-                $"Configure only one style, or avoid combining features that require different styles.");
+                $"Cannot apply {nameof(McpRequestFilters.CallToolFilters)} when an explicit " +
+                $"{nameof(McpServerHandlers.CallToolWithAlternateHandler)} is configured. The alternate handler replaces " +
+                $"the ordinary tool-call pipeline. Move the behavior to {nameof(McpRequestFilters.CallToolWithAlternateFilters)} " +
+                $"or remove the explicit alternate handler.");
+        }
+
+        if (callToolWithAlternateHandler is not null && options.HasAlternateResultFilters(RequestMethods.ToolsCall))
+        {
+            throw new InvalidOperationException(
+                $"Cannot apply an alternate-result filter registered for '{RequestMethods.ToolsCall}' when an explicit " +
+                $"{nameof(McpServerHandlers.CallToolWithAlternateHandler)} is configured. The alternate handler replaces " +
+                $"the ordinary tool-call pipeline. Remove the explicit alternate handler or the method-keyed filter.");
         }
 
         // Handle tools provided via DI by augmenting the list handler.
@@ -1376,12 +1392,9 @@ internal sealed partial class McpServerImpl : McpServer
 
         listToolsHandler = BuildFilterPipeline(listToolsHandler, options.Filters.Request.ListToolsFilters);
 
-        // Build the unified alternate-result handler from one of the two paths.
-        if (hasAlternatePath)
+        // An explicit alternate handler replaces the ordinary tool-call pipeline.
+        if (callToolWithAlternateHandler is not null)
         {
-            // Case 2: alternate filter + alternate handler
-            callToolWithAlternateHandler ??= (static async (request, _) => throw new McpProtocolException($"Unknown tool: '{request.Params?.Name}'", McpErrorCode.InvalidParams));
-
             // Augment with DI tools.
             if (tools is not null)
             {
@@ -1398,10 +1411,15 @@ internal sealed partial class McpServerImpl : McpServer
             }
 
             callToolWithAlternateHandler = BuildFilterPipeline(callToolWithAlternateHandler, callToolWithAlternateFilters, BuildInitialAlternateToolFilter(tools));
+
+            SetWithAlternateHandler(
+                RequestMethods.ToolsCall,
+                callToolWithAlternateHandler,
+                McpJsonUtilities.JsonContext.Default.CallToolRequestParams,
+                McpJsonUtilities.JsonContext.Default.CallToolResult);
         }
         else
         {
-            // Case 1: non-alternate filter + non-alternate handler -> apply filters, then convert to alternate-based
             callToolHandler ??= (static async (request, _) => throw new McpProtocolException($"Unknown tool: '{request.Params?.Name}'", McpErrorCode.InvalidParams));
 
             // Augment with DI tools.
@@ -1421,10 +1439,12 @@ internal sealed partial class McpServerImpl : McpServer
 
             callToolHandler = BuildFilterPipeline(callToolHandler, callToolFilters, BuildInitialCallToolFilter(tools));
 
-            // Convert to alternate-based.
-            var finalCallToolHandler = callToolHandler;
-            callToolWithAlternateHandler = async (request, cancellationToken) =>
-                await finalCallToolHandler(request, cancellationToken).ConfigureAwait(false);
+            SetHandler(
+                RequestMethods.ToolsCall,
+                callToolHandler,
+                McpJsonUtilities.JsonContext.Default.CallToolRequestParams,
+                McpJsonUtilities.JsonContext.Default.CallToolResult,
+                callToolWithAlternateFilters);
         }
         ServerCapabilities.Tools.ListChanged = listChanged;
 
@@ -1434,11 +1454,6 @@ internal sealed partial class McpServerImpl : McpServer
             McpJsonUtilities.JsonContext.Default.ListToolsRequestParams,
             McpJsonUtilities.JsonContext.Default.ListToolsResult);
 
-        SetWithAlternateHandler(
-            RequestMethods.ToolsCall,
-            callToolWithAlternateHandler,
-            McpJsonUtilities.JsonContext.Default.CallToolRequestParams,
-            McpJsonUtilities.JsonContext.Default.CallToolResult);
     }
     private static async ValueTask<ResultOrAlternate<CallToolResult>> InvokeToolWithAlternate(
         McpServerTool tool,
@@ -1635,11 +1650,14 @@ internal sealed partial class McpServerImpl : McpServer
         return server;
     }
 
+#pragma warning disable MCPEXP002 // SetHandler and SetWithAlternateHandler wrap the experimental ResultOrAlternate seam
     private void SetHandler<TParams, TResult>(
         string method,
         McpRequestHandler<TParams, TResult> handler,
         JsonTypeInfo<TParams> requestTypeInfo,
-        JsonTypeInfo<TResult> responseTypeInfo)
+        JsonTypeInfo<TResult> responseTypeInfo,
+        IList<McpRequestFilter<TParams, ResultOrAlternate<TResult>>>? alternateResultFilters = null)
+        where TResult : Result
     {
         // SEP-2549: results that carry caching hints (tools/list, prompts/list, resources/list,
         // resources/templates/list, and resources/read) declare ttlMs and cacheScope as required fields.
@@ -1662,19 +1680,38 @@ internal sealed partial class McpServerImpl : McpServer
             };
         }
 
-        if (typeof(Result).IsAssignableFrom(typeof(TResult)))
+        var resultHandler = handler;
+        handler = async (request, cancellationToken) =>
         {
-            var innerHandler = handler;
-            handler = async (request, cancellationToken) =>
+            var result = await resultHandler(request, cancellationToken).ConfigureAwait(false);
+            if (result.ResultType is null)
             {
-                var result = await innerHandler(request, cancellationToken).ConfigureAwait(false);
-                if (result is Result protocolResult && protocolResult.ResultType is null)
-                {
-                    protocolResult.ResultType = "complete";
-                }
+                result.ResultType = "complete";
+            }
 
-                return result;
-            };
+            return result;
+        };
+
+        var registeredAlternateResultFilters = ServerOptions.GetAlternateResultFilters<TParams, TResult>(method);
+        if (registeredAlternateResultFilters.Count > 0 || alternateResultFilters is { Count: > 0 })
+        {
+            if (registeredAlternateResultFilters.Count > 0)
+            {
+                _configuredAlternateResultFilterMethods.Add(method);
+            }
+
+            var ordinaryHandler = handler;
+            McpRequestHandler<TParams, ResultOrAlternate<TResult>> alternateHandler = async (request, cancellationToken) =>
+                await ordinaryHandler(request, cancellationToken).ConfigureAwait(false);
+
+            if (alternateResultFilters is not null)
+            {
+                alternateHandler = BuildFilterPipeline(alternateHandler, alternateResultFilters);
+            }
+
+            alternateHandler = BuildFilterPipeline(alternateHandler, registeredAlternateResultFilters);
+            SetWithAlternateHandler(method, alternateHandler, requestTypeInfo, responseTypeInfo);
+            return;
         }
 
         _requestHandlers.Set(method,
@@ -1683,7 +1720,6 @@ internal sealed partial class McpServerImpl : McpServer
             requestTypeInfo, responseTypeInfo);
     }
 
-#pragma warning disable MCPEXP002 // SetWithAlternateHandler wraps the experimental ResultOrAlternate seam
     private void SetWithAlternateHandler<TParams, TResult>(
         string method,
         McpRequestHandler<TParams, ResultOrAlternate<TResult>> handler,
@@ -1695,9 +1731,15 @@ internal sealed partial class McpServerImpl : McpServer
         handler = async (request, cancellationToken) =>
         {
             var result = await innerHandler(request, cancellationToken).ConfigureAwait(false);
-            if (!result.IsAlternate && result.Result is { ResultType: null } immediateResult)
+            if (!result.IsAlternate && result.Result is { } immediateResult)
             {
-                immediateResult.ResultType = "complete";
+                if (immediateResult is ICacheableResult cacheable)
+                {
+                    cacheable.TimeToLive ??= TimeSpan.Zero;
+                    cacheable.CacheScope ??= CacheScope.Private;
+                }
+
+                immediateResult.ResultType ??= "complete";
             }
 
             return result;

--- a/src/ModelContextProtocol.Core/Server/McpServerOptions.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerOptions.cs
@@ -10,6 +10,8 @@ namespace ModelContextProtocol.Server;
 /// </summary>
 public sealed class McpServerOptions
 {
+    private readonly List<AlternateResultFilterRegistration> _alternateResultFilters = [];
+
     /// <summary>
     /// Gets or sets information about this server implementation, including its name and version.
     /// </summary>
@@ -219,4 +221,87 @@ public sealed class McpServerOptions
     /// </remarks>
     [Experimental(Experimentals.Subclassing_DiagnosticId, UrlFormat = Experimentals.Subclassing_Url)]
     public IList<McpServerRequestHandler>? RequestHandlers { get; set; }
+
+    /// <summary>
+    /// Adds a typed filter that may return an alternate result for an existing server request handler.
+    /// </summary>
+    /// <typeparam name="TParams">The request parameter type handled by the method.</typeparam>
+    /// <typeparam name="TResult">The method's standard result type.</typeparam>
+    /// <param name="method">The case-sensitive JSON-RPC method name to augment.</param>
+    /// <param name="filter">The alternate-result filter to add.</param>
+    /// <remarks>
+    /// <para>
+    /// The method must identify a typed handler configured by the server, and the supplied parameter and result
+    /// types must exactly match that handler. Invalid method names and type mismatches are reported when the server
+    /// is created.
+    /// </para>
+    /// <para>
+    /// Filters are applied in registration order. The first filter registered for a method is the outermost filter
+    /// and executes first. The ordinary typed handler pipeline executes inside these filters.
+    /// </para>
+    /// </remarks>
+    [Experimental(Experimentals.Subclassing_DiagnosticId, UrlFormat = Experimentals.Subclassing_Url)]
+    public void AddAlternateResultFilter<TParams, TResult>(
+        string method,
+        McpRequestFilter<TParams, ResultOrAlternate<TResult>> filter)
+        where TResult : Result
+    {
+        Throw.IfNullOrWhiteSpace(method);
+        Throw.IfNull(filter);
+
+        _alternateResultFilters.Add(new AlternateResultFilterRegistration<TParams, TResult>(method, filter));
+    }
+
+    internal bool HasAlternateResultFilters(string method) =>
+        _alternateResultFilters.Exists(registration => string.Equals(registration.Method, method, StringComparison.Ordinal));
+
+    internal IList<McpRequestFilter<TParams, ResultOrAlternate<TResult>>> GetAlternateResultFilters<TParams, TResult>(string method)
+        where TResult : Result
+    {
+        List<McpRequestFilter<TParams, ResultOrAlternate<TResult>>>? filters = null;
+
+        foreach (var registration in _alternateResultFilters)
+        {
+            if (!string.Equals(registration.Method, method, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (registration is not AlternateResultFilterRegistration<TParams, TResult> typedRegistration)
+            {
+                throw new InvalidOperationException(
+                    $"An alternate-result filter for method '{method}' was registered for " +
+                    $"'{registration.ParamsType.FullName}' and '{registration.ResultType.FullName}', but the server handler uses " +
+                    $"'{typeof(TParams).FullName}' and '{typeof(TResult).FullName}'.");
+            }
+
+            (filters ??= []).Add(typedRegistration.Filter);
+        }
+
+        return filters ?? [];
+    }
+
+    internal IEnumerable<string> AlternateResultFilterMethods =>
+        _alternateResultFilters.Select(registration => registration.Method).Distinct(StringComparer.Ordinal);
+
+    private abstract class AlternateResultFilterRegistration(string method)
+    {
+        public string Method { get; } = method;
+
+        public abstract Type ParamsType { get; }
+
+        public abstract Type ResultType { get; }
+    }
+
+    private sealed class AlternateResultFilterRegistration<TParams, TResult>(
+        string method,
+        McpRequestFilter<TParams, ResultOrAlternate<TResult>> filter) : AlternateResultFilterRegistration(method)
+        where TResult : Result
+    {
+        public McpRequestFilter<TParams, ResultOrAlternate<TResult>> Filter { get; } = filter;
+
+        public override Type ParamsType => typeof(TParams);
+
+        public override Type ResultType => typeof(TResult);
+    }
 }

--- a/src/ModelContextProtocol.Extensions.Tasks/Server/McpTasksBuilderExtensions.cs
+++ b/src/ModelContextProtocol.Extensions.Tasks/Server/McpTasksBuilderExtensions.cs
@@ -36,13 +36,20 @@ public static class McpTasksBuilderExtensions
         // background task body has somewhere to report failures. It is optional: if no logging is
         // registered, the options fall back to NullLoggerFactory.
         builder.Services.AddSingleton<IPostConfigureOptions<McpServerOptions>>(
-            sp => new McpTasksPostConfigureOptions(store, sp.GetService<ILoggerFactory>()));
+            sp => new McpTasksPostConfigureOptions(
+                store,
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetService<ILoggerFactory>()));
         return builder;
     }
 
-    private sealed class McpTasksPostConfigureOptions(IMcpTaskStore store, ILoggerFactory? loggerFactory) : IPostConfigureOptions<McpServerOptions>
+    private sealed class McpTasksPostConfigureOptions(
+        IMcpTaskStore store,
+        IServiceScopeFactory serviceScopeFactory,
+        ILoggerFactory? loggerFactory) : IPostConfigureOptions<McpServerOptions>
     {
         private readonly IMcpTaskStore _store = store;
+        private readonly IServiceScopeFactory _serviceScopeFactory = serviceScopeFactory;
         private readonly ILogger _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<McpTasksPostConfigureOptions>();
         private readonly ConcurrentDictionary<string, CancellationTokenSource> _cancellationSources = new(StringComparer.Ordinal);
 
@@ -66,124 +73,161 @@ public static class McpTasksBuilderExtensions
             options.RequestHandlers.Add(new McpServerRequestHandler { Method = TasksProtocol.MethodTasksUpdate, Handler = HandleUpdateTask });
             options.RequestHandlers.Add(new McpServerRequestHandler { Method = TasksProtocol.MethodTasksCancel, Handler = HandleCancelTask });
 
-            // Use a filter rather than a handler so it wraps around Core's tool dispatch.
-            // This ensures it intercepts tool calls BEFORE the tool is invoked, allowing
-            // it to spawn background execution and return the task alternate immediately.
-            options.Filters.Request.CallToolWithAlternateFilters.Add(next => async (request, cancellationToken) =>
+            // Augment Core's typed tool handler at the outer boundary. This lets the extension
+            // return the task alternate immediately while the ordinary filters and tool run in the background.
+            options.AddAlternateResultFilter<CallToolRequestParams, CallToolResult>(
+                RequestMethods.ToolsCall,
+                WrapCallToolWithTasks);
+        }
+
+        private McpRequestHandler<CallToolRequestParams, ResultOrAlternate<CallToolResult>> WrapCallToolWithTasks(
+            McpRequestHandler<CallToolRequestParams, ResultOrAlternate<CallToolResult>> next) =>
+            async (request, cancellationToken) =>
             {
-                if (IsJuly2026OrLaterProtocolRequest(request.JsonRpcRequest) && HasTaskExtensionOptIn(request.Params?.Meta))
+                if (!IsJuly2026OrLaterProtocolRequest(request.JsonRpcRequest) || !HasTaskExtensionOptIn(request.Params?.Meta))
                 {
-                    var taskInfo = await _store.CreateTaskAsync(cancellationToken).ConfigureAwait(false);
-                    var taskId = taskInfo.TaskId;
-                    var cts = new CancellationTokenSource();
-                    _cancellationSources[taskId] = cts;
-                    var taskCancellationToken = cts.Token;
-
-                    _ = Task.Run(async () =>
-                    {
-                        try
-                        {
-                            using (McpTasksServerExtensions.CreateMcpTaskScope(request.Server, taskId, _store))
-                            {
-                                try
-                                {
-                                    var augmented = await next(request, taskCancellationToken).ConfigureAwait(false);
-
-                                    if (augmented.IsAlternate)
-                                    {
-                                        var error = new JsonRpcErrorDetail
-                                        {
-                                            Code = (int)McpErrorCode.InternalError,
-                                            Message = $"{nameof(IMcpTaskStore)} is configured and the {nameof(McpServerHandlers.CallToolWithAlternateHandler)} returned IsAlternate = true. Use only one mechanism.",
-                                        };
-                                        var errorJson = JsonSerializer.SerializeToElement(error, McpJsonUtilities.DefaultOptions.GetTypeInfo<JsonRpcErrorDetail>());
-                                        await _store.SetFailedAsync(taskId, errorJson).ConfigureAwait(false);
-                                        return;
-                                    }
-
-                                    var resultJson = JsonSerializer.SerializeToElement(augmented.Result!, McpJsonUtilities.DefaultOptions.GetTypeInfo<CallToolResult>());
-                                    await _store.SetCompletedAsync(taskId, resultJson).ConfigureAwait(false);
-                                }
-                                catch (OperationCanceledException) when (taskCancellationToken.IsCancellationRequested)
-                                {
-                                    await _store.SetCancelledAsync(taskId, CancellationToken.None).ConfigureAwait(false);
-                                }
-                                catch (InputRequiredException)
-                                {
-                                    var error = new JsonRpcErrorDetail
-                                    {
-                                        Code = (int)McpErrorCode.InvalidRequest,
-                                        Message = "MRTR and tasks cannot be composed via [McpServerTool] yet.",
-                                    };
-                                    var errorJson = JsonSerializer.SerializeToElement(error, McpJsonUtilities.DefaultOptions.GetTypeInfo<JsonRpcErrorDetail>());
-                                    await _store.SetFailedAsync(taskId, errorJson).ConfigureAwait(false);
-                                }
-                                catch (McpProtocolException mcpEx)
-                                {
-                                    // SEP-2663 §186: protocol exceptions store as failed with JSON-RPC error shape.
-                                    var error = new JsonRpcErrorDetail { Code = (int)mcpEx.ErrorCode, Message = mcpEx.Message };
-                                    var errorJson = JsonSerializer.SerializeToElement(error, McpJsonUtilities.DefaultOptions.GetTypeInfo<JsonRpcErrorDetail>());
-                                    await _store.SetFailedAsync(taskId, errorJson).ConfigureAwait(false);
-                                }
-                                catch (Exception ex)
-                                {
-                                    // Non-protocol exceptions are wrapped as CallToolResult { IsError = true },
-                                    // matching Core's BuildInitialAlternateToolFilter behavior.
-                                    var errorResult = new CallToolResult
-                                    {
-                                        IsError = true,
-                                        Content = [new TextContentBlock
-                                        {
-                                            Text = ex is McpException
-                                                ? $"An error occurred invoking '{request.Params?.Name}': {ex.Message}"
-                                                : $"An error occurred invoking '{request.Params?.Name}'.",
-                                        }],
-                                    };
-                                    var resultJson = JsonSerializer.SerializeToElement(errorResult, McpJsonUtilities.DefaultOptions.GetTypeInfo<CallToolResult>());
-                                    await _store.SetCompletedAsync(taskId, resultJson).ConfigureAwait(false);
-                                }
-                                finally
-                                {
-                                    if (_cancellationSources.TryRemove(taskId, out var registeredCts))
-                                    {
-                                        registeredCts.Dispose();
-                                    }
-                                }
-                            }
-                        }
-                        catch (Exception outer)
-                        {
-                            // The inner handlers above record every expected outcome. Reaching here means a
-                            // store operation inside one of those handlers (or the task scope) threw, most
-                            // likely from a custom IMcpTaskStore. Record the failure best-effort and never let
-                            // it surface as an unobserved task exception.
-                            _logger.LogError(outer, "Background execution of task '{TaskId}' terminated unexpectedly while recording its result.", taskId);
-
-                            try
-                            {
-                                var error = new JsonRpcErrorDetail { Code = (int)McpErrorCode.InternalError, Message = outer.Message };
-                                var errorJson = JsonSerializer.SerializeToElement(error, McpJsonUtilities.DefaultOptions.GetTypeInfo<JsonRpcErrorDetail>());
-                                await _store.SetFailedAsync(taskId, errorJson).ConfigureAwait(false);
-                            }
-                            catch (Exception storeEx)
-                            {
-                                _logger.LogError(storeEx, "Failed to record the failure of background task '{TaskId}'.", taskId);
-                            }
-
-                            if (_cancellationSources.TryRemove(taskId, out var leftoverCts))
-                            {
-                                leftoverCts.Dispose();
-                            }
-                        }
-                    }, CancellationToken.None);
-
-                    return ResultOrAlternate<CallToolResult>.FromAlternate(
-                        ToCreateTaskResult(taskInfo),
-                        McpTasksJsonContext.Default.CreateTaskResult);
+                    return await next(request, cancellationToken).ConfigureAwait(false);
                 }
 
-                return await next(request, cancellationToken).ConfigureAwait(false);
-            });
+                var executionScope = _serviceScopeFactory.CreateAsyncScope();
+                request.Services = executionScope.ServiceProvider;
+
+                McpTaskInfo taskInfo;
+                try
+                {
+                    taskInfo = await _store.CreateTaskAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    await executionScope.DisposeAsync().ConfigureAwait(false);
+                    throw;
+                }
+
+                var taskCancellationSource = new CancellationTokenSource();
+                _cancellationSources[taskInfo.TaskId] = taskCancellationSource;
+                _ = Task.Run(
+                    () => RunToolAsTaskAsync(next, request, taskInfo.TaskId, taskCancellationSource, executionScope),
+                    CancellationToken.None);
+
+                return ResultOrAlternate<CallToolResult>.FromAlternate(
+                    ToCreateTaskResult(taskInfo),
+                    McpTasksJsonContext.Default.CreateTaskResult);
+            };
+
+        private async Task RunToolAsTaskAsync(
+            McpRequestHandler<CallToolRequestParams, ResultOrAlternate<CallToolResult>> next,
+            RequestContext<CallToolRequestParams> request,
+            string taskId,
+            CancellationTokenSource taskCancellationSource,
+            AsyncServiceScope executionScope)
+        {
+            try
+            {
+                try
+                {
+                    using (McpTasksServerExtensions.CreateMcpTaskScope(request.Server, taskId, _store))
+                    {
+                        await ExecuteToolPipelineAsync(next, request, taskId, taskCancellationSource.Token).ConfigureAwait(false);
+                    }
+                }
+                finally
+                {
+                    await executionScope.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+            catch (Exception outer)
+            {
+                // Expected outcomes are recorded by ExecuteToolPipelineAsync. Reaching here usually
+                // means a custom store operation or scope disposal failed. Record it best-effort.
+                _logger.LogError(outer, "Background execution of task '{TaskId}' terminated unexpectedly while recording its result.", taskId);
+
+                try
+                {
+                    var error = new JsonRpcErrorDetail { Code = (int)McpErrorCode.InternalError, Message = outer.Message };
+                    var errorJson = JsonSerializer.SerializeToElement(error, McpJsonUtilities.DefaultOptions.GetTypeInfo<JsonRpcErrorDetail>());
+                    await _store.SetFailedAsync(taskId, errorJson).ConfigureAwait(false);
+                }
+                catch (Exception storeEx)
+                {
+                    _logger.LogError(storeEx, "Failed to record the failure of background task '{TaskId}'.", taskId);
+                }
+            }
+            finally
+            {
+                if (_cancellationSources.TryRemove(taskId, out var registeredCancellationSource))
+                {
+                    registeredCancellationSource.Dispose();
+                }
+                else
+                {
+                    taskCancellationSource.Dispose();
+                }
+            }
+        }
+
+        private async Task ExecuteToolPipelineAsync(
+            McpRequestHandler<CallToolRequestParams, ResultOrAlternate<CallToolResult>> next,
+            RequestContext<CallToolRequestParams> request,
+            string taskId,
+            CancellationToken taskCancellationToken)
+        {
+            try
+            {
+                var augmented = await next(request, taskCancellationToken).ConfigureAwait(false);
+
+                if (augmented.IsAlternate)
+                {
+                    var error = new JsonRpcErrorDetail
+                    {
+                        Code = (int)McpErrorCode.InternalError,
+                        Message = $"{nameof(IMcpTaskStore)} is configured and an inner alternate-result filter returned IsAlternate = true. Use only one alternate-result mechanism per request.",
+                    };
+                    var errorJson = JsonSerializer.SerializeToElement(error, McpJsonUtilities.DefaultOptions.GetTypeInfo<JsonRpcErrorDetail>());
+                    await _store.SetFailedAsync(taskId, errorJson).ConfigureAwait(false);
+                    return;
+                }
+
+                var resultJson = JsonSerializer.SerializeToElement(augmented.Result!, McpJsonUtilities.DefaultOptions.GetTypeInfo<CallToolResult>());
+                await _store.SetCompletedAsync(taskId, resultJson).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (taskCancellationToken.IsCancellationRequested)
+            {
+                await _store.SetCancelledAsync(taskId, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (InputRequiredException)
+            {
+                var error = new JsonRpcErrorDetail
+                {
+                    Code = (int)McpErrorCode.InvalidRequest,
+                    Message = "MRTR and tasks cannot be composed via [McpServerTool] yet.",
+                };
+                var errorJson = JsonSerializer.SerializeToElement(error, McpJsonUtilities.DefaultOptions.GetTypeInfo<JsonRpcErrorDetail>());
+                await _store.SetFailedAsync(taskId, errorJson).ConfigureAwait(false);
+            }
+            catch (McpProtocolException mcpEx)
+            {
+                // SEP-2663 §186: protocol exceptions store as failed with JSON-RPC error shape.
+                var error = new JsonRpcErrorDetail { Code = (int)mcpEx.ErrorCode, Message = mcpEx.Message };
+                var errorJson = JsonSerializer.SerializeToElement(error, McpJsonUtilities.DefaultOptions.GetTypeInfo<JsonRpcErrorDetail>());
+                await _store.SetFailedAsync(taskId, errorJson).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Non-protocol exceptions are wrapped as CallToolResult { IsError = true },
+                // matching Core's BuildInitialAlternateToolFilter behavior.
+                var errorResult = new CallToolResult
+                {
+                    IsError = true,
+                    Content = [new TextContentBlock
+                    {
+                        Text = ex is McpException
+                            ? $"An error occurred invoking '{request.Params?.Name}': {ex.Message}"
+                            : $"An error occurred invoking '{request.Params?.Name}'.",
+                    }],
+                };
+                var resultJson = JsonSerializer.SerializeToElement(errorResult, McpJsonUtilities.DefaultOptions.GetTypeInfo<CallToolResult>());
+                await _store.SetCompletedAsync(taskId, resultJson).ConfigureAwait(false);
+            }
         }
 
         private async ValueTask<JsonNode?> HandleGetTask(JsonRpcRequest request, CancellationToken cancellationToken)

--- a/tests/ModelContextProtocol.AspNetCore.Tests/AuthorizeAttributeTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/AuthorizeAttributeTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.AspNetCore.Tests.Utils;
 using ModelContextProtocol.Client;
+using ModelContextProtocol.Extensions.Tasks;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Tests.Utils;
@@ -91,6 +92,47 @@ public class AuthorizeAttributeTests(ITestOutputHelper testOutputHelper) : Kestr
         Assert.False(result.IsError ?? false);
         var content = Assert.Single(result.Content.OfType<TextContentBlock>());
         Assert.Equal("Authorized: test", content.Text);
+    }
+
+    [Fact]
+    public async Task Authorize_ToolAsTask_DeniesBeforeToolExecution()
+    {
+        var taskStore = new TrackingTaskStore { DefaultPollIntervalMs = 10 };
+        TaskAuthorizationTestTools.InvocationCount = 0;
+        await using var app = await StartServerWithAuth(builder => builder
+            .WithTools<TaskAuthorizationTestTools>()
+            .WithTasks(taskStore));
+
+        await using var client = await ConnectAsync();
+
+        var exception = await Assert.ThrowsAsync<McpException>(async () =>
+            await client.CallToolWithPollingAsync(
+                new CallToolRequestParams { Name = "authorized_task_tool" },
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Contains("Access forbidden: This tool requires authorization.", exception.Message);
+        Assert.Equal(1, taskStore.CreateCount);
+        Assert.Equal(0, TaskAuthorizationTestTools.InvocationCount);
+    }
+
+    [Fact]
+    public async Task Authorize_ToolAsTask_AllowsAuthenticatedTaskToComplete()
+    {
+        var taskStore = new TrackingTaskStore { DefaultPollIntervalMs = 10 };
+        TaskAuthorizationTestTools.InvocationCount = 0;
+        await using var app = await StartServerWithAuth(builder => builder
+            .WithTools<TaskAuthorizationTestTools>()
+            .WithTasks(taskStore), "TestUser");
+
+        await using var client = await ConnectAsync();
+
+        var result = await client.CallToolWithPollingAsync(
+            new CallToolRequestParams { Name = "authorized_task_tool" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("authorized task result", Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text);
+        Assert.Equal(1, taskStore.CreateCount);
+        Assert.Equal(1, TaskAuthorizationTestTools.InvocationCount);
     }
 
     [Fact]
@@ -540,6 +582,31 @@ public class AuthorizeAttributeTests(ITestOutputHelper testOutputHelper) : Kestr
         => new(new ClaimsIdentity(
             [new Claim("name", name), new Claim(ClaimTypes.NameIdentifier, name), .. roles.Select(role => new Claim("role", role))],
             "TestAuthType", "name", "role"));
+
+    private sealed class TrackingTaskStore : InMemoryMcpTaskStore, IMcpTaskStore
+    {
+        public int CreateCount { get; private set; }
+
+        Task<McpTaskInfo> IMcpTaskStore.CreateTaskAsync(CancellationToken cancellationToken)
+        {
+            CreateCount++;
+            return base.CreateTaskAsync(cancellationToken);
+        }
+    }
+
+    [McpServerToolType]
+    private sealed class TaskAuthorizationTestTools
+    {
+        public static int InvocationCount;
+
+        [McpServerTool(Name = "authorized_task_tool")]
+        [Authorize]
+        public static string AuthorizedTaskTool()
+        {
+            Interlocked.Increment(ref InvocationCount);
+            return "authorized task result";
+        }
+    }
 
     [McpServerToolType]
     private class AuthorizationTestTools

--- a/tests/ModelContextProtocol.AspNetCore.Tests/ModelContextProtocol.AspNetCore.Tests.csproj
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/ModelContextProtocol.AspNetCore.Tests.csproj
@@ -60,6 +60,7 @@
     <ProjectReference Include="..\..\samples\TestServerWithHosting\TestServerWithHosting.csproj" />
     <ProjectReference Include="..\..\src\ModelContextProtocol.Core\ModelContextProtocol.Core.csproj" />
     <ProjectReference Include="..\..\src\ModelContextProtocol.AspNetCore\ModelContextProtocol.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\ModelContextProtocol.Extensions.Tasks\ModelContextProtocol.Extensions.Tasks.csproj" />
     <ProjectReference Include="..\ModelContextProtocol.TestSseServer\ModelContextProtocol.TestSseServer.csproj" />
     <ProjectReference Include="..\ModelContextProtocol.TestOAuthServer\ModelContextProtocol.TestOAuthServer.csproj" />
     <ProjectReference Include="..\ModelContextProtocol.ConformanceClient\ModelContextProtocol.ConformanceClient.csproj" />

--- a/tests/ModelContextProtocol.Tests/Server/AlternateResultFilterTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/AlternateResultFilterTests.cs
@@ -1,0 +1,109 @@
+using ModelContextProtocol.Extensions.Tasks;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json;
+
+namespace ModelContextProtocol.Tests.Server;
+
+#pragma warning disable MCPEXP002 // exercises the experimental alternate-result filter seam
+public class AlternateResultFilterTests(ITestOutputHelper testOutputHelper) : ClientServerTestBase(testOutputHelper)
+{
+    private readonly List<string> _invocations = [];
+
+    protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder) =>
+        mcpServerBuilder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.GetPromptHandler = (request, cancellationToken) =>
+            {
+                _invocations.Add("handler");
+                return new ValueTask<GetPromptResult>(new GetPromptResult
+                {
+                    Description = "normal result",
+                });
+            };
+
+            options.AddAlternateResultFilter<GetPromptRequestParams, GetPromptResult>(
+                RequestMethods.PromptsGet,
+                next => async (request, cancellationToken) =>
+                {
+                    _invocations.Add("outer-before");
+                    var result = await next(request, cancellationToken);
+                    _invocations.Add("outer-after");
+                    return result;
+                });
+
+            options.AddAlternateResultFilter<GetPromptRequestParams, GetPromptResult>(
+                RequestMethods.PromptsGet,
+                next => async (request, cancellationToken) =>
+                {
+                    _invocations.Add("filter");
+                    if (request.Params?.Name == "as-task")
+                    {
+                        return ResultOrAlternate<GetPromptResult>.FromAlternate(
+                            new CreateTaskResult
+                            {
+                                TaskId = "prompt-task",
+                                Status = McpTaskStatus.Working,
+                                CreatedAt = DateTimeOffset.UnixEpoch,
+                                LastUpdatedAt = DateTimeOffset.UnixEpoch,
+                            },
+                            McpTasksJsonContext.Default.CreateTaskResult);
+                    }
+
+                    return await next(request, cancellationToken);
+                });
+
+            options.AddAlternateResultFilter<ListPromptsRequestParams, ListPromptsResult>(
+                RequestMethods.PromptsList,
+                next => (request, cancellationToken) =>
+                    new ValueTask<ResultOrAlternate<ListPromptsResult>>(new ListPromptsResult()));
+        });
+
+    [Fact]
+    public async Task AlternateResultFilter_OnPromptHandler_CanReturnAlternateResult()
+    {
+        await using var client = await CreateMcpClientForServer();
+        var serializerOptions = new JsonSerializerOptions(McpJsonUtilities.DefaultOptions);
+        serializerOptions.TypeInfoResolverChain.Add(McpTasksJsonContext.Default);
+
+        var result = await client.SendRequestAsync<GetPromptRequestParams, CreateTaskResult>(
+            RequestMethods.PromptsGet,
+            new GetPromptRequestParams { Name = "as-task" },
+            serializerOptions: serializerOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("prompt-task", result.TaskId);
+        Assert.Equal(["outer-before", "filter", "outer-after"], _invocations);
+    }
+
+    [Fact]
+    public async Task AlternateResultFilter_OnPromptHandler_CanInvokeNormalPipeline()
+    {
+        await using var client = await CreateMcpClientForServer();
+
+        var result = await client.GetPromptAsync(
+            "normal",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("normal result", result.Description);
+        Assert.Equal(["outer-before", "filter", "handler", "outer-after"], _invocations);
+    }
+
+    [Fact]
+    public async Task AlternateResultFilter_NormalizesCacheableImmediateResult()
+    {
+        await using var client = await CreateMcpClientForServer();
+
+        var result = await client.SendRequestAsync<ListPromptsRequestParams, ListPromptsResult>(
+            RequestMethods.PromptsList,
+            new ListPromptsRequestParams(),
+            serializerOptions: McpJsonUtilities.DefaultOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(TimeSpan.Zero, result.TimeToLive);
+        Assert.Equal(CacheScope.Private, result.CacheScope);
+        Assert.Equal("complete", result.ResultType);
+    }
+}
+#pragma warning restore MCPEXP002

--- a/tests/ModelContextProtocol.Tests/Server/AlternateResultFilterValidationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/AlternateResultFilterValidationTests.cs
@@ -1,0 +1,79 @@
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Tests.Utils;
+
+namespace ModelContextProtocol.Tests.Server;
+
+#pragma warning disable MCPEXP002 // exercises the experimental alternate-result filter seam
+public class AlternateResultFilterValidationTests(ITestOutputHelper testOutputHelper) : LoggedTest(testOutputHelper)
+{
+    private static McpRequestFilter<CallToolRequestParams, ResultOrAlternate<CallToolResult>> PassThroughAlternateFilter =>
+        next => next;
+
+    [Fact]
+    public async Task AlternateResultFilter_ForUnknownMethod_ThrowsActionableError()
+    {
+        await using var transport = new StreamServerTransport(Stream.Null, Stream.Null);
+        var options = new McpServerOptions();
+        options.AddAlternateResultFilter("unknown/method", PassThroughAlternateFilter);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => McpServer.Create(transport, options, LoggerFactory));
+
+        Assert.Contains("unknown/method", exception.Message);
+        Assert.Contains("no matching typed handler", exception.Message);
+    }
+
+    [Fact]
+    public async Task AlternateResultFilter_WithMismatchedTypes_ThrowsActionableError()
+    {
+        await using var transport = new StreamServerTransport(Stream.Null, Stream.Null);
+        var options = new McpServerOptions
+        {
+            Capabilities = new() { Prompts = new() },
+        };
+        options.AddAlternateResultFilter(RequestMethods.PromptsGet, PassThroughAlternateFilter);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => McpServer.Create(transport, options, LoggerFactory));
+
+        Assert.Contains(RequestMethods.PromptsGet, exception.Message);
+        Assert.Contains(nameof(CallToolRequestParams), exception.Message);
+        Assert.Contains(nameof(GetPromptRequestParams), exception.Message);
+    }
+
+    [Fact]
+    public async Task ExplicitAlternateHandler_WithMethodKeyedFilter_ThrowsActionableError()
+    {
+        await using var transport = new StreamServerTransport(Stream.Null, Stream.Null);
+        var options = new McpServerOptions { Capabilities = new() { Tools = new() } };
+        options.Handlers.CallToolWithAlternateHandler = static (request, cancellationToken) =>
+            new ValueTask<ResultOrAlternate<CallToolResult>>(new CallToolResult());
+        options.AddAlternateResultFilter(RequestMethods.ToolsCall, PassThroughAlternateFilter);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => McpServer.Create(transport, options, LoggerFactory));
+
+        Assert.Contains(nameof(McpServerHandlers.CallToolWithAlternateHandler), exception.Message);
+        Assert.Contains(RequestMethods.ToolsCall, exception.Message);
+        Assert.Contains("replaces", exception.Message);
+    }
+
+    [Fact]
+    public async Task ExplicitAlternateHandler_WithOrdinaryFilter_ThrowsActionableError()
+    {
+        await using var transport = new StreamServerTransport(Stream.Null, Stream.Null);
+        var options = new McpServerOptions { Capabilities = new() { Tools = new() } };
+        options.Handlers.CallToolWithAlternateHandler = static (request, cancellationToken) =>
+            new ValueTask<ResultOrAlternate<CallToolResult>>(new CallToolResult());
+        options.Filters.Request.CallToolFilters.Add(next => next);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => McpServer.Create(transport, options, LoggerFactory));
+
+        Assert.Contains(nameof(McpServerHandlers.CallToolWithAlternateHandler), exception.Message);
+        Assert.Contains(nameof(McpRequestFilters.CallToolFilters), exception.Message);
+        Assert.Contains("replaces", exception.Message);
+    }
+}
+#pragma warning restore MCPEXP002

--- a/tests/ModelContextProtocol.Tests/Server/CallToolFilterMixingTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/CallToolFilterMixingTests.cs
@@ -1,38 +1,67 @@
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ModelContextProtocol.Tests.Server;
 
 /// <summary>
-/// Verifies that combining the non-alternate <see cref="McpRequestFilters.CallToolFilters"/> with the
-/// alternate <see cref="McpRequestFilters.CallToolWithAlternateFilters"/> fails at configuration time
-/// with an actionable message.
+/// Verifies composition of the non-alternate <see cref="McpRequestFilters.CallToolFilters"/> with the
+/// alternate <see cref="McpRequestFilters.CallToolWithAlternateFilters"/>.
 /// </summary>
-public class CallToolFilterMixingTests(ITestOutputHelper testOutputHelper) : LoggedTest(testOutputHelper)
+public class CallToolFilterMixingTests(ITestOutputHelper testOutputHelper) : ClientServerTestBase(testOutputHelper)
 {
 #pragma warning disable MCPEXP002 // exercises the experimental CallToolWithAlternateFilters seam
+    private readonly List<string> _invocations = [];
+
     private static McpRequestFilter<CallToolRequestParams, CallToolResult> PassThroughCallToolFilter =>
         next => next;
 
     private static McpRequestFilter<CallToolRequestParams, ResultOrAlternate<CallToolResult>> PassThroughAlternateFilter =>
         next => next;
 
+    protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder) =>
+        mcpServerBuilder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Handlers.CallToolHandler = (request, cancellationToken) =>
+            {
+                _invocations.Add("handler");
+                return new ValueTask<CallToolResult>(new CallToolResult
+                {
+                    Content = [new TextContentBlock { Text = "mixed filters result" }],
+                });
+            };
+
+            options.Filters.Request.CallToolFilters.Add(next => async (request, cancellationToken) =>
+            {
+                _invocations.Add("ordinary-before");
+                var result = await next(request, cancellationToken);
+                _invocations.Add("ordinary-after");
+                return result;
+            });
+
+            options.Filters.Request.CallToolWithAlternateFilters.Add(next => async (request, cancellationToken) =>
+            {
+                _invocations.Add("alternate-before");
+                var result = await next(request, cancellationToken);
+                _invocations.Add("alternate-after");
+                return result;
+            });
+        });
+
     [Fact]
-    public async Task MixingCallToolFilters_WithAlternateFilters_ThrowsActionableError()
+    public async Task MixingCallToolFilters_WithAlternateFilters_ComposesInOrder()
     {
-        await using var transport = new StreamServerTransport(Stream.Null, Stream.Null);
-        var options = new McpServerOptions { Capabilities = new() { Tools = new() } };
-        options.Filters.Request.CallToolFilters.Add(PassThroughCallToolFilter);
-        options.Filters.Request.CallToolWithAlternateFilters.Add(PassThroughAlternateFilter);
+        await using var client = await CreateMcpClientForServer();
 
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => McpServer.Create(transport, options, LoggerFactory));
+        var result = await client.CallToolAsync(
+            "mixed-tool",
+            cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.Contains(nameof(McpRequestFilters.CallToolFilters), ex.Message);
-        Assert.Contains(nameof(McpRequestFilters.CallToolWithAlternateFilters), ex.Message);
-        Assert.Contains("AddAuthorizationFilters", ex.Message);
-        Assert.Contains("WithTasks", ex.Message);
+        Assert.Equal(
+            ["alternate-before", "ordinary-before", "handler", "ordinary-after", "alternate-after"],
+            _invocations);
+        Assert.Equal("mixed filters result", Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text);
     }
 
     [Fact]

--- a/tests/ModelContextProtocol.Tests/Server/TaskCallToolFilterCompositionTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/TaskCallToolFilterCompositionTests.cs
@@ -1,0 +1,104 @@
+using ModelContextProtocol.Extensions.Tasks;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ModelContextProtocol.Tests.Server;
+
+#pragma warning disable MCPEXP002 // exercises the experimental alternate-result filter seam
+public class TaskCallToolFilterCompositionTests(ITestOutputHelper testOutputHelper) : ClientServerTestBase(testOutputHelper)
+{
+    private readonly TaskCompletionSource<bool> _continueBackgroundExecution = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<CallToolResult> _backgroundExecutionCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _executionScopeDisposed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _filterInvocationCount;
+    private string? _matchedPrimitiveId;
+
+    protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
+    {
+        mcpServerBuilder
+            .WithTools<TaskFilterTools>()
+            .WithTasks(new InMemoryMcpTaskStore { DefaultPollIntervalMs = 10 });
+
+        services.AddScoped(_ => new ScopedDependency(_executionScopeDisposed));
+
+        mcpServerBuilder.Services.Configure<McpServerOptions>(options =>
+            options.Filters.Request.CallToolFilters.Add(next => async (request, cancellationToken) =>
+            {
+                Interlocked.Increment(ref _filterInvocationCount);
+                _matchedPrimitiveId = request.MatchedPrimitive?.Id;
+
+                if (request.Params?.Name != "scoped-task-filter-tool")
+                {
+                    return await next(request, cancellationToken);
+                }
+
+                try
+                {
+                    await _continueBackgroundExecution.Task.WaitAsync(TestConstants.DefaultTimeout, cancellationToken);
+                    _ = request.Services!.GetRequiredService<ScopedDependency>();
+                    var result = await next(request, cancellationToken);
+                    _backgroundExecutionCompleted.TrySetResult(result);
+                    return result;
+                }
+                catch (Exception exception)
+                {
+                    _backgroundExecutionCompleted.TrySetException(exception);
+                    throw;
+                }
+            }));
+    }
+
+    [Fact]
+    public async Task TaskBackedTool_RunsOrdinaryFilterOnce_WithMatchedPrimitive()
+    {
+        await using var client = await CreateMcpClientForServer();
+
+        var result = await client.CallToolWithPollingAsync(
+            new CallToolRequestParams { Name = "task-filter-tool" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("task filter result", Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text);
+        Assert.Equal(1, _filterInvocationCount);
+        Assert.Equal("task-filter-tool", _matchedPrimitiveId);
+    }
+
+    [Fact]
+    public async Task TaskBackedTool_UsesIndependentScopeForBackgroundExecution()
+    {
+        await using var client = await CreateMcpClientForServer();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var augmented = await client.CallToolAsTaskAsync(
+            new CallToolRequestParams { Name = "scoped-task-filter-tool" },
+            cancellationToken);
+
+        Assert.True(augmented.IsTask);
+        _continueBackgroundExecution.TrySetResult(true);
+
+        var result = await _backgroundExecutionCompleted.Task.WaitAsync(TestConstants.DefaultTimeout, cancellationToken);
+        Assert.Equal("scoped task result", Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text);
+        Assert.True(await _executionScopeDisposed.Task.WaitAsync(TestConstants.DefaultTimeout, cancellationToken));
+    }
+
+    private sealed class ScopedDependency(TaskCompletionSource<bool> disposed) : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync()
+        {
+            disposed.TrySetResult(true);
+            return default;
+        }
+    }
+
+    [McpServerToolType]
+    private sealed class TaskFilterTools
+    {
+        [McpServerTool(Name = "task-filter-tool")]
+        public static string Invoke() => "task filter result";
+
+        [McpServerTool(Name = "scoped-task-filter-tool")]
+        public static string InvokeWithScopedDependency(ScopedDependency dependency) => "scoped task result";
+    }
+}
+#pragma warning restore MCPEXP002

--- a/tests/ModelContextProtocol.Tests/Server/TaskStoreOrphanedTaskTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/TaskStoreOrphanedTaskTests.cs
@@ -1,26 +1,20 @@
 ﻿using ModelContextProtocol.Extensions.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using System.Runtime.InteropServices;
-using System.Text.Json;
-using System.Text.Json.Serialization.Metadata;
 
 namespace ModelContextProtocol.Tests.Server;
 
 /// <summary>
 /// Verifies that when both <see cref="McpTasksBuilderExtensions.WithTasks(IMcpServerBuilder, IMcpTaskStore)"/> and
-/// <see cref="McpServerHandlers.CallToolWithAlternateHandler"/> are configured and the handler returns
-/// <see cref="CreateTaskResult"/> (IsTask = true), the store's pre-created task is failed with a
-/// clear error rather than being orphaned in <see cref="McpTaskStatus.Working"/> forever.
+/// <see cref="McpServerHandlers.CallToolWithAlternateHandler"/> are configured, server creation fails before
+/// either alternate-result mechanism can create a task.
 /// </summary>
 public class TaskStoreOrphanedTaskTests : ClientServerTestBase
 {
 #pragma warning disable MCPEXP002 // exercises the experimental CallToolWithAlternateHandler/ResultOrAlternate seam
-    private static readonly JsonTypeInfo<CreateTaskResult> s_createTaskResultTypeInfo = McpTasksJsonContext.Default.CreateTaskResult;
-
-    public TaskStoreOrphanedTaskTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    public TaskStoreOrphanedTaskTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper, startServer: false)
     {
 #if !NET
         Assert.SkipWhen(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "https://github.com/modelcontextprotocol/csharp-sdk/issues/587");
@@ -35,56 +29,20 @@ public class TaskStoreOrphanedTaskTests : ClientServerTestBase
         {
             options.Capabilities ??= new ServerCapabilities();
 
-            // Returning IsTask = true here while the tasks extension is also configured is the
-            // misconfiguration the server must guard against.
-            options.Handlers.CallToolWithAlternateHandler = (context, cancellationToken) =>
-                new ValueTask<ResultOrAlternate<CallToolResult>>(
-                    ResultOrAlternate<CallToolResult>.FromAlternate(
-                        new CreateTaskResult
-                        {
-                            TaskId = "user-task",
-                            Status = McpTaskStatus.Working,
-                            CreatedAt = DateTimeOffset.UtcNow,
-                            LastUpdatedAt = DateTimeOffset.UtcNow,
-                        },
-                        s_createTaskResultTypeInfo));
+            options.Handlers.CallToolWithAlternateHandler = static (context, cancellationToken) =>
+                new ValueTask<ResultOrAlternate<CallToolResult>>(new CallToolResult());
         });
     }
 
     [Fact]
-    public async Task TaskStoreAndHandler_BothCreatingTasks_FailsStoreTaskWithClearError()
+    public void TaskStoreAndExplicitAlternateHandler_ThrowsActionableStartupError()
     {
-        await using var client = await CreateMcpClientForServer();
-        var ct = TestContext.Current.CancellationToken;
+        var exception = Assert.Throws<InvalidOperationException>(() => StartServer());
 
-        // The store's task is created synchronously and its taskId returned to the client.
-        var augmented = await client.CallToolAsTaskAsync(
-            new CallToolRequestParams { Name = "anything" }, ct);
-
-        Assert.True(augmented.IsTask);
-        var taskId = augmented.TaskCreated!.TaskId;
-
-        // Poll until the background runner observes the handler's IsTask=true and fails the
-        // store's task. Without the fix this would loop forever in Working.
-        GetTaskResult? taskResult = null;
-        for (int i = 0; i < 40; i++)
-        {
-            await Task.Delay(50, ct);
-            taskResult = await client.GetTaskAsync(taskId, ct);
-            if (taskResult is FailedTaskResult)
-            {
-                break;
-            }
-        }
-
-        var failed = Assert.IsType<FailedTaskResult>(taskResult);
-        Assert.Equal(JsonValueKind.Object, failed.Error.ValueKind);
-        Assert.Equal((int)McpErrorCode.InternalError, failed.Error.GetProperty("code").GetInt32());
-
-        var message = failed.Error.GetProperty("message").GetString();
-        Assert.NotNull(message);
-        Assert.Contains(nameof(IMcpTaskStore), message);
-        Assert.Contains(nameof(McpServerHandlers.CallToolWithAlternateHandler), message);
+        Assert.Contains(nameof(McpServerHandlers.CallToolWithAlternateHandler), exception.Message);
+        Assert.Contains(RequestMethods.ToolsCall, exception.Message);
+        Assert.Contains("alternate-result filter", exception.Message);
+        Assert.Contains("replaces", exception.Message);
     }
 #pragma warning restore MCPEXP002
 }


### PR DESCRIPTION
Alternate-result handlers currently replace the normal typed server pipeline. For Tasks, that means enabling task support can bypass ordinary tool filters such as validation, telemetry, and ASP.NET authorization.

This PR lets extension-owned alternate results wrap the existing pipeline instead:

- Adds an experimental, method-keyed `AddAlternateResultFilter` API.
- Moves Tasks to that API and runs ordinary filters once, before the tool body, with `MatchedPrimitive` set.
- Gives background task execution its own async DI scope so scoped filters and tool dependencies stay alive.
- Keeps `CallToolWithAlternateHandler` as the explicit replacement API and reports incompatible registrations at startup.

This covers the alternate-result composition part of #1704. Custom RPC registration and subscription grants remain follow-up work.

## How Has This Been Tested?

- Full solution build for netstandard2.0, net8.0, net9.0, and net10.0: no warnings or errors.
- Core net10 suite: 2,296 passed, 5 skipped.
- ASP.NET net10 suite (excluding external conformance/OAuth fixtures): 284 passed, 30 skipped.
- Focused alternate/filter/task tests: 73 passed on net10 and 13 passed on both net8 and net9.
- Tasks + authorization integration: 2 passed on each of net8, net9, and net10.
- `dotnet format whitespace --verify-no-changes` and `git diff --check` pass.

## Breaking Changes

No stable API break. The new API is experimental. Registering both an explicit `CallToolWithAlternateHandler` and a method-keyed alternate-result filter now fails at startup because the explicit handler is a full replacement.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Tasks is the first consumer, using `tools/call`. Tests also cover `prompts/get` and `prompts/list` to make sure the registration is not tool-specific.