### PR TITLE
Preserve HTTP status codes across target frameworks

### DIFF
--- a/src/Common/HttpResponseMessageExtensions.cs
+++ b/src/Common/HttpResponseMessageExtensions.cs
@@ -69,10 +69,53 @@ internal static class HttpResponseMessageExtensions
             ? $"Response status code does not indicate success: {statusCodeInt} ({response.ReasonPhrase})."
             : $"Response status code does not indicate success: {statusCodeInt} ({response.ReasonPhrase}). Response body: {responseBody}";
 
+        return HttpRequestExceptionExtensions.Create(message, innerException: null, response.StatusCode);
+    }
+}
+
+/// <summary>
+/// Helpers for preserving HTTP status codes on <see cref="HttpRequestException"/> across all target frameworks.
+/// </summary>
+internal static class HttpRequestExceptionExtensions
+{
+    internal const string StatusCodeDataKey = "ModelContextProtocol.HttpStatusCode";
+
+    /// <summary>
+    /// Creates an <see cref="HttpRequestException"/> and preserves its HTTP status code.
+    /// </summary>
+    public static HttpRequestException Create(string message, Exception? innerException, HttpStatusCode? statusCode)
+    {
 #if NET
-        return new HttpRequestException(message, inner: null, response.StatusCode);
+        var exception = new HttpRequestException(message, innerException, statusCode);
 #else
-        return new HttpRequestException(message);
+        var exception = new HttpRequestException(message, innerException);
 #endif
+
+        if (statusCode is not null)
+        {
+            exception.Data[StatusCodeDataKey] = statusCode.Value;
+        }
+
+        return exception;
+    }
+
+    /// <summary>
+    /// Gets the preserved HTTP status code from an <see cref="HttpRequestException"/>.
+    /// </summary>
+    public static HttpStatusCode? GetStatusCode(this HttpRequestException exception)
+    {
+#if NET
+        if (exception.StatusCode is { } statusCode)
+        {
+            return statusCode;
+        }
+#endif
+
+        return exception.Data[StatusCodeDataKey] switch
+        {
+            HttpStatusCode storedStatusCode => storedStatusCode,
+            int storedStatusCodeValue => (HttpStatusCode)storedStatusCodeValue,
+            _ => null,
+        };
     }
 }

--- a/src/Common/HttpResponseMessageExtensions.cs
+++ b/src/Common/HttpResponseMessageExtensions.cs
@@ -114,7 +114,6 @@ internal static class HttpRequestExceptionExtensions
         return exception.Data[StatusCodeDataKey] switch
         {
             HttpStatusCode storedStatusCode => storedStatusCode,
-            int storedStatusCodeValue => (HttpStatusCode)storedStatusCodeValue,
             _ => null,
         };
     }

--- a/src/ModelContextProtocol.Core/Client/AutoDetectingClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/AutoDetectingClientSessionTransport.cs
@@ -146,14 +146,10 @@ internal sealed partial class AutoDetectingClientSessionTransport : ITransport
             // keep HttpRequestException as the surfaced type so existing callers can still catch it and read StatusCode.
             await sseTransport.DisposeAsync().ConfigureAwait(false);
             LogSseFallbackFailedAfterStreamableHttp(_name, sseError);
-#if NET
-            throw new HttpRequestException(streamableHttpError.Message, sseError, streamableHttpError.StatusCode);
-#else
-            // net472 has no HttpRequestException overload that carries a status code, so this target
-            // preserves the status text in the message but not a programmatic StatusCode. Preserving the
-            // status code is intentionally net5+ only rather than an oversight.
-            throw new HttpRequestException(streamableHttpError.Message, sseError);
-#endif
+            throw HttpRequestExceptionExtensions.Create(
+                streamableHttpError.Message,
+                sseError,
+                streamableHttpError.GetStatusCode());
         }
         catch
         {

--- a/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportAutoDetectTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportAutoDetectTests.cs
@@ -101,6 +101,10 @@ public class HttpClientTransportAutoDetectTests(ITestOutputHelper testOutputHelp
         Assert.Contains("403", ex.Message);
         Assert.IsType<HttpRequestException>(ex.InnerException);
         Assert.Contains("405", ex.InnerException.Message);
+        Assert.Equal(HttpStatusCode.Forbidden, ex.Data["ModelContextProtocol.HttpStatusCode"]);
+#if NET
+        Assert.Equal(HttpStatusCode.Forbidden, ex.StatusCode);
+#endif
     }
 
     [Fact]
@@ -300,6 +304,7 @@ public class HttpClientTransportAutoDetectTests(ITestOutputHelper testOutputHelp
         var httpEx = Assert.IsType<HttpRequestException>(ex);
         Assert.Contains("415", httpEx.Message);
         Assert.Contains(streamableHttpBody, httpEx.Message);
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, httpEx.Data["ModelContextProtocol.HttpStatusCode"]);
 #if NET
         Assert.Equal(HttpStatusCode.UnsupportedMediaType, httpEx.StatusCode);
 #endif


### PR DESCRIPTION
## Motivation and Context

`HttpRequestException.StatusCode` is unavailable on `netstandard2.0`, so HTTP status information is currently lost on that target. AutoDetect also recreates the original Streamable HTTP exception when SSE fallback fails, which must preserve the status for downstream handling.

This prepares for #1765, where connect-time fallback needs to distinguish HTTP 400/404 responses consistently across all supported target frameworks.

## Changes

- Add internal helpers that create `HttpRequestException` instances while preserving the HTTP status in `Exception.Data`.
- Prefer the native `HttpRequestException.StatusCode` where available, with the stored value as a cross-target fallback.
- Preserve the original Streamable HTTP status when AutoDetect wraps a failed SSE fallback.
- Add coverage for status preservation across `net10.0`, `net9.0`, `net8.0`, and `net472`.

No public API is added or changed.

## How Has This Been Tested?

- `dotnet build`
- Focused AutoDetect transport tests on `net10.0`, `net9.0`, `net8.0`, and `net472`
- Full core test suites

The ASP.NET conformance suite could not start locally because Node.js 21.6.2 does not provide `fs.globSync`, which is required by the pinned conformance package.

## Breaking Changes

None.

> This pull request description was generated with GitHub Copilot.