### PR TITLE
Add custom tool result marshaling

### DIFF
--- a/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
+++ b/src/ModelContextProtocol.Core/Server/AIFunctionMcpServerTool.cs
@@ -74,7 +74,7 @@ internal sealed partial class AIFunctionMcpServerTool : McpServerTool
         {
             Name = options?.Name ?? method.GetCustomAttribute<McpServerToolAttribute>()?.Name ?? DeriveName(method),
             Description = options?.Description,
-            MarshalResult = static (result, _, cancellationToken) => new ValueTask<object?>(result),
+            MarshalResult = options?.MarshalResult ?? (static (result, _, cancellationToken) => new ValueTask<object?>(result)),
             SerializerOptions = options?.SerializerOptions ?? McpJsonUtilities.DefaultOptions,
             JsonSchemaCreateOptions = options?.SchemaCreateOptions,
             ConfigureParameterBinding = pi =>

--- a/src/ModelContextProtocol.Core/Server/McpServerToolCreateOptions.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerToolCreateOptions.cs
@@ -158,6 +158,15 @@ public sealed class McpServerToolCreateOptions
     public JsonSerializerOptions? SerializerOptions { get; set; }
 
     /// <summary>
+    /// Gets or sets a delegate used to marshal the result returned by the tool method.
+    /// </summary>
+    /// <remarks>
+    /// The delegate receives the result, its declared return type, and a cancellation token.
+    /// If <see langword="null"/>, the result is passed through unchanged.
+    /// </remarks>
+    public Func<object?, Type?, CancellationToken, ValueTask<object?>>? MarshalResult { get; set; }
+
+    /// <summary>
     /// Gets or sets the JSON schema options when creating an <see cref="AIFunction"/> from a method.
     /// </summary>
     /// <value>
@@ -214,6 +223,7 @@ public sealed class McpServerToolCreateOptions
             UseStructuredContent = UseStructuredContent,
             OutputSchema = OutputSchema,
             SerializerOptions = SerializerOptions,
+            MarshalResult = MarshalResult,
             SchemaCreateOptions = SchemaCreateOptions,
             Metadata = Metadata,
             Icons = Icons,

--- a/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerToolTests.cs
@@ -355,6 +355,29 @@ public partial class McpServerToolTests
     }
 
     [Fact]
+    public async Task SupportsCustomResultMarshaling()
+    {
+        Mock<McpServer> mockServer = new();
+        McpServerTool tool = McpServerTool.Create(() => 42, new()
+        {
+            MarshalResult = (result, resultType, cancellationToken) =>
+            {
+                Assert.Equal(42, result);
+                Assert.Equal(typeof(int), resultType);
+                Assert.Equal(TestContext.Current.CancellationToken, cancellationToken);
+                return new($"marshaled:{result}");
+            },
+        });
+
+        var result = await tool.InvokeAsync(
+            new RequestContext<CallToolRequestParams>(mockServer.Object, CreateTestJsonRpcRequest(), new() { Name = "" }),
+            TestContext.Current.CancellationToken);
+
+        Assert.Single(result.Content);
+        Assert.Equal("marshaled:42", Assert.IsType<TextContentBlock>(result.Content[0]).Text);
+    }
+
+    [Fact]
     public async Task CanReturnCollectionOfStrings()
     {
         Mock<McpServer> mockServer = new();


### PR DESCRIPTION
## Summary

- add a `MarshalResult` delegate to `McpServerToolCreateOptions`
- pass the custom delegate to `AIFunctionFactoryOptions` while preserving the existing pass-through default
- preserve the delegate when deriving tool options
- add a regression test covering the result value, declared return type, cancellation token, and transformed tool response

## Motivation and context

This lets reflection-created MCP tools customize `AIFunction` result marshaling without recreating the SDK's private option-derivation logic.

Closes #1602.

## Validation

- `dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj --framework net10.0 --filter FullyQualifiedName~SupportsCustomResultMarshaling` — 1 passed
- `dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj --framework net10.0 --filter "Execution!=Manual"` — 2,335 passed, 3 skipped
- `make generate-docs` — Release build and DocFX succeeded with 0 warnings and 0 errors
- `git diff --check`

## Breaking changes

None. The new option is nullable and the existing pass-through behavior remains the default.