### PR TITLE
Avoid reading Configuration in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,30 +11,19 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- This works around issues with dotnet test which are fixed in https://github.com/dotnet/sdk/pull/51794 -->
-    <!-- It can be safely removed once .NET SDK 10.0.101 is out and is used in the repo -->
-    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))</RepoRoot>
     <ArtifactsDir Condition="'$(ArtifactsDir)' == ''">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</ArtifactsDir>
     <ArtifactsObjDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'obj'))</ArtifactsObjDir>
     <ArtifactsBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'bin'))</ArtifactsBinDir>
-    <ArtifactsTestResultsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'TestResults', '$(Configuration)'))</ArtifactsTestResultsDir>
-    <ArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'packages', '$(Configuration)'))</ArtifactsPackagesDir>
     <OutDirName>$(MSBuildProjectName)</OutDirName>
 
     <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(ArtifactsObjDir)$(OutDirName)\'))</BaseIntermediateOutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
 
     <BaseOutputPath>$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)$(OutDirName)\'))</BaseOutputPath>
-    <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
-
-    <PackageOutputPath>$(ArtifactsPackagesDir)</PackageOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>
     <VSTestLogger Condition="'$(VSTestLogger)' == ''">trx%3bLogFileName=$(MSBuildProjectName).$(TargetFramework).$(OS).trx</VSTestLogger>
-    <VSTestResultsDirectory Condition="'$(VSTestResultsDirectory)' == ''">$(ArtifactsTestResultsDir)</VSTestResultsDirectory>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <ArtifactsTestResultsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'TestResults', '$(Configuration)'))</ArtifactsTestResultsDir>
+    <ArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'packages', '$(Configuration)'))</ArtifactsPackagesDir>
+    <PackageOutputPath>$(ArtifactsPackagesDir)</PackageOutputPath>
+    <VSTestResultsDirectory Condition="'$(VSTestResultsDirectory)' == ''">$(ArtifactsTestResultsDir)</VSTestResultsDirectory>
+  </PropertyGroup>
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.101",
     "rollForward": "minor"
   }
 }

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="..\Directory.Build.targets" />
+
   <Target Name="PinMcpProjectReferencePackageVersions"
           AfterTargets="_GetProjectReferenceVersions"
           Condition="'$(MSBuildProjectName)' == 'ModelContextProtocol'


### PR DESCRIPTION
## Summary
- keep configuration-independent artifact base paths in `Directory.Build.props`
- move package and test-result paths to `Directory.Build.targets`, after `Configuration` is initialized
- import the root targets from `src/Directory.Build.targets` and require SDK 10.0.101 or newer

Closes #995

## Test plan
- `dotnet build ModelContextProtocol.slnx --configuration Debug --no-incremental`
- `dotnet build ModelContextProtocol.slnx --configuration Release --no-incremental`
- `dotnet test ModelContextProtocol.slnx --configuration Debug --no-build --no-restore --filter "(Execution!=Manual)"` (8,862 passed)
- `dotnet pack ModelContextProtocol.slnx --configuration Release --no-build --no-restore`
- verify Debug and Release MSBuild property evaluation for output, intermediate, package, and test-result paths
- direct analyzer test run writes TRX output under `artifacts/TestResults/Debug`