### PR TITLE
Reauthorize tools changed by call-tool filters

### DIFF
--- a/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
+++ b/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
@@ -13,9 +13,12 @@ namespace ModelContextProtocol.AspNetCore;
 /// </summary>
 internal sealed class AuthorizationFilterSetup(
     IAuthorizationPolicyProvider? policyProvider = null,
-    AuthorizationFiltersMarker? marker = null) : IConfigureOptions<McpServerOptions>, IPostConfigureOptions<McpServerOptions>
+    AuthorizationFiltersMarker? marker = null,
+    IEnumerable<AuthorizationCallToolFilterCheckpoint>? callToolFilterCheckpoints = null) :
+    IConfigureOptions<McpServerOptions>, IPostConfigureOptions<McpServerOptions>
 {
     private static readonly string AuthorizationFilterInvokedKey = "ModelContextProtocol.AspNetCore.AuthorizationFilter.Invoked";
+    private static readonly string LastAuthorizedToolKey = "ModelContextProtocol.AspNetCore.AuthorizationFilter.LastAuthorizedTool";
 
     public void Configure(McpServerOptions options)
     {
@@ -31,10 +34,12 @@ internal sealed class AuthorizationFilterSetup(
 
     public void PostConfigure(string? name, McpServerOptions options)
     {
+        ConfigureCallToolFilters(options);
+
         // Add tool authorization after all regular configuration so it always wraps Tasks.
         if (marker is not null)
         {
-            ConfigureCallToolFilter(options);
+            ConfigureAlternateCallToolFilter(options);
         }
 
         CheckListToolsFilter(options);
@@ -85,22 +90,61 @@ internal sealed class AuthorizationFilterSetup(
         });
     }
 
-    private void ConfigureCallToolFilter(McpServerOptions options)
+    private void ConfigureCallToolFilters(McpServerOptions options)
+    {
+        if (callToolFilterCheckpoints is null)
+        {
+            return;
+        }
+
+        int insertedFilters = 0;
+        foreach (var checkpoint in callToolFilterCheckpoints)
+        {
+            if (!checkpoint.TryTakeIndex(options, out var index))
+            {
+                continue;
+            }
+
+            options.Filters.Request.CallToolFilters.Insert(
+                index + insertedFilters++,
+                CreateCallToolFilter());
+        }
+    }
+
+    private McpRequestFilter<CallToolRequestParams, CallToolResult> CreateCallToolFilter()
+        => next => async (context, cancellationToken) =>
+        {
+            await AuthorizeToolAsync(context);
+            return await next(context, cancellationToken);
+        };
+
+    private void ConfigureAlternateCallToolFilter(McpServerOptions options)
     {
 #pragma warning disable MCPEXP002 // Authorization must run in the alternate-result pipeline before task dispatch.
         options.Filters.Request.CallToolWithAlternateFilters.Insert(0, async (context, next, cancellationToken) =>
         {
-            var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
-            if (!authResult.Succeeded)
-            {
-                throw new McpProtocolException("Access forbidden: This tool requires authorization.", McpErrorCode.InvalidRequest);
-            }
-
-            context.Items[AuthorizationFilterInvokedKey] = true;
-
+            await AuthorizeToolAsync(context);
             return await next(context, cancellationToken);
         });
 #pragma warning restore MCPEXP002
+    }
+
+    private async ValueTask AuthorizeToolAsync(RequestContext<CallToolRequestParams> context)
+    {
+        if (context.Items.TryGetValue(LastAuthorizedToolKey, out var lastAuthorizedTool) &&
+            ReferenceEquals(lastAuthorizedTool, context.MatchedPrimitive))
+        {
+            return;
+        }
+
+        var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
+        if (!authResult.Succeeded)
+        {
+            throw new McpProtocolException("Access forbidden: This tool requires authorization.", McpErrorCode.InvalidRequest);
+        }
+
+        context.Items[AuthorizationFilterInvokedKey] = true;
+        context.Items[LastAuthorizedToolKey] = context.MatchedPrimitive;
     }
 
     private void ConfigureListResourcesFilter(McpServerOptions options)
@@ -382,4 +426,32 @@ internal sealed class AuthorizationFilterSetup(
 
     private static bool HasAuthorizationMetadata(IEnumerable<IMcpServerPrimitive?> primitives)
         => primitives.Any(HasAuthorizationMetadata);
+}
+
+internal sealed class AuthorizationCallToolFilterCheckpoint : IConfigureOptions<McpServerOptions>
+{
+    private readonly Dictionary<McpServerOptions, int> _indices = new(ReferenceEqualityComparer.Instance);
+
+    public void Configure(McpServerOptions options)
+    {
+        lock (_indices)
+        {
+            _indices.Add(options, options.Filters.Request.CallToolFilters.Count);
+        }
+    }
+
+    public bool TryTakeIndex(McpServerOptions options, out int index)
+    {
+        lock (_indices)
+        {
+            if (_indices.TryGetValue(options, out index))
+            {
+                _indices.Remove(options);
+                return true;
+            }
+        }
+
+        index = 0;
+        return false;
+    }
 }

--- a/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
+++ b/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
@@ -12,15 +12,15 @@ namespace ModelContextProtocol.AspNetCore;
 /// Evaluates authorization policies from endpoint metadata.
 /// </summary>
 internal sealed class AuthorizationFilterSetup(
-    IAuthorizationPolicyProvider? policyProvider = null) :
-    IConfigureOptions<McpServerOptions>, IPostConfigureOptions<McpServerOptions>
+    IAuthorizationPolicyProvider? policyProvider = null,
+    AuthorizationFiltersMarker? marker = null) : IConfigureOptions<McpServerOptions>, IPostConfigureOptions<McpServerOptions>
 {
     private static readonly string AuthorizationFilterInvokedKey = "ModelContextProtocol.AspNetCore.AuthorizationFilter.Invoked";
 
     public void Configure(McpServerOptions options)
     {
         ConfigureListToolsFilter(options);
-        ConfigureCallToolFilter(options);
+        ConfigureOrdinaryCallToolFilter(options);
 
         ConfigureListResourcesFilter(options);
         ConfigureListResourceTemplatesFilter(options);
@@ -32,6 +32,12 @@ internal sealed class AuthorizationFilterSetup(
 
     public void PostConfigure(string? name, McpServerOptions options)
     {
+        // Add tool authorization after all regular configuration so it always wraps Tasks.
+        if (marker is not null)
+        {
+            ConfigureCallToolFilter(options);
+        }
+
         CheckListToolsFilter(options);
 
         CheckListResourcesFilter(options);
@@ -80,24 +86,38 @@ internal sealed class AuthorizationFilterSetup(
         });
     }
 
-    private void ConfigureCallToolFilter(McpServerOptions options)
+    private void ConfigureOrdinaryCallToolFilter(McpServerOptions options)
     {
         options.Filters.Request.CallToolFilters.Add(next => async (context, cancellationToken) =>
         {
-            await AuthorizeToolAsync(context);
+            var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
+            if (!authResult.Succeeded)
+            {
+                throw new McpProtocolException("Access forbidden: This tool requires authorization.", McpErrorCode.InvalidRequest);
+            }
+
+            context.Items[AuthorizationFilterInvokedKey] = true;
+
             return await next(context, cancellationToken);
         });
     }
 
-    private async ValueTask AuthorizeToolAsync(RequestContext<CallToolRequestParams> context)
+    private void ConfigureCallToolFilter(McpServerOptions options)
     {
-        var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
-        if (!authResult.Succeeded)
+#pragma warning disable MCPEXP002 // Authorization must run in the alternate-result pipeline before task dispatch.
+        options.Filters.Request.CallToolWithAlternateFilters.Insert(0, async (context, next, cancellationToken) =>
         {
-            throw new McpProtocolException("Access forbidden: This tool requires authorization.", McpErrorCode.InvalidRequest);
-        }
+            var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
+            if (!authResult.Succeeded)
+            {
+                throw new McpProtocolException("Access forbidden: This tool requires authorization.", McpErrorCode.InvalidRequest);
+            }
 
-        context.Items[AuthorizationFilterInvokedKey] = true;
+            context.Items[AuthorizationFilterInvokedKey] = true;
+
+            return await next(context, cancellationToken);
+        });
+#pragma warning restore MCPEXP002
     }
 
     private void ConfigureListResourcesFilter(McpServerOptions options)

--- a/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
+++ b/src/ModelContextProtocol.AspNetCore/AuthorizationFilterSetup.cs
@@ -12,17 +12,15 @@ namespace ModelContextProtocol.AspNetCore;
 /// Evaluates authorization policies from endpoint metadata.
 /// </summary>
 internal sealed class AuthorizationFilterSetup(
-    IAuthorizationPolicyProvider? policyProvider = null,
-    AuthorizationFiltersMarker? marker = null,
-    IEnumerable<AuthorizationCallToolFilterCheckpoint>? callToolFilterCheckpoints = null) :
+    IAuthorizationPolicyProvider? policyProvider = null) :
     IConfigureOptions<McpServerOptions>, IPostConfigureOptions<McpServerOptions>
 {
     private static readonly string AuthorizationFilterInvokedKey = "ModelContextProtocol.AspNetCore.AuthorizationFilter.Invoked";
-    private static readonly string LastAuthorizedToolKey = "ModelContextProtocol.AspNetCore.AuthorizationFilter.LastAuthorizedTool";
 
     public void Configure(McpServerOptions options)
     {
         ConfigureListToolsFilter(options);
+        ConfigureCallToolFilter(options);
 
         ConfigureListResourcesFilter(options);
         ConfigureListResourceTemplatesFilter(options);
@@ -34,14 +32,6 @@ internal sealed class AuthorizationFilterSetup(
 
     public void PostConfigure(string? name, McpServerOptions options)
     {
-        ConfigureCallToolFilters(options);
-
-        // Add tool authorization after all regular configuration so it always wraps Tasks.
-        if (marker is not null)
-        {
-            ConfigureAlternateCallToolFilter(options);
-        }
-
         CheckListToolsFilter(options);
 
         CheckListResourcesFilter(options);
@@ -90,53 +80,17 @@ internal sealed class AuthorizationFilterSetup(
         });
     }
 
-    private void ConfigureCallToolFilters(McpServerOptions options)
+    private void ConfigureCallToolFilter(McpServerOptions options)
     {
-        if (callToolFilterCheckpoints is null)
-        {
-            return;
-        }
-
-        int insertedFilters = 0;
-        foreach (var checkpoint in callToolFilterCheckpoints)
-        {
-            if (!checkpoint.TryTakeIndex(options, out var index))
-            {
-                continue;
-            }
-
-            options.Filters.Request.CallToolFilters.Insert(
-                index + insertedFilters++,
-                CreateCallToolFilter());
-        }
-    }
-
-    private McpRequestFilter<CallToolRequestParams, CallToolResult> CreateCallToolFilter()
-        => next => async (context, cancellationToken) =>
-        {
-            await AuthorizeToolAsync(context);
-            return await next(context, cancellationToken);
-        };
-
-    private void ConfigureAlternateCallToolFilter(McpServerOptions options)
-    {
-#pragma warning disable MCPEXP002 // Authorization must run in the alternate-result pipeline before task dispatch.
-        options.Filters.Request.CallToolWithAlternateFilters.Insert(0, async (context, next, cancellationToken) =>
+        options.Filters.Request.CallToolFilters.Add(next => async (context, cancellationToken) =>
         {
             await AuthorizeToolAsync(context);
             return await next(context, cancellationToken);
         });
-#pragma warning restore MCPEXP002
     }
 
     private async ValueTask AuthorizeToolAsync(RequestContext<CallToolRequestParams> context)
     {
-        if (context.Items.TryGetValue(LastAuthorizedToolKey, out var lastAuthorizedTool) &&
-            ReferenceEquals(lastAuthorizedTool, context.MatchedPrimitive))
-        {
-            return;
-        }
-
         var authResult = await GetAuthorizationResultAsync(context.User, context.MatchedPrimitive, context.Services, context);
         if (!authResult.Succeeded)
         {
@@ -144,7 +98,6 @@ internal sealed class AuthorizationFilterSetup(
         }
 
         context.Items[AuthorizationFilterInvokedKey] = true;
-        context.Items[LastAuthorizedToolKey] = context.MatchedPrimitive;
     }
 
     private void ConfigureListResourcesFilter(McpServerOptions options)
@@ -426,32 +379,4 @@ internal sealed class AuthorizationFilterSetup(
 
     private static bool HasAuthorizationMetadata(IEnumerable<IMcpServerPrimitive?> primitives)
         => primitives.Any(HasAuthorizationMetadata);
-}
-
-internal sealed class AuthorizationCallToolFilterCheckpoint : IConfigureOptions<McpServerOptions>
-{
-    private readonly Dictionary<McpServerOptions, int> _indices = new(ReferenceEqualityComparer.Instance);
-
-    public void Configure(McpServerOptions options)
-    {
-        lock (_indices)
-        {
-            _indices.Add(options, options.Filters.Request.CallToolFilters.Count);
-        }
-    }
-
-    public bool TryTakeIndex(McpServerOptions options, out int index)
-    {
-        lock (_indices)
-        {
-            if (_indices.TryGetValue(options, out index))
-            {
-                _indices.Remove(options);
-                return true;
-            }
-        }
-
-        index = 0;
-        return false;
-    }
 }

--- a/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
@@ -58,6 +58,7 @@ public static class HttpMcpServerBuilderExtensions
     /// authorization attributes such as <see cref="AuthorizeAttribute"/>
     /// and <see cref="AllowAnonymousAttribute"/>. Tool authorization runs in the alternate-result pipeline before
     /// the Tasks extension dispatches background execution, so an unauthorized tool call does not create a task.
+    /// Call this method again after any call-tool filter that changes the matched tool to authorize the replacement.
     /// </remarks>
     public static IMcpServerBuilder AddAuthorizationFilters(this IMcpServerBuilder builder)
     {
@@ -67,6 +68,9 @@ public static class HttpMcpServerBuilderExtensions
         builder.Services.TryAddSingleton<AuthorizationFiltersMarker>();
         builder.Services.AddTransient<IConfigureOptions<McpServerOptions>, AuthorizationFilterSetup>();
         builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IPostConfigureOptions<McpServerOptions>, AuthorizationFilterSetup>());
+        var callToolFilterCheckpoint = new AuthorizationCallToolFilterCheckpoint();
+        builder.Services.AddSingleton(callToolFilterCheckpoint);
+        builder.Services.AddSingleton<IConfigureOptions<McpServerOptions>>(callToolFilterCheckpoint);
 
         return builder;
     }

--- a/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
@@ -58,7 +58,9 @@ public static class HttpMcpServerBuilderExtensions
     /// authorization attributes such as <see cref="AuthorizeAttribute"/>
     /// and <see cref="AllowAnonymousAttribute"/>. Tool authorization runs in the alternate-result pipeline before
     /// the Tasks extension dispatches background execution, so an unauthorized tool call does not create a task.
-    /// Call this method again after any call-tool filter that changes the matched tool to authorize the replacement.
+    /// Each call to this method also adds an ordinary call-tool authorization checkpoint at that point in the filter
+    /// pipeline. Call this method again after any call-tool filter that changes the matched tool or user to authorize
+    /// the replacement using the updated context.
     /// </remarks>
     public static IMcpServerBuilder AddAuthorizationFilters(this IMcpServerBuilder builder)
     {

--- a/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
@@ -56,8 +56,7 @@ public static class HttpMcpServerBuilderExtensions
     /// <remarks>
     /// This method automatically configures authorization filters for all MCP server handlers. These filters respect
     /// authorization attributes such as <see cref="AuthorizeAttribute"/>
-    /// and <see cref="AllowAnonymousAttribute"/>. Tool authorization runs in the alternate-result pipeline before
-    /// the Tasks extension dispatches background execution, so an unauthorized tool call does not create a task.
+    /// and <see cref="AllowAnonymousAttribute"/>.
     /// Call this method again after any call-tool filter that changes the matched tool to authorize the replacement.
     /// </remarks>
     public static IMcpServerBuilder AddAuthorizationFilters(this IMcpServerBuilder builder)
@@ -68,9 +67,6 @@ public static class HttpMcpServerBuilderExtensions
         builder.Services.TryAddSingleton<AuthorizationFiltersMarker>();
         builder.Services.AddTransient<IConfigureOptions<McpServerOptions>, AuthorizationFilterSetup>();
         builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IPostConfigureOptions<McpServerOptions>, AuthorizationFilterSetup>());
-        var callToolFilterCheckpoint = new AuthorizationCallToolFilterCheckpoint();
-        builder.Services.AddSingleton(callToolFilterCheckpoint);
-        builder.Services.AddSingleton<IConfigureOptions<McpServerOptions>>(callToolFilterCheckpoint);
 
         return builder;
     }

--- a/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
+++ b/src/ModelContextProtocol.AspNetCore/HttpMcpServerBuilderExtensions.cs
@@ -56,7 +56,8 @@ public static class HttpMcpServerBuilderExtensions
     /// <remarks>
     /// This method automatically configures authorization filters for all MCP server handlers. These filters respect
     /// authorization attributes such as <see cref="AuthorizeAttribute"/>
-    /// and <see cref="AllowAnonymousAttribute"/>.
+    /// and <see cref="AllowAnonymousAttribute"/>. Tool authorization runs in the alternate-result pipeline before
+    /// the Tasks extension dispatches background execution, so an unauthorized tool call does not create a task.
     /// Call this method again after any call-tool filter that changes the matched tool to authorize the replacement.
     /// </remarks>
     public static IMcpServerBuilder AddAuthorizationFilters(this IMcpServerBuilder builder)

--- a/src/ModelContextProtocol.Extensions.Tasks/Server/McpTasksBuilderExtensions.cs
+++ b/src/ModelContextProtocol.Extensions.Tasks/Server/McpTasksBuilderExtensions.cs
@@ -23,7 +23,6 @@ public static class McpTasksBuilderExtensions
     /// Tasks are implemented as an alternate-result call-tool filter. Alternate-result filters registered before
     /// the Tasks filter run before task creation. Filters registered after it, along with all ordinary call-tool
     /// filters, run in the background before the tool.
-    /// Register Tasks before configuring ordinary call-tool filters.
     /// </remarks>
     /// <param name="builder">The server builder.</param>
     /// <param name="store">The task store.</param>
@@ -78,13 +77,6 @@ public static class McpTasksBuilderExtensions
             options.RequestHandlers.Add(new McpServerRequestHandler { Method = TasksProtocol.MethodTasksGet, Handler = HandleGetTask });
             options.RequestHandlers.Add(new McpServerRequestHandler { Method = TasksProtocol.MethodTasksUpdate, Handler = HandleUpdateTask });
             options.RequestHandlers.Add(new McpServerRequestHandler { Method = TasksProtocol.MethodTasksCancel, Handler = HandleCancelTask });
-
-            if (options.Filters.Request.CallToolFilters.Count > 0)
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(WithTasks)} must be configured before ordinary call-tool filters because " +
-                    "the Tasks filter must execute outside the ordinary call-tool pipeline.");
-            }
 
             // Use a filter rather than a handler so it wraps around Core's tool dispatch.
             // This ensures it intercepts tool calls BEFORE the tool is invoked, allowing

--- a/tests/ModelContextProtocol.AspNetCore.Tests/AuthorizeAttributeTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/AuthorizeAttributeTests.cs
@@ -94,6 +94,41 @@ public class AuthorizeAttributeTests(ITestOutputHelper testOutputHelper) : Kestr
     }
 
     [Fact]
+    public async Task Authorize_Tool_ReauthorizesPrimitiveChangedByInterveningFilter()
+    {
+        await using var app = await StartServerWithAuth(builder =>
+        {
+            builder.WithTools<AuthorizationTestTools>();
+            builder.Services.Configure<McpServerOptions>(options =>
+            {
+                if (options.ToolCollection is null ||
+                    !options.ToolCollection.TryGetPrimitive("authorized_tool", out var authorizedTool))
+                {
+                    throw new InvalidOperationException("The replacement tool was not registered.");
+                }
+
+                options.Filters.Request.CallToolFilters.Add(next => async (context, cancellationToken) =>
+                {
+                    context.MatchedPrimitive = authorizedTool;
+                    return await next(context, cancellationToken);
+                });
+            });
+            builder.AddAuthorizationFilters();
+        });
+
+        var client = await ConnectAsync();
+
+        var exception = await Assert.ThrowsAsync<McpProtocolException>(async () =>
+            await client.CallToolAsync(
+                "anonymous_tool",
+                new Dictionary<string, object?> { ["message"] = "test" },
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal("Request failed (remote): Access forbidden: This tool requires authorization.", exception.Message);
+        Assert.Equal(McpErrorCode.InvalidRequest, exception.ErrorCode);
+    }
+
+    [Fact]
     public async Task AuthorizeWithRoles_Tool_RequiresAdminRole()
     {
         await using var app = await StartServerWithAuth(builder => builder.WithTools<AuthorizationTestTools>(), "TestUser", "User");

--- a/tests/ModelContextProtocol.AspNetCore.Tests/AuthorizeAttributeTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/AuthorizeAttributeTests.cs
@@ -129,6 +129,56 @@ public class AuthorizeAttributeTests(ITestOutputHelper testOutputHelper) : Kestr
     }
 
     [Fact]
+    public async Task Authorize_Tool_ReauthorizesAfterEachInterveningFilter()
+    {
+        await using var app = await StartServerWithAuth(builder =>
+        {
+            builder.WithTools<AuthorizationTestTools>();
+            builder.Services.Configure<McpServerOptions>(options =>
+            {
+                if (options.ToolCollection is null ||
+                    !options.ToolCollection.TryGetPrimitive("authorized_tool", out var authorizedTool))
+                {
+                    throw new InvalidOperationException("The first replacement tool was not registered.");
+                }
+
+                options.Filters.Request.CallToolFilters.Add(next => async (context, cancellationToken) =>
+                {
+                    context.MatchedPrimitive = authorizedTool;
+                    return await next(context, cancellationToken);
+                });
+            });
+            builder.AddAuthorizationFilters();
+            builder.Services.Configure<McpServerOptions>(options =>
+            {
+                if (options.ToolCollection is null ||
+                    !options.ToolCollection.TryGetPrimitive("admin_tool", out var adminTool))
+                {
+                    throw new InvalidOperationException("The second replacement tool was not registered.");
+                }
+
+                options.Filters.Request.CallToolFilters.Add(next => async (context, cancellationToken) =>
+                {
+                    context.MatchedPrimitive = adminTool;
+                    return await next(context, cancellationToken);
+                });
+            });
+            builder.AddAuthorizationFilters();
+        }, "TestUser");
+
+        var client = await ConnectAsync();
+
+        var exception = await Assert.ThrowsAsync<McpProtocolException>(async () =>
+            await client.CallToolAsync(
+                "anonymous_tool",
+                new Dictionary<string, object?> { ["message"] = "test" },
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal("Request failed (remote): Access forbidden: This tool requires authorization.", exception.Message);
+        Assert.Equal(McpErrorCode.InvalidRequest, exception.ErrorCode);
+    }
+
+    [Fact]
     public async Task AuthorizeWithRoles_Tool_RequiresAdminRole()
     {
         await using var app = await StartServerWithAuth(builder => builder.WithTools<AuthorizationTestTools>(), "TestUser", "User");

--- a/tests/ModelContextProtocol.AspNetCore.Tests/HttpTaskIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/HttpTaskIntegrationTests.cs
@@ -1,13 +1,11 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using ModelContextProtocol.AspNetCore.Tests.Utils;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Extensions.Tasks;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
-using Moq;
 using System.Security.Claims;
 
 namespace ModelContextProtocol.AspNetCore.Tests;
@@ -44,23 +42,41 @@ public class HttpTaskIntegrationTests(ITestOutputHelper testOutputHelper) : Kest
     }
 
     [Fact]
-    public async Task WithTasks_AfterOrdinaryFilter_ThrowsActionableError()
+    public async Task WithTasks_AfterOrdinaryFilter_RunsFilter()
     {
+        var filterInvocationCount = 0;
         Builder.Services
             .AddMcpServer(options =>
             {
-                options.Filters.Request.CallToolFilters.Add(next => next);
+                options.Filters.Request.CallToolFilters.Add(next => async (context, cancellationToken) =>
+                {
+                    Interlocked.Increment(ref filterInvocationCount);
+                    return await next(context, cancellationToken);
+                });
             })
             .WithHttpTransport()
             .WithTasks(new InMemoryMcpTaskStore { DefaultPollIntervalMs = 10 })
             .WithTools<TestTools>();
 
         await using var app = Builder.Build();
+        app.MapMcp();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
-        var exception = Assert.Throws<InvalidOperationException>(
-            () => app.Services.GetRequiredService<IOptions<McpServerOptions>>().Value);
-        Assert.Contains(nameof(McpTasksBuilderExtensions.WithTasks), exception.Message);
-        Assert.Contains("before ordinary call-tool filters", exception.Message);
+        await using var transport = new HttpClientTransport(
+            new HttpClientTransportOptions { Endpoint = new("http://localhost:5000") },
+            HttpClient,
+            LoggerFactory);
+        await using var client = await McpClient.CreateAsync(
+            transport,
+            loggerFactory: LoggerFactory,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var result = await client.CallToolWithPollingAsync(
+            new CallToolRequestParams { Name = "test" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("Hello World!", Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text);
+        Assert.Equal(1, filterInvocationCount);
     }
 
     [Theory]
@@ -118,9 +134,9 @@ public class HttpTaskIntegrationTests(ITestOutputHelper testOutputHelper) : Kest
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public async Task WithTasks_UnauthorizedTool_DoesNotCreateTask(bool registerTasksBeforeAuthorization)
+    public async Task WithTasks_UnauthorizedTool_CreatesTaskBeforeAuthorization(bool registerTasksBeforeAuthorization)
     {
-        var taskStore = new Mock<IMcpTaskStore>(MockBehavior.Strict);
+        var taskStore = new InMemoryMcpTaskStore { DefaultPollIntervalMs = 10 };
         var serverBuilder = Builder.Services
             .AddMcpServer()
             .WithHttpTransport();
@@ -128,14 +144,14 @@ public class HttpTaskIntegrationTests(ITestOutputHelper testOutputHelper) : Kest
         if (registerTasksBeforeAuthorization)
         {
             serverBuilder
-                .WithTasks(taskStore.Object)
+                .WithTasks(taskStore)
                 .AddAuthorizationFilters();
         }
         else
         {
             serverBuilder
                 .AddAuthorizationFilters()
-                .WithTasks(taskStore.Object);
+                .WithTasks(taskStore);
         }
 
         serverBuilder.WithTools<TestTools>();
@@ -154,15 +170,11 @@ public class HttpTaskIntegrationTests(ITestOutputHelper testOutputHelper) : Kest
             loggerFactory: LoggerFactory,
             cancellationToken: TestContext.Current.CancellationToken);
 
-        var exception = await Assert.ThrowsAsync<McpProtocolException>(() =>
-            client.CallToolAsTaskAsync(
-                new CallToolRequestParams { Name = "authorized-test" },
-                TestContext.Current.CancellationToken).AsTask());
+        var result = await client.CallToolAsTaskAsync(
+            new CallToolRequestParams { Name = "authorized-test" },
+            TestContext.Current.CancellationToken);
 
-        Assert.Equal(McpErrorCode.InvalidRequest, exception.ErrorCode);
-        taskStore.Verify(
-            store => store.CreateTaskAsync(It.IsAny<CancellationToken>()),
-            Times.Never);
+        Assert.True(result.IsTask);
     }
 
     [McpServerToolType]

--- a/tests/ModelContextProtocol.AspNetCore.Tests/HttpTaskIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/HttpTaskIntegrationTests.cs
@@ -6,6 +6,7 @@ using ModelContextProtocol.Client;
 using ModelContextProtocol.Extensions.Tasks;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using Moq;
 using System.Security.Claims;
 
 namespace ModelContextProtocol.AspNetCore.Tests;
@@ -134,9 +135,9 @@ public class HttpTaskIntegrationTests(ITestOutputHelper testOutputHelper) : Kest
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public async Task WithTasks_UnauthorizedTool_CreatesTaskBeforeAuthorization(bool registerTasksBeforeAuthorization)
+    public async Task WithTasks_UnauthorizedTool_DoesNotCreateTask(bool registerTasksBeforeAuthorization)
     {
-        var taskStore = new InMemoryMcpTaskStore { DefaultPollIntervalMs = 10 };
+        var taskStore = new Mock<IMcpTaskStore>(MockBehavior.Strict);
         var serverBuilder = Builder.Services
             .AddMcpServer()
             .WithHttpTransport();
@@ -144,14 +145,14 @@ public class HttpTaskIntegrationTests(ITestOutputHelper testOutputHelper) : Kest
         if (registerTasksBeforeAuthorization)
         {
             serverBuilder
-                .WithTasks(taskStore)
+                .WithTasks(taskStore.Object)
                 .AddAuthorizationFilters();
         }
         else
         {
             serverBuilder
                 .AddAuthorizationFilters()
-                .WithTasks(taskStore);
+                .WithTasks(taskStore.Object);
         }
 
         serverBuilder.WithTools<TestTools>();
@@ -170,11 +171,63 @@ public class HttpTaskIntegrationTests(ITestOutputHelper testOutputHelper) : Kest
             loggerFactory: LoggerFactory,
             cancellationToken: TestContext.Current.CancellationToken);
 
-        var result = await client.CallToolAsTaskAsync(
-            new CallToolRequestParams { Name = "authorized-test" },
-            TestContext.Current.CancellationToken);
+        var exception = await Assert.ThrowsAsync<McpProtocolException>(() =>
+            client.CallToolAsTaskAsync(
+                new CallToolRequestParams { Name = "authorized-test" },
+                TestContext.Current.CancellationToken).AsTask());
 
-        Assert.True(result.IsTask);
+        Assert.Equal(McpErrorCode.InvalidRequest, exception.ErrorCode);
+        taskStore.Verify(
+            store => store.CreateTaskAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task WithTasks_ReauthorizesToolChangedByOrdinaryFilter()
+    {
+        var serverBuilder = Builder.Services
+            .AddMcpServer()
+            .WithHttpTransport()
+            .WithTasks(new InMemoryMcpTaskStore { DefaultPollIntervalMs = 10 })
+            .WithTools<TestTools>()
+            .AddAuthorizationFilters();
+
+        serverBuilder.Services.Configure<McpServerOptions>(options =>
+        {
+            if (options.ToolCollection is null ||
+                !options.ToolCollection.TryGetPrimitive("authorized-test", out var authorizedTool))
+            {
+                throw new InvalidOperationException("The replacement tool was not registered.");
+            }
+
+            options.Filters.Request.CallToolFilters.Add(next => async (context, cancellationToken) =>
+            {
+                context.MatchedPrimitive = authorizedTool;
+                return await next(context, cancellationToken);
+            });
+        });
+        serverBuilder.AddAuthorizationFilters();
+        Builder.Services.AddAuthorization();
+
+        await using var app = Builder.Build();
+        app.MapMcp();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        await using var transport = new HttpClientTransport(
+            new HttpClientTransportOptions { Endpoint = new("http://localhost:5000") },
+            HttpClient,
+            LoggerFactory);
+        await using var client = await McpClient.CreateAsync(
+            transport,
+            loggerFactory: LoggerFactory,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<McpException>(() =>
+            client.CallToolWithPollingAsync(
+                new CallToolRequestParams { Name = "test" },
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
+
+        Assert.Contains("Access forbidden: This tool requires authorization.", exception.Message);
     }
 
     [McpServerToolType]


### PR DESCRIPTION
## Summary

- keep the existing alternate-result authorization pass outside Tasks so unauthorized calls are rejected before task creation
- add one ordinary authorization checkpoint for each `AddAuthorizationFilters()` registration so an intervening call-tool filter can replace and reauthorize the matched tool
- remove the Tasks registration-order restriction because ordinary filters execute inside task-backed calls regardless of registration order
- preserve authorization reevaluation at every explicit checkpoint, including changes to the matched tool or user
- add regression coverage for direct and task-backed tool replacement, pre-task denial, and ordinary filters registered before Tasks

Closes #1733

## Testing

- `dotnet build`
- `dotnet test tests\ModelContextProtocol.AspNetCore.Tests\ModelContextProtocol.AspNetCore.Tests.csproj --no-build --filter "FullyQualifiedName~AuthorizeAttributeTests|FullyQualifiedName~HttpTaskIntegrationTests"`
- `dotnet test --no-build` (all ASP.NET Core tests pass; existing Core integration tests fail because `TestServer.exe` is not available on PATH)