### PR TITLE
Document Windows stdio command-shell parsing

### DIFF
--- a/docs/concepts/transports/transports.md
+++ b/docs/concepts/transports/transports.md
@@ -45,6 +45,9 @@ The following table describes the key <xref:ModelContextProtocol.Client.StdioCli
 | `StandardErrorLines` | Callback for stderr output from the server process |
 | `Name` | Optional transport identifier for logging |
 
+> [!WARNING]
+> **Windows command-shell parsing:** On Windows, <xref:ModelContextProtocol.Client.StdioClientTransport> launches every command other than `cmd.exe` through `cmd.exe /c`. Both `Command` and `Arguments` are therefore interpreted by the Windows command shell, even though `Arguments` is supplied as a list. For values without whitespace, the SDK applies limited caret-escaping for `&`, `^`, `>`, `<`, and `|`, but this is not a general-purpose defense against command injection. Do not build either property from untrusted input; validate or allowlist any externally derived values before launching a stdio server.
+
 #### Environment variable inheritance
 
 By default, the server process inherits **all** environment variables from the current process. This includes credentials, tokens, proxy settings, and internal configuration that might be sensitive or irrelevant to the server. When running third-party or untrusted MCP servers, consider disabling inheritance to prevent unintentional credential leakage:

--- a/src/ModelContextProtocol.Core/Client/StdioClientTransportOptions.cs
+++ b/src/ModelContextProtocol.Core/Client/StdioClientTransportOptions.cs
@@ -94,6 +94,13 @@ public sealed class StdioClientTransportOptions
     /// <summary>
     /// Gets or sets the command to execute to start the server process.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// On Windows, commands other than <c>cmd.exe</c> are launched through <c>cmd.exe /c</c>. As a result, the
+    /// command is interpreted by the Windows command shell rather than passed directly to the child process. Do not
+    /// construct this value from untrusted input.
+    /// </para>
+    /// </remarks>
     /// <exception cref="ArgumentException">The value is <see langword="null"/>, empty, or composed entirely of whitespace.</exception>
     public required string Command
     {
@@ -112,6 +119,16 @@ public sealed class StdioClientTransportOptions
     /// <summary>
     /// Gets or sets the arguments to pass to the server process when it is started.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// On Windows, commands other than <c>cmd.exe</c> are launched through <c>cmd.exe /c</c>, so these values are
+    /// interpreted by the Windows command shell even though they are supplied as a list. For values without
+    /// whitespace, the transport applies limited caret-escaping for <c>&amp;</c>, <c>^</c>, <c>&gt;</c>, <c>&lt;</c>, and
+    /// <c>|</c>, but callers must not rely on the list representation or that escaping as a general-purpose defense
+    /// against command injection. Validate or allowlist any values derived from external input before including them
+    /// here.
+    /// </para>
+    /// </remarks>
     public IList<string>? Arguments { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- document on the public `Command` and `Arguments` API that Windows stdio launches are routed through `cmd.exe /c`
- clarify that list-shaped arguments are still interpreted by the Windows command shell
- add a security warning to the stdio transport guide describing the SDK's limited escaping and recommending validation or allowlisting

## Motivation

Callers can otherwise reasonably assume that `Arguments` reaches the child as an argv vector without shell interpretation. On Windows, that assumption is false for commands other than `cmd.exe`, which can invalidate command-injection threat models.

Fixes #1751.

## Validation

- `dotnet build` — 0 warnings, 0 errors
- `make generate-docs` — DocFX completed with `--warningsAsErrors true`, 0 warnings, 0 errors
- `git diff --check`