### PR TITLE
Fall back to initialize when server/discover fails at the HTTP layer

### DIFF
--- a/src/ModelContextProtocol.Core/Client/McpClientImpl.cs
+++ b/src/ModelContextProtocol.Core/Client/McpClientImpl.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Protocol;
 using System.Collections.Concurrent;
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -385,6 +386,17 @@ internal sealed partial class McpClientImpl : McpClient
                         // signals (-32022 UnsupportedProtocolVersion, -32021
                         // MissingRequiredClientCapability, -32020 HeaderMismatch) are caught above and
                         // never reach here.
+                        fallbackToInitialize = true;
+                    }
+                    catch (HttpRequestException ex) when (
+                        ex.GetStatusCode() is HttpStatusCode.BadRequest or HttpStatusCode.NotFound)
+                    {
+                        // A server predating SEP-2575 can reject the session-less server/discover POST at the
+                        // HTTP layer instead of with a JSON-RPC error: 400 when it cannot parse the request,
+                        // 404 when it requires Mcp-Session-Id on every non-initialize POST. A 400 carrying a
+                        // structured JSON-RPC error is surfaced as McpProtocolException and handled above, so
+                        // anything reaching here is plain or empty. Either way this is an initialize-handshake
+                        // server, so fall back. Other statuses stay uncaught and surface to the caller.
                         fallbackToInitialize = true;
                     }
                     catch (OperationCanceledException) when (probeCts.IsCancellationRequested && !initializationCts.IsCancellationRequested)

--- a/tests/ModelContextProtocol.Tests/Client/July2026ProtocolFallbackTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/July2026ProtocolFallbackTests.cs
@@ -2,6 +2,8 @@ using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Tests.Utils;
 using System.Diagnostics;
+using System.Net;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Channels;
@@ -206,6 +208,117 @@ public class July2026ProtocolFallbackTests(ITestOutputHelper testOutputHelper) :
         options.DiscoverProbeTimeout = Timeout.InfiniteTimeSpan;
         Assert.Equal(Timeout.InfiniteTimeSpan, options.DiscoverProbeTimeout);
     }
+
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound, HttpTransportMode.StreamableHttp)]
+    [InlineData(HttpStatusCode.NotFound, HttpTransportMode.AutoDetect)]
+    [InlineData(HttpStatusCode.BadRequest, HttpTransportMode.StreamableHttp)]
+    [InlineData(HttpStatusCode.BadRequest, HttpTransportMode.AutoDetect)]
+    public async Task Client_OnFallbackHttpStatusFromProbe_FallsBackTo_Initialize(
+        HttpStatusCode status, HttpTransportMode transportMode)
+    {
+        // A server predating SEP-2575 can reject the session-less server/discover probe at the HTTP layer
+        // rather than with a JSON-RPC error: 404 when it requires Mcp-Session-Id on every non-initialize
+        // POST, or a plain/empty 400 when it cannot parse the request. Both are initialize-handshake
+        // servers, so the connect must fall back instead of failing.
+        var ct = TestContext.Current.CancellationToken;
+        var initializeReceived = false;
+
+        using var mockHttpHandler = new MockHttpHandler();
+        using var httpClient = new HttpClient(mockHttpHandler);
+        mockHttpHandler.RequestHandler = CreateProbeRejectingServer(
+            status, "Invalid session ID", () => initializeReceived = true);
+
+        await using var transport = CreateTransport(httpClient, transportMode);
+
+        // Default options (ProtocolVersion = null) prefer 2026-07-28 but allow automatic fallback.
+        await using var client = await McpClient.CreateAsync(transport, new McpClientOptions(),
+            loggerFactory: LoggerFactory, cancellationToken: ct);
+
+        Assert.True(initializeReceived);
+        Assert.Equal(McpProtocolVersions.November2025ProtocolVersion, client.NegotiatedProtocolVersion);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError, HttpTransportMode.StreamableHttp)]
+    [InlineData(HttpStatusCode.Forbidden, HttpTransportMode.StreamableHttp)]
+    [InlineData(HttpStatusCode.InternalServerError, HttpTransportMode.AutoDetect)]
+    public async Task Client_OnOtherHttpErrorFromProbe_Surfaces_NoFallback(
+        HttpStatusCode status, HttpTransportMode transportMode)
+    {
+        // Only 400 and 404 are read as "this server needs the initialize handshake". Any other HTTP failure
+        // is a genuine transport error and must surface, so callers are not handed a misleading downstream
+        // error. Guards the deliberate narrowing of the status filter.
+        var ct = TestContext.Current.CancellationToken;
+        var initializeReceived = false;
+
+        using var mockHttpHandler = new MockHttpHandler();
+        using var httpClient = new HttpClient(mockHttpHandler);
+        mockHttpHandler.RequestHandler = CreateProbeRejectingServer(
+            status, "nope", () => initializeReceived = true);
+
+        await using var transport = CreateTransport(httpClient, transportMode);
+
+        await Assert.ThrowsAnyAsync<HttpRequestException>(async () =>
+        {
+            await using var client = await McpClient.CreateAsync(transport, new McpClientOptions(),
+                loggerFactory: LoggerFactory, cancellationToken: ct);
+        });
+
+        Assert.False(initializeReceived);
+    }
+
+    private HttpClientTransport CreateTransport(HttpClient httpClient, HttpTransportMode transportMode)
+        => new(new HttpClientTransportOptions
+        {
+            Endpoint = new Uri("http://localhost"),
+            TransportMode = transportMode,
+            Name = "HTTP discover probe test client",
+        }, httpClient, LoggerFactory);
+
+    /// <summary>
+    /// Mock Streamable HTTP server that rejects <c>server/discover</c> with <paramref name="probeStatus"/>
+    /// and, if the client falls back, completes an <c>initialize</c> handshake at 2025-11-25.
+    /// </summary>
+    private static Func<HttpRequestMessage, Task<HttpResponseMessage>> CreateProbeRejectingServer(
+        HttpStatusCode probeStatus, string probeBody, Action onInitialize)
+        => async request =>
+        {
+            // The server offers no standalone SSE stream, which the spec permits.
+            // net472 does not populate a default Content, so every response sets one explicitly.
+            if (request.Method == HttpMethod.Get)
+                return EmptyResponse(HttpStatusCode.MethodNotAllowed);
+
+            var body = await request.Content!.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            if (!doc.RootElement.TryGetProperty("method", out var methodElement))
+                return EmptyResponse(HttpStatusCode.Accepted);
+
+            switch (methodElement.GetString())
+            {
+                case RequestMethods.ServerDiscover:
+                    return new HttpResponseMessage(probeStatus) { Content = new StringContent(probeBody) };
+
+                case RequestMethods.Initialize:
+                    onInitialize();
+                    var id = doc.RootElement.GetProperty("id").GetRawText();
+                    var result = "{\"jsonrpc\":\"2.0\",\"id\":" + id
+                        + ",\"result\":{\"protocolVersion\":\"" + McpProtocolVersions.November2025ProtocolVersion
+                        + "\",\"capabilities\":{},\"serverInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}";
+                    var response = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(result, Encoding.UTF8, "application/json"),
+                    };
+                    response.Headers.Add("mcp-session-id", "test-session");
+                    return response;
+
+                default:
+                    return EmptyResponse(HttpStatusCode.Accepted);
+            }
+        };
+
+    private static HttpResponseMessage EmptyResponse(HttpStatusCode status)
+        => new(status) { Content = new StringContent(string.Empty) };
 
     /// <summary>
     /// Minimal in-memory transport that simulates an initialize-handshake server: rejects


### PR DESCRIPTION
Treat an HTTP 404 from the SEP-2575 `server/discover` probe as evidence of an initialize-handshake server and fall back, instead of failing the connection. Scoped to the explicit Streamable HTTP transport — see the AutoDetect note below.

## Motivation and Context

Fixes #1765.

Under the 2026-07-28 revision (SEP-2575) a client with `ProtocolVersion` unset probes `server/discover` and is expected to fall back to the `initialize` handshake for down-level servers. That fallback is keyed entirely on `McpProtocolException` plus the probe timeout, so it only fires when the server answers with a JSON-RPC error.

A Streamable HTTP server that requires `Mcp-Session-Id` on every non-initialize POST rejects the session-less `server/discover` at the HTTP layer instead — Datadog's hosted server answers `404 "Invalid session ID"`. That surfaces as `HttpRequestException` from `EnsureSuccessStatusCodeWithResponseBodyAsync`, which no catch in `ConnectAsync` handles, so it escapes and the connection fails outright. The server is reachable and speaks 2025-11-25 happily; only the probe fails. This is a regression from 2.0.0 — the same endpoint and credentials connect fine on 1.4.0 and 1.4.1.

`StreamableHttpClientSessionTransport` deliberately surfaces non-400 statuses as `HttpRequestException` for back-compat, so the gap is at the connect layer and that is where this fixes it.

## Scope, and what this deliberately does not fix

This PR is intentionally narrow. Three adjacent gaps are real and left for follow-ups:

**1. `AutoDetect` is excluded.** `AutoDetect` is the default `TransportMode`, but the fallback is gated off for it. Under AutoDetect a 404 causes the provisional Streamable transport to be disposed and an SSE GET attempted; when that fails, `SseClientSessionTransport.SetDisconnected` completes the *shared* message channel. An initialize sent afterwards is answered by the server but its response can never be read, so the connect stalls until `InitializationTimeout` and then fails. Measured locally: `ClientTransportClosedException` after ~6s with `initializeReceived == true`, versus an immediate, clear 404 without this change. Falling back there would be strictly worse than today's behavior, so it is gated out and pinned by a test. Fixing AutoDetect properly needs provisional SSE failure to leave the shared channel open, the way `StreamableHttpClientSessionTransport` already does — happy to open that as a separate issue/PR.

**2. Plain HTTP 400 is still unhandled.** `docs/concepts/stateless/stateless.md` states that a `400` carrying anything other than a structured `-32022`/`-32021`/`-32020` error should switch to the `initialize` flow. A plain-text or empty 400 fails JSON-RPC parsing, becomes `HttpRequestException`, and escapes exactly like the 404 did. That documented case predates this PR and is not addressed here; 404 is fixed because it is the case with a reproducible public server behind it.

**3. netstandard2.0 / net472 do not get the fix.** `HttpRequestException.StatusCode` is .NET 5+, and `HttpResponseMessageExtensions.CreateHttpRequestException` drops the status entirely on non-NET targets, so there is nothing to read. The catch and its tests are `#if NET`-guarded, matching the existing pattern in `AutoDetectingClientSessionTransport.cs`. A portable version would need an internal exception subtype carrying the status code on all TFMs — glad to do that instead if you'd prefer the fix apply everywhere.

## How Has This Been Tested?

Yes — in a real application as well as unit tests.

- **New tests** in `July2026ProtocolFallbackTests`, all driving a real `HttpClientTransport` over `MockHttpHandler`:
  - `Client_OnHttpNotFoundFromProbe_FallsBackTo_Initialize` — the fix. Verified both directions: fails on unmodified `main` with the production error, passes with the fix.
  - `Client_OnNonNotFoundHttpErrorFromProbe_Surfaces_NoFallback` (500, 403) — guards the deliberate narrowing. Verified it fails if the catch is broadened to all `HttpRequestException`.
  - `Client_OnHttpNotFoundFromProbe_UnderAutoDetect_Surfaces_NoFallback` — pins the AutoDetect exclusion above.
- **Full suite**, Release: 2344 passed, 1 failed. The failure is `DockerEverythingServerTests.Sampling_Sse_EverythingServer`, which reproduces identically on unmodified `main`.
- **Debug and Release** both run clean on the fallback suite (15/15). Called out because an earlier iteration of this fix tripped a `Debug.Assert` on a closed channel.
- **Live servers**, `TransportMode = StreamableHttp`, no pinned `ProtocolVersion`:

  | Server | before | after |
  |---|---|---|
  | Datadog | `404 Invalid session ID` | 30 tools, negotiated 2025-11-25 |
  | GitHub | 36 tools, 2026-07-28 | 36 tools, 2026-07-28 |
  | Sentry | 8 tools, 2026-07-28 | 8 tools, 2026-07-28 |

  GitHub and Sentry genuinely support SEP-2575 and are unaffected.
- **Real application:** a production Slack agent connecting to five MCP servers. Its Datadog provider failed to connect on stock 2.0.0 and connects with this patch, other four unchanged. A/B'd by swapping only `ModelContextProtocol.Core.dll` under the same application binary.

Not verified: the net472 leg (cannot build .NET Framework locally) and the net8.0/net9.0 legs (only the 10.0 runtime is installed here). All guarded code is excluded from net472 by construction, so that translation unit is unchanged from `main`.

## Breaking Changes

None. No public API change. The only behavioral difference is that a connect over an explicit Streamable HTTP transport which previously threw `HttpRequestException` on a 404 from the discover probe now falls back to `initialize` and can succeed. Non-404 statuses, and all AutoDetect behavior, are unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The `_transport is not AutoDetectingClientSessionTransport` guard in the filter is a type check I'd rather not need. If you'd prefer, the alternative is to land the SSE channel-lifetime fix first and then apply the 404 fallback uniformly across both transport modes — that would be a cleaner end state, just a larger change. Happy to go that route instead.
