### PR TITLE
Expand npm conformance coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@modelcontextprotocol/conformance": "0.2.0-alpha.8",
+        "@modelcontextprotocol/conformance": "0.2.0-alpha.9",
         "@modelcontextprotocol/server-everything": "2026.1.26",
         "@modelcontextprotocol/server-memory": "2026.1.26"
       }
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/conformance": {
-      "version": "0.2.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/conformance/-/conformance-0.2.0-alpha.8.tgz",
-      "integrity": "sha512-ktbvq6ftvs23TjZ/WVmTKZHue8dqoUF5bBG3Qd5pbawfTyuveZw93o07uQij8tslBlccpPVS5jE212G+SnLo2A==",
+      "version": "0.2.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/conformance/-/conformance-0.2.0-alpha.9.tgz",
+      "integrity": "sha512-Bi5P5TQlOQGPJxCT7UAHbpG7wsR7sNZskHGtCoZBo6vDu416D2FXPgM4wKbg91teIgj4HjGkhnzlvP7U2dszfQ==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "description": "Pinned npm dependencies for MCP C# SDK integration and conformance tests",
   "dependencies": {
-    "@modelcontextprotocol/conformance": "0.2.0-alpha.8",
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.9",
     "@modelcontextprotocol/server-everything": "2026.1.26",
     "@modelcontextprotocol/server-memory": "2026.1.26"
   }

--- a/tests/ModelContextProtocol.AspNetCore.Tests/ClientConformanceTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/ClientConformanceTests.cs
@@ -46,6 +46,19 @@ public class ClientConformanceTests
     [InlineData("auth/resource-mismatch")]
     [InlineData("auth/pre-registration")]
 
+    // Offline access scope negotiation.
+    [InlineData("auth/offline-access-scope")]
+    [InlineData("auth/offline-access-not-supported")]
+
+    // RFC 9207 authorization server issuer validation.
+    [InlineData("auth/iss-supported")]
+    [InlineData("auth/iss-not-advertised")]
+    [InlineData("auth/iss-supported-missing")]
+    [InlineData("auth/iss-wrong-issuer")]
+    [InlineData("auth/iss-unexpected")]
+    [InlineData("auth/iss-normalized")]
+    [InlineData("auth/metadata-issuer-mismatch")]
+
     // Backcompat: 2025-03-26 OAuth flows (no per-request metadata, root-location metadata).
     [InlineData("auth/2025-03-26-oauth-metadata-backcompat")]
     [InlineData("auth/2025-03-26-oauth-endpoint-fallback")]

--- a/tests/ModelContextProtocol.AspNetCore.Tests/ServerConformanceTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/ServerConformanceTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using ModelContextProtocol.Tests.Utils;
 
 namespace ModelContextProtocol.ConformanceTests;
@@ -28,12 +27,9 @@ public class ServerConformanceTests(
     }
 
     [Fact]
-    public async Task RunPendingConformanceTest_JsonSchema202012()
+    public async Task RunConformanceTest_JsonSchema202012()
     {
         Assert.SkipWhen(!NodeHelpers.IsNodeInstalled(), "Node.js is not installed. Skipping conformance tests.");
-        Assert.SkipWhen(
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Pending Node-based conformance scenario is unstable on Windows due to a libuv shutdown assertion.");
 
         var result = await RunConformanceTestsAsync($"server --url {fixture.ServerUrl} --scenario json-schema-2020-12");
 
@@ -42,12 +38,9 @@ public class ServerConformanceTests(
     }
 
     [Fact]
-    public async Task RunPendingConformanceTest_ServerSsePolling()
+    public async Task RunConformanceTest_ServerSsePolling()
     {
         Assert.SkipWhen(!NodeHelpers.IsNodeInstalled(), "Node.js is not installed. Skipping conformance tests.");
-        Assert.SkipWhen(
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Pending Node-based conformance scenario is unstable on Windows due to a libuv shutdown assertion.");
 
         var result = await RunConformanceTestsAsync($"server --url {fixture.ServerUrl} --scenario server-sse-polling");
 


### PR DESCRIPTION
## Summary

- update `@modelcontextprotocol/conformance` from `0.2.0-alpha.8` to `0.2.0-alpha.9`
- enable offline-access and RFC 9207 issuer client scenarios now supported by the SDK
- enable `json-schema-2020-12` and `server-sse-polling` on Windows now that the runner's completed success summary handles the known Node/libuv shutdown assertion

The alpha.9 package does not include a scenario for an initialize `MCP-Protocol-Version` header/body mismatch.

## Intentionally not enabled

The following client scenarios still fail and require SDK functionality outside this PR: `auth/authorization-server-migration`, `auth/client-credentials-jwt`, `auth/client-credentials-basic`, `auth/enterprise-managed-authorization`, `sep-2322-client-request-state`, and `json-schema-ref-no-deref`. The alpha.9 task-extension server scenarios also remain unwired because the conformance server does not provide their required task fixtures/capabilities; `tasks-status-notifications` executes zero checks in that configuration.

## Validation

- `dotnet build`
- changed net10 conformance tests: 36 passed
- full `ModelContextProtocol.AspNetCore.Tests` on net8/net9/net10: 537 passed, 30 skipped per target
- direct alpha.9 probes of every previously unwired client scenario and all task-extension scenarios
- repeated Windows probes of `json-schema-2020-12` and `server-sse-polling`

A repository-wide `dotnet test --no-build` run reached an unrelated environment blocker in `ModelContextProtocol.Tests`: stdio integration tests cannot discover `TestServer.exe` on this Windows machine (71-72 failures per target). All ASP.NET Core test targets, including the changed conformance coverage, passed.