### PR TITLE
Add Application Insights telemetry example

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,6 +64,7 @@
   <!-- Testing dependencies -->
   <ItemGroup>
     <PackageVersion Include="Anthropic" Version="12.39.0" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.6.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/AspNetCoreMcpServer/AspNetCoreMcpServer.csproj
+++ b/samples/AspNetCoreMcpServer/AspNetCoreMcpServer.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/samples/AspNetCoreMcpServer/Program.cs
+++ b/samples/AspNetCoreMcpServer/Program.cs
@@ -1,3 +1,4 @@
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -34,15 +35,27 @@ builder.Services.AddMcpServer()
     .WithTools<WeatherTools>()
     .WithResources<SimpleResourceType>();
 
-builder.Services.AddOpenTelemetry()
+var telemetry = builder.Services.AddOpenTelemetry()
     .WithTracing(b => b.AddSource("*")
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation())
     .WithMetrics(b => b.AddMeter("*")
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation())
-    .WithLogging()
-    .UseOtlpExporter();
+    .WithLogging();
+
+string? applicationInsightsConnectionString =
+    builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
+
+if (string.IsNullOrWhiteSpace(applicationInsightsConnectionString))
+{
+    telemetry.UseOtlpExporter();
+}
+else
+{
+    telemetry.UseAzureMonitor(options =>
+        options.ConnectionString = applicationInsightsConnectionString);
+}
 
 // Configure HttpClientFactory for weather.gov API
 builder.Services.AddHttpClient("WeatherApi", client =>

--- a/samples/AspNetCoreMcpServer/README.md
+++ b/samples/AspNetCoreMcpServer/README.md
@@ -1,0 +1,48 @@
+# ASP.NET Core MCP server sample
+
+This sample hosts an MCP server with Streamable HTTP and configures OpenTelemetry for MCP operations, ASP.NET Core requests, outgoing HTTP requests, metrics, and structured logs.
+
+## Export to Application Insights
+
+Set the Application Insights connection string and run the sample:
+
+```bash
+export APPLICATIONINSIGHTS_CONNECTION_STRING='InstrumentationKey=<your-instrumentation-key>;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/'
+dotnet run --project samples/AspNetCoreMcpServer
+```
+
+PowerShell:
+
+```powershell
+$env:APPLICATIONINSIGHTS_CONNECTION_STRING = 'InstrumentationKey=<your-instrumentation-key>;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/'
+dotnet run --project samples/AspNetCoreMcpServer
+```
+
+The connection string is read through ASP.NET Core configuration. Keep it outside source control and use your deployment platform's secret configuration in production.
+
+When `APPLICATIONINSIGHTS_CONNECTION_STRING` is absent or empty, the sample retains its default OTLP exporter. Configure that path with standard `OTEL_EXPORTER_OTLP_*` environment variables.
+
+## Signals and MCP attributes
+
+Application Insights receives the signals already emitted by the SDK and the configured ASP.NET Core/OpenTelemetry instrumentation:
+
+- server activities appear as requests and client activities appear as dependencies;
+- structured logs appear as traces;
+- MCP histograms appear as custom metrics;
+- HTTP server and client instrumentation provides the surrounding transport spans.
+
+MCP activities can include attributes such as `mcp.method.name`, `mcp.protocol.version`, `mcp.session.id`, `jsonrpc.request.id`, and `gen_ai.tool.name`. The exact attributes depend on the operation and whether sensitive-data telemetry is enabled.
+
+For example, query MCP request and dependency telemetry in Logs:
+
+```kusto
+union withsource=TelemetryType requests, dependencies
+| extend McpMethod = tostring(customDimensions["mcp.method.name"]),
+         ToolName = tostring(customDimensions["gen_ai.tool.name"]),
+         McpSession = tostring(customDimensions["mcp.session.id"])
+| where isnotempty(McpMethod)
+| project timestamp, TelemetryType, name, success, resultCode, McpMethod, ToolName, McpSession
+| order by timestamp desc
+```
+
+Invalid tool calls, malformed JSON-RPC messages, and other failures appear only when the current SDK or ASP.NET Core instrumentation emits a log or activity for that path. This sample exports existing telemetry; it does not add custom protocol events or per-tool instrumentation.


### PR DESCRIPTION
## Summary
- add the Azure Monitor OpenTelemetry distro to the compiled ASP.NET Core MCP server sample
- select Application Insights when `APPLICATIONINSIGHTS_CONNECTION_STRING` is configured while retaining OTLP as the default
- document setup, exported signals, MCP attributes, and a sample Application Insights query

Closes #1026

## Test plan
- `dotnet build samples/AspNetCoreMcpServer/AspNetCoreMcpServer.csproj --configuration Debug --no-incremental`
- `dotnet build samples/AspNetCoreMcpServer/AspNetCoreMcpServer.csproj --configuration Release --no-incremental`
- OTLP-default startup smoke test and MCP endpoint request
- Azure Monitor startup smoke test with a non-secret placeholder connection string
- `dotnet build ModelContextProtocol.slnx --configuration Debug --no-incremental`
- `dotnet test ModelContextProtocol.slnx --configuration Debug --no-build --no-restore --filter "(Execution!=Manual)"` (8,862 passed)
- focused `dotnet format` verification for the modified C# file; the repository-wide formatter currently reports 74 pre-existing files on main