### PR TITLE
Clarify AI disclosure format with > [!NOTE] alert example

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ This repository contains the official C# SDK for the Model Context Protocol (MCP
 - Never chain commit and push in the same command. Commit first, report what was committed, then wait for explicit push instructions. This creates a mandatory decision point.
 
 ### AI-Generated Content Disclosure
-When posting any content to GitHub under a user's credentials — opening pull requests, creating issues, commenting on pull requests or issues, posting review comments, or taking any other public-facing action — include a concise, visible note at the bottom indicating that the content was AI/Copilot-generated.
+When posting any content to GitHub under a user's credentials — opening pull requests, creating issues, commenting on pull requests or issues, posting review comments, or taking any other public-facing action — include a concise, visible note (e.g. a `> [!NOTE]` alert) at the bottom indicating that the content was AI/Copilot-generated.
 
 This disclosure is not required when:
 - The account is a recognized bot or Copilot app account (for example, `github-actions[bot]` or `copilot`), where the AI origin is already apparent from the account identity.


### PR DESCRIPTION
## Summary

Standardizes the AI-generated content disclosure format in Copilot instructions by specifying a `> [!NOTE]` GitHub alert as the recommended presentation. This matches how dotnet/runtime handles AI disclosure formatting.

### Change

In `.github/copilot-instructions.md`, the disclosure guidance now reads:

> include a concise, visible note (e.g. a `> [!NOTE]` alert) at the bottom indicating that the content was AI/Copilot-generated.

Previously it just said "a concise, visible note" with no formatting guidance. All other rules and exceptions are unchanged.

> [!NOTE]
> This PR was created by GitHub Copilot.
