### PR TITLE
Clarify client handling of embedded binary tool resources

### DIFF
--- a/docs/concepts/tools/tools.md
+++ b/docs/concepts/tools/tools.md
@@ -121,6 +121,8 @@ public static EmbeddedResourceBlock GetBinaryData(string id)
 }
 ```
 
+The SDK sends binary embedded resources using the MCP resource shape: a URI, MIME type, and base64-encoded `blob`. It does not convert formats such as `application/pdf` into images. How an embedded resource is rendered or made available to a model depends on the client. When targeting clients that do not support a binary format, consider also returning a text representation or another client-supported content block.
+
 #### Mixed content
 
 Tools can return multiple content blocks by returning `IEnumerable<ContentBlock>`:

--- a/tests/ModelContextProtocol.Tests/Protocol/CallToolResultTests.cs
+++ b/tests/ModelContextProtocol.Tests/Protocol/CallToolResultTests.cs
@@ -1,4 +1,5 @@
 using ModelContextProtocol.Protocol;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -44,5 +45,43 @@ public static class CallToolResultTests
         Assert.Null(deserialized.StructuredContent);
         Assert.Null(deserialized.IsError);
         Assert.Null(deserialized.Meta);
+    }
+
+    [Fact]
+    public static void CallToolResult_SerializationRoundTrip_PreservesEmbeddedPdfResource()
+    {
+        byte[] pdfBytes = Encoding.ASCII.GetBytes("%PDF-1.7\n");
+        var original = new CallToolResult
+        {
+            Content =
+            [
+                new EmbeddedResourceBlock
+                {
+                    Resource = BlobResourceContents.FromBytes(
+                        pdfBytes,
+                        "file:///mypdf.pdf",
+                        "application/pdf")
+                }
+            ]
+        };
+
+        string json = JsonSerializer.Serialize(original, McpJsonUtilities.DefaultOptions);
+
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement resourceBlock = document.RootElement.GetProperty("content")[0];
+        Assert.Equal("resource", resourceBlock.GetProperty("type").GetString());
+
+        JsonElement resource = resourceBlock.GetProperty("resource");
+        Assert.Equal("file:///mypdf.pdf", resource.GetProperty("uri").GetString());
+        Assert.Equal("application/pdf", resource.GetProperty("mimeType").GetString());
+        Assert.Equal(Convert.ToBase64String(pdfBytes), resource.GetProperty("blob").GetString());
+
+        var deserialized = JsonSerializer.Deserialize<CallToolResult>(json, McpJsonUtilities.DefaultOptions);
+        Assert.NotNull(deserialized);
+        var embeddedResource = Assert.IsType<EmbeddedResourceBlock>(Assert.Single(deserialized.Content));
+        var pdfResource = Assert.IsType<BlobResourceContents>(embeddedResource.Resource);
+        Assert.Equal("file:///mypdf.pdf", pdfResource.Uri);
+        Assert.Equal("application/pdf", pdfResource.MimeType);
+        Assert.Equal(pdfBytes, pdfResource.DecodedData.ToArray());
     }
 }

--- a/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
@@ -4,6 +4,7 @@ using ModelContextProtocol.Server;
 using ModelContextProtocol.Tests.Utils;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -975,6 +976,84 @@ public class McpServerTests : LoggedTest
                 Assert.NotEmpty(result.Content);
                 Assert.Equal("test", Assert.IsType<TextContentBlock>(result.Content[0]).Text);
             });
+    }
+
+    [Fact]
+    public async Task Can_Handle_Call_Tool_Requests_With_Embedded_Pdf_Resource_On_Wire()
+    {
+        byte[] pdfBytes = Encoding.ASCII.GetBytes("%PDF-1.7\n");
+        await using var transport = new TestServerTransport();
+        var options = CreateOptions(new ServerCapabilities { Tools = new() });
+        options.Handlers.CallToolHandler = async (request, ct) =>
+        {
+            return new CallToolResult
+            {
+                Content =
+                [
+                    new EmbeddedResourceBlock
+                    {
+                        Resource = BlobResourceContents.FromBytes(
+                            pdfBytes,
+                            "file:///mypdf.pdf",
+                            "application/pdf")
+                    }
+                ]
+            };
+        };
+        options.Handlers.ListToolsHandler = (request, ct) => throw new NotImplementedException();
+
+        await using var server = McpServer.Create(transport, options, LoggerFactory);
+        var runTask = server.RunAsync(TestContext.Current.CancellationToken);
+        var receivedMessage = new TaskCompletionSource<JsonRpcResponse>();
+
+        transport.OnMessageSent = message =>
+        {
+            if (message is JsonRpcResponse response && response.Id.ToString() == "55")
+            {
+                receivedMessage.SetResult(response);
+            }
+        };
+
+        await transport.SendMessageAsync(
+            new JsonRpcRequest
+            {
+                Method = RequestMethods.ToolsCall,
+                Id = new RequestId(55)
+            },
+            TestContext.Current.CancellationToken);
+
+        var response = await receivedMessage.Task.WaitAsync(
+            TestConstants.DefaultTimeout,
+            TestContext.Current.CancellationToken);
+        string wireJson = JsonSerializer.Serialize<JsonRpcMessage>(
+            response,
+            McpJsonUtilities.DefaultOptions);
+
+        using JsonDocument document = JsonDocument.Parse(wireJson);
+        JsonElement root = document.RootElement;
+        Assert.Equal("2.0", root.GetProperty("jsonrpc").GetString());
+        Assert.Equal(55, root.GetProperty("id").GetInt32());
+
+        JsonElement resourceBlock = root.GetProperty("result").GetProperty("content")[0];
+        Assert.Equal("resource", resourceBlock.GetProperty("type").GetString());
+        JsonElement resource = resourceBlock.GetProperty("resource");
+        Assert.Equal("file:///mypdf.pdf", resource.GetProperty("uri").GetString());
+        Assert.Equal("application/pdf", resource.GetProperty("mimeType").GetString());
+        Assert.Equal(Convert.ToBase64String(pdfBytes), resource.GetProperty("blob").GetString());
+
+        var roundTrippedMessage = JsonSerializer.Deserialize<JsonRpcMessage>(
+            wireJson,
+            McpJsonUtilities.DefaultOptions);
+        var roundTrippedResponse = Assert.IsType<JsonRpcResponse>(roundTrippedMessage);
+        var result = roundTrippedResponse.Result.Deserialize<CallToolResult>(
+            McpJsonUtilities.DefaultOptions);
+        Assert.NotNull(result);
+        var embeddedResource = Assert.IsType<EmbeddedResourceBlock>(Assert.Single(result.Content));
+        var pdfResource = Assert.IsType<BlobResourceContents>(embeddedResource.Resource);
+        Assert.Equal(pdfBytes, pdfResource.DecodedData.ToArray());
+
+        await transport.DisposeAsync();
+        await runTask;
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- document that binary embedded resources are sent as MCP resource contents without SDK-side format conversion
- clarify that rendering and model availability depend on the client, with a text fallback suggested for unsupported formats
- add a protocol serialization regression for an embedded PDF resource
- add a server-path regression that verifies the complete JSON-RPC response and round-trip

## Findings

The SDK preserves the PDF MIME type and emits the MCP binary-resource shape:

```json
{
  "result": {
    "content": [
      {
        "type": "resource",
        "resource": {
          "uri": "file:///mypdf.pdf",
          "mimeType": "application/pdf",
          "blob": "JVBERi0xLjcK"
        }
      }
    ]
  },
  "id": 55,
  "jsonrpc": "2.0"
}
```

This indicates that the PDF-to-image behavior reported in #1261 occurs after the SDK emits the tool result.

## Validation

- `dotnet build --no-restore` — 0 warnings, 0 errors
- protocol PDF round-trip test — passed on `net472`, `net8.0`, `net9.0`, and `net10.0`
- server wire-response test — passed on `net8.0`, `net9.0`, and `net10.0`
  - `net472` is skipped by the existing Windows guard for `McpServerTests` (#587)

Resolves #1261.
