### PR TITLE
Speed up CLI argument escaping tests

### DIFF
--- a/tests/ModelContextProtocol.TestServer/Program.cs
+++ b/tests/ModelContextProtocol.TestServer/Program.cs
@@ -34,6 +34,13 @@ internal static class Program
 
     private static async Task Main(string[] args)
     {
+        if (args.Contains("--echo-cli-arg-and-exit"))
+        {
+            Console.Error.WriteLine($"CLI_ARG:{JsonSerializer.Serialize(ParseCliArgument(args))}");
+            Console.Error.Flush();
+            return;
+        }
+
         Log.Logger.Information("Starting server...");
 
         string? cliArg = ParseCliArgument(args);

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -152,7 +152,9 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
         {
             Assert.Skip("mono runtime does not handle arguments ending with backslash correctly.");
         }
-        
+
+        const string OutputPrefix = "CLI_ARG:";
+        var capturedArgument = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         string cliArgument = $"--cli-arg={cliArgumentValue}";
         string testServerExecutable = Path.Combine(AppContext.BaseDirectory, "TestServer.exe");
         string testServerDll = Path.Combine(AppContext.BaseDirectory, "TestServer.dll");
@@ -168,25 +170,34 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
             },
             Arguments = (PlatformDetection.IsMonoRuntime, PlatformDetection.IsWindows) switch
             {
-                (true, _) => [testServerExecutable, cliArgument],
-                (_, true) => [cliArgument],
-                _ => [testServerDll, cliArgument],
+                (true, _) => [testServerExecutable, "--echo-cli-arg-and-exit", cliArgument],
+                (_, true) => ["--echo-cli-arg-and-exit", cliArgument],
+                _ => [testServerDll, "--echo-cli-arg-and-exit", cliArgument],
+            },
+            StandardErrorLines = line =>
+            {
+                if (line.StartsWith(OutputPrefix, StringComparison.Ordinal))
+                {
+                    capturedArgument.TrySetResult(line[OutputPrefix.Length..]);
+                }
             },
         };
 
         var transport = new StdioClientTransport(options, LoggerFactory);
+        await using var session = await transport.ConnectAsync(TestContext.Current.CancellationToken);
 
-        // Act: Create client (handshake) and list tools to ensure full round trip works with the argument present.
-        await using var client = await McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
-        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        string serializedArgument = await capturedArgument.Task.WaitAsync(
+            TestConstants.DefaultTimeout,
+            TestContext.Current.CancellationToken);
+        JsonElement parsedArgument = JsonElement.Parse(serializedArgument);
+        Assert.Equal(cliArgumentValue ?? "", parsedArgument.GetString());
 
-        // Assert
-        Assert.NotNull(tools);
-        Assert.NotEmpty(tools);
-
-        var result = await client.CallToolAsync("echoCliArg", cancellationToken: TestContext.Current.CancellationToken);
-        var content = Assert.IsType<TextContentBlock>(Assert.Single(result.Content));
-        Assert.Equal(cliArgumentValue ?? "", content.Text);
+        var exception = await Assert.ThrowsAsync<ClientTransportClosedException>(
+            async () => await session.MessageReader.Completion.WaitAsync(
+                TestConstants.DefaultTimeout,
+                TestContext.Current.CancellationToken));
+        var completionDetails = Assert.IsType<StdioClientCompletionDetails>(exception.Details);
+        Assert.Equal(0, completionDetails.ExitCode);
     }
 
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]


### PR DESCRIPTION
Replace repeated MCP handshake/tool calls with a lightweight TestServer mode that echoes the parsed CLI argument through stderr and exits cleanly. This preserves real child-process coverage across Windows `cmd.exe`, Unix `dotnet`, and Mono launch paths.

Targeted runtime across all frameworks dropped from **3m 53s to ~8s** (~30× faster), saving approximately **3½ minutes per affected CI leg** and potentially from overall PR validation time.

**Validation:** `dotnet build` and all 38 targeted cases pass on net10.0, net9.0, net8.0, and net472.

> Generated with GitHub Copilot.