### PR TITLE
Make the alternate-result seam method-agnostic

### DIFF
--- a/src/ModelContextProtocol.Core/Server/AlternateResultFilterCollection.cs
+++ b/src/ModelContextProtocol.Core/Server/AlternateResultFilterCollection.cs
@@ -1,0 +1,131 @@
+using ModelContextProtocol.Protocol;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModelContextProtocol.Server;
+
+#pragma warning disable MCPEXP002 // this collection is itself part of the experimental ResultOrAlternate seam
+
+/// <summary>
+/// Stores alternate-result filters keyed by JSON-RPC method name, so that augmenting a Core-dispatched
+/// method to return an alternate <see cref="Result"/> subtype does not require a new
+/// <c>&lt;Method&gt;WithAlternateHandler</c>/<c>&lt;Method&gt;WithAlternateFilters</c> pair per method.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each method may only be registered with a single (<c>TParams</c>, <c>TResult</c>) pair, matching the
+/// types Core dispatches that method with. Registering the same method with different types throws, because
+/// the mismatched filters could never be invoked.
+/// </para>
+/// <para>
+/// <see cref="McpRequestFilters.CallToolWithAlternateFilters"/> is a typed view over the
+/// <see cref="RequestMethods.ToolsCall"/> entry of this collection.
+/// </para>
+/// </remarks>
+[Experimental(Experimentals.Extensibility_DiagnosticId, UrlFormat = Experimentals.Extensibility_Url)]
+public sealed class AlternateResultFilterCollection
+{
+    private readonly Dictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the filter list registered for <paramref name="method"/>, creating an empty one if the method
+    /// has not been registered yet.
+    /// </summary>
+    /// <typeparam name="TParams">The request parameter type Core dispatches <paramref name="method"/> with.</typeparam>
+    /// <typeparam name="TResult">The result type Core dispatches <paramref name="method"/> with.</typeparam>
+    /// <param name="method">The JSON-RPC method name, for example <see cref="RequestMethods.PromptsGet"/>.</param>
+    /// <returns>The mutable filter list for <paramref name="method"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="method"/> was already registered with a different parameter or result type.
+    /// </exception>
+    public IList<McpRequestInvocationFilter<TParams, ResultOrAlternate<TResult>>> GetOrAdd<TParams, TResult>(string method)
+        where TResult : Result
+    {
+        Throw.IfNullOrWhiteSpace(method);
+
+        if (_entries.TryGetValue(method, out var entry))
+        {
+            return Cast<TParams, TResult>(entry, method);
+        }
+
+        var filters = new List<McpRequestInvocationFilter<TParams, ResultOrAlternate<TResult>>>();
+        _entries[method] = new Entry(typeof(TParams), typeof(TResult), filters, () => filters.Count);
+        return filters;
+    }
+
+    /// <summary>
+    /// Replaces the filter list registered for <paramref name="method"/>.
+    /// </summary>
+    /// <typeparam name="TParams">The request parameter type Core dispatches <paramref name="method"/> with.</typeparam>
+    /// <typeparam name="TResult">The result type Core dispatches <paramref name="method"/> with.</typeparam>
+    /// <param name="method">The JSON-RPC method name.</param>
+    /// <param name="filters">The filter list to store.</param>
+    public void Set<TParams, TResult>(
+        string method,
+        IList<McpRequestInvocationFilter<TParams, ResultOrAlternate<TResult>>> filters)
+        where TResult : Result
+    {
+        Throw.IfNullOrWhiteSpace(method);
+        Throw.IfNull(filters);
+
+        _entries[method] = new Entry(typeof(TParams), typeof(TResult), filters, () => filters.Count);
+    }
+
+    /// <summary>
+    /// Gets the method names that currently have at least one registered filter.
+    /// </summary>
+    internal IEnumerable<string> NonEmptyMethods
+    {
+        get
+        {
+            foreach (var entry in _entries)
+            {
+                if (entry.Value.Count > 0)
+                {
+                    yield return entry.Key;
+                }
+            }
+        }
+    }
+
+    internal bool TryGetNonEmpty<TParams, TResult>(
+        string method,
+        [NotNullWhen(true)] out IList<McpRequestInvocationFilter<TParams, ResultOrAlternate<TResult>>>? filters)
+        where TResult : Result
+    {
+        if (_entries.TryGetValue(method, out var entry) && entry.Count > 0)
+        {
+            filters = Cast<TParams, TResult>(entry, method);
+            return true;
+        }
+
+        filters = null;
+        return false;
+    }
+
+    private static IList<McpRequestInvocationFilter<TParams, ResultOrAlternate<TResult>>> Cast<TParams, TResult>(
+        Entry entry,
+        string method)
+        where TResult : Result
+    {
+        if (entry.Filters is IList<McpRequestInvocationFilter<TParams, ResultOrAlternate<TResult>>> typed)
+        {
+            return typed;
+        }
+
+        throw new InvalidOperationException(
+            $"Alternate-result filters for method '{method}' were registered with " +
+            $"({entry.ParamsType}, {entry.ResultType}), but ({typeof(TParams)}, {typeof(TResult)}) was requested. " +
+            $"A method can only carry alternate-result filters for the types the server dispatches it with.");
+    }
+
+    private sealed class Entry(Type paramsType, Type resultType, object filters, Func<int> count)
+    {
+        public Type ParamsType { get; } = paramsType;
+
+        public Type ResultType { get; } = resultType;
+
+        public object Filters { get; } = filters;
+
+        public int Count => count();
+    }
+}

--- a/src/ModelContextProtocol.Core/Server/McpRequestFilters.cs
+++ b/src/ModelContextProtocol.Core/Server/McpRequestFilters.cs
@@ -67,6 +67,24 @@ public sealed class McpRequestFilters
     }
 
     /// <summary>
+    /// Gets the alternate-result filters registered for arbitrary JSON-RPC methods.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Alternate-result filters let an extension augment a Core-dispatched method so it can return an alternate
+    /// <see cref="Result"/> subtype (for example a task-creation result) in place of the method's normal result.
+    /// The collection is keyed by method name, so enabling a new method is an extension-only change rather than a
+    /// new <c>&lt;Method&gt;WithAlternateHandler</c>/<c>&lt;Method&gt;WithAlternateFilters</c> pair on Core.
+    /// </para>
+    /// <para>
+    /// <see cref="CallToolWithAlternateFilters"/> is a typed view over the <see cref="RequestMethods.ToolsCall"/>
+    /// entry of this collection, so the two stay in sync.
+    /// </para>
+    /// </remarks>
+    [Experimental(Experimentals.Extensibility_DiagnosticId, UrlFormat = Experimentals.Extensibility_Url)]
+    public AlternateResultFilterCollection AlternateResultFilters => field ??= new();
+
+    /// <summary>
     /// Gets or sets the filters for the call-tool handler pipeline with alternate result support.
     /// </summary>
     /// <remarks>
@@ -83,15 +101,19 @@ public sealed class McpRequestFilters
     /// Alternate-result filters run in registration order. If one filter dispatches the remainder of the pipeline
     /// asynchronously, filters registered after it execute as part of that asynchronous operation.
     /// </para>
+    /// <para>
+    /// This property is a view over the <see cref="RequestMethods.ToolsCall"/> entry of
+    /// <see cref="AlternateResultFilters"/>. Filters added through either API share one ordered list.
+    /// </para>
     /// </remarks>
     [Experimental(Experimentals.Extensibility_DiagnosticId, UrlFormat = Experimentals.Extensibility_Url)]
     public IList<McpRequestInvocationFilter<CallToolRequestParams, ResultOrAlternate<CallToolResult>>> CallToolWithAlternateFilters
     {
-        get => field ??= [];
+        get => AlternateResultFilters.GetOrAdd<CallToolRequestParams, CallToolResult>(RequestMethods.ToolsCall);
         set
         {
             Throw.IfNull(value);
-            field = value;
+            AlternateResultFilters.Set<CallToolRequestParams, CallToolResult>(RequestMethods.ToolsCall, value);
         }
     }
 #pragma warning restore MCPEXP002

--- a/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
@@ -49,6 +49,9 @@ internal sealed partial class McpServerImpl : McpServer
     private ClientCapabilities? _clientCapabilities;
     private Implementation? _clientInfo;
 
+    /// <summary>Methods whose alternate-result filters were actually wired into a dispatched handler.</summary>
+    private readonly HashSet<string> _alternateResultMethodsApplied = new(StringComparer.Ordinal);
+
     private readonly string _serverOnlyEndpointName;
     private string? _negotiatedProtocolVersion;
     private string _endpointName;
@@ -109,6 +112,7 @@ internal sealed partial class McpServerImpl : McpServer
         ConfigureExperimentalAndExtensions(options);
         ConfigureMrtr();
         ConfigureCustomRequestHandlers(options);
+        ValidateAlternateResultRegistrations(options);
 
         // Register any notification handlers that were provided.
         if (options.Handlers.NotificationHandlers is { } notificationHandlers)
@@ -973,7 +977,7 @@ internal sealed partial class McpServerImpl : McpServer
 
         ServerCapabilities.Completions = new();
 
-        SetHandler(
+        SetHandlerWithAlternateSupport(
             RequestMethods.CompletionComplete,
             completeHandler,
             McpJsonUtilities.JsonContext.Default.CompleteRequestParams,
@@ -1240,31 +1244,31 @@ internal sealed partial class McpServerImpl : McpServer
         ServerCapabilities.Resources.ListChanged = listChanged;
         ServerCapabilities.Resources.Subscribe = subscribe;
 
-        SetHandler(
+        SetHandlerWithAlternateSupport(
             RequestMethods.ResourcesList,
             listResourcesHandler,
             McpJsonUtilities.JsonContext.Default.ListResourcesRequestParams,
             McpJsonUtilities.JsonContext.Default.ListResourcesResult);
 
-        SetHandler(
+        SetHandlerWithAlternateSupport(
             RequestMethods.ResourcesTemplatesList,
             listResourceTemplatesHandler,
             McpJsonUtilities.JsonContext.Default.ListResourceTemplatesRequestParams,
             McpJsonUtilities.JsonContext.Default.ListResourceTemplatesResult);
 
-        SetHandler(
+        SetHandlerWithAlternateSupport(
             RequestMethods.ResourcesRead,
             readResourceHandler,
             McpJsonUtilities.JsonContext.Default.ReadResourceRequestParams,
             McpJsonUtilities.JsonContext.Default.ReadResourceResult);
 
-        SetHandler(
+        SetHandlerWithAlternateSupport(
             RequestMethods.ResourcesSubscribe,
             subscribeHandler,
             McpJsonUtilities.JsonContext.Default.SubscribeRequestParams,
             McpJsonUtilities.JsonContext.Default.EmptyResult);
 
-        SetHandler(
+        SetHandlerWithAlternateSupport(
             RequestMethods.ResourcesUnsubscribe,
             unsubscribeHandler,
             McpJsonUtilities.JsonContext.Default.UnsubscribeRequestParams,
@@ -1351,13 +1355,13 @@ internal sealed partial class McpServerImpl : McpServer
 
         ServerCapabilities.Prompts.ListChanged = listChanged;
 
-        SetHandler(
+        SetHandlerWithAlternateSupport(
             RequestMethods.PromptsList,
             listPromptsHandler,
             McpJsonUtilities.JsonContext.Default.ListPromptsRequestParams,
             McpJsonUtilities.JsonContext.Default.ListPromptsResult);
 
-        SetHandler(
+        SetHandlerWithAlternateSupport(
             RequestMethods.PromptsGet,
             getPromptHandler,
             McpJsonUtilities.JsonContext.Default.GetPromptRequestParams,
@@ -1487,12 +1491,13 @@ internal sealed partial class McpServerImpl : McpServer
         }
         ServerCapabilities.Tools.ListChanged = listChanged;
 
-        SetHandler(
+        SetHandlerWithAlternateSupport(
             RequestMethods.ToolsList,
             listToolsHandler,
             McpJsonUtilities.JsonContext.Default.ListToolsRequestParams,
             McpJsonUtilities.JsonContext.Default.ListToolsResult);
 
+        _alternateResultMethodsApplied.Add(RequestMethods.ToolsCall);
         SetWithAlternateHandler(
             RequestMethods.ToolsCall,
             callToolWithAlternateHandler,
@@ -1761,30 +1766,7 @@ internal sealed partial class McpServerImpl : McpServer
         JsonTypeInfo<TParams> requestTypeInfo,
         JsonTypeInfo<TResult> responseTypeInfo)
     {
-        // SEP-2549: results that carry caching hints (tools/list, prompts/list, resources/list,
-        // resources/templates/list, and resources/read) declare ttlMs and cacheScope as required fields.
-        // When a handler leaves them unset, fill in conservative defaults (immediately stale and not
-        // shareable) so the wire form always carries the fields while preserving today's "don't cache"
-        // behavior. Any value supplied by the handler or a filter is left untouched.
-        if (typeof(ICacheableResult).IsAssignableFrom(typeof(TResult)))
-        {
-            var innerHandler = handler;
-            handler = async (request, cancellationToken) =>
-            {
-                var result = await innerHandler(request, cancellationToken).ConfigureAwait(false);
-
-                // ttlMs and cacheScope are 2026-07-28 result fields; only stamp them when the request
-                // was negotiated under that revision or later. Earlier revisions (e.g. 2025-11-25) reject
-                // these as unrecognized keys (issue #1721).
-                if (result is ICacheableResult cacheable && IsJuly2026OrLaterProtocolRequest(request.JsonRpcRequest))
-                {
-                    cacheable.TimeToLive ??= TimeSpan.Zero;
-                    cacheable.CacheScope ??= CacheScope.Private;
-                }
-
-                return result;
-            };
-        }
+        handler = WrapWithCacheableDefaults(handler);
 
         if (typeof(Result).IsAssignableFrom(typeof(TResult)))
         {
@@ -1810,6 +1792,94 @@ internal sealed partial class McpServerImpl : McpServer
             (request, jsonRpcRequest, cancellationToken) =>
                 InvokeHandlerAsync(handler, request, jsonRpcRequest, cancellationToken),
             requestTypeInfo, responseTypeInfo);
+    }
+
+    /// <summary>
+    /// Registers a built-in typed handler, routing it through the method-keyed alternate-result pipeline
+    /// when <see cref="McpServerOptions.AddAlternateResultFilter{TParams, TResult}"/> registered filters for
+    /// <paramref name="method"/>.
+    /// </summary>
+    /// <remarks>
+    /// Only adaptation and filter composition are generalized here. Per-method policy such as primitive
+    /// matching and lifecycle logging stays with the method that needs it; <c>tools/call</c> keeps its own
+    /// composition in <see cref="BuildComposedCallToolHandler"/>.
+    /// </remarks>
+#pragma warning disable MCPEXP002 // consumes the experimental alternate-result seam
+    private void SetHandlerWithAlternateSupport<TParams, TResult>(
+        string method,
+        McpRequestHandler<TParams, TResult> handler,
+        JsonTypeInfo<TParams> requestTypeInfo,
+        JsonTypeInfo<TResult> responseTypeInfo)
+        where TResult : Result
+    {
+        if (!ServerOptions.Filters.Request.AlternateResultFilters.TryGetNonEmpty<TParams, TResult>(method, out var filters))
+        {
+            SetHandler(method, handler, requestTypeInfo, responseTypeInfo);
+            return;
+        }
+
+        _alternateResultMethodsApplied.Add(method);
+
+        var ordinaryHandler = WrapWithCacheableDefaults(handler);
+        McpRequestHandler<TParams, ResultOrAlternate<TResult>> adapted = async (request, cancellationToken) =>
+            await ordinaryHandler(request, cancellationToken).ConfigureAwait(false);
+
+        SetWithAlternateHandler(
+            method,
+            BuildInvocationFilterPipeline(adapted, filters),
+            requestTypeInfo,
+            responseTypeInfo);
+    }
+
+    /// <summary>
+    /// Throws when alternate-result filters were registered for a method the server never dispatches, so a
+    /// typo or a missing capability surfaces at construction instead of silently dropping the filters.
+    /// </summary>
+    private void ValidateAlternateResultRegistrations(McpServerOptions options)
+    {
+        foreach (var method in options.Filters.Request.AlternateResultFilters.NonEmptyMethods)
+        {
+            if (!_alternateResultMethodsApplied.Contains(method))
+            {
+                throw new InvalidOperationException(
+                    $"Alternate-result filters were registered for method '{method}', but this server does not " +
+                    $"dispatch that method. Register them for a method the server handles, or configure the " +
+                    $"capability that provides it.");
+            }
+        }
+    }
+#pragma warning restore MCPEXP002
+
+    /// <summary>
+    /// SEP-2549: results that carry caching hints (tools/list, prompts/list, resources/list,
+    /// resources/templates/list, and resources/read) declare ttlMs and cacheScope as required fields.
+    /// When a handler leaves them unset, fill in conservative defaults (immediately stale and not
+    /// shareable) so the wire form always carries the fields while preserving today's "don't cache"
+    /// behavior. Any value supplied by the handler or a filter is left untouched.
+    /// </summary>
+    private McpRequestHandler<TParams, TResult> WrapWithCacheableDefaults<TParams, TResult>(
+        McpRequestHandler<TParams, TResult> handler)
+    {
+        if (!typeof(ICacheableResult).IsAssignableFrom(typeof(TResult)))
+        {
+            return handler;
+        }
+
+        return async (request, cancellationToken) =>
+        {
+            var result = await handler(request, cancellationToken).ConfigureAwait(false);
+
+            // ttlMs and cacheScope are 2026-07-28 result fields; only stamp them when the request
+            // was negotiated under that revision or later. Earlier revisions (e.g. 2025-11-25) reject
+            // these as unrecognized keys (issue #1721).
+            if (result is ICacheableResult cacheable && IsJuly2026OrLaterProtocolRequest(request.JsonRpcRequest))
+            {
+                cacheable.TimeToLive ??= TimeSpan.Zero;
+                cacheable.CacheScope ??= CacheScope.Private;
+            }
+
+            return result;
+        };
     }
 
 #pragma warning disable MCPEXP002 // SetWithAlternateHandler wraps the experimental ResultOrAlternate seam

--- a/src/ModelContextProtocol.Core/Server/McpServerOptions.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerOptions.cs
@@ -220,4 +220,40 @@ public sealed class McpServerOptions
     /// </remarks>
     [Experimental(Experimentals.Extensibility_DiagnosticId, UrlFormat = Experimentals.Extensibility_Url)]
     public IList<McpServerRequestHandler>? RequestHandlers { get; set; }
+
+    /// <summary>
+    /// Registers a filter that can replace the result of a Core-dispatched method with an alternate
+    /// <see cref="Result"/> subtype.
+    /// </summary>
+    /// <typeparam name="TParams">The request parameter type the server dispatches <paramref name="method"/> with.</typeparam>
+    /// <typeparam name="TResult">The result type the server dispatches <paramref name="method"/> with.</typeparam>
+    /// <param name="method">The JSON-RPC method to augment, for example <see cref="RequestMethods.PromptsGet"/>.</param>
+    /// <param name="filter">The filter to append to the method's alternate-result pipeline.</param>
+    /// <remarks>
+    /// <para>
+    /// Unlike <see cref="McpServerHandlers.CallToolWithAlternateHandler"/>, this seam is method-agnostic:
+    /// enabling alternate results for another method is a call to this method rather than a new pair of
+    /// Core APIs. Filters run outside the method's ordinary filter pipeline, in registration order, and
+    /// receive a handler that produces the method's normal result.
+    /// </para>
+    /// <para>
+    /// Registering a filter for a method the server does not dispatch (for example because the corresponding
+    /// capability is not configured) throws when the server is constructed, so a typo or a missing capability
+    /// fails loudly instead of silently dropping the filter.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="method"/> already carries alternate-result filters registered with different types.
+    /// </exception>
+    [Experimental(Experimentals.Extensibility_DiagnosticId, UrlFormat = Experimentals.Extensibility_Url)]
+    public void AddAlternateResultFilter<TParams, TResult>(
+        string method,
+        McpRequestInvocationFilter<TParams, ResultOrAlternate<TResult>> filter)
+        where TResult : Result
+    {
+        Throw.IfNullOrWhiteSpace(method);
+        Throw.IfNull(filter);
+
+        Filters.Request.AlternateResultFilters.GetOrAdd<TParams, TResult>(method).Add(filter);
+    }
 }

--- a/tests/ModelContextProtocol.Tests/Server/AlternateResultFilterTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/AlternateResultFilterTests.cs
@@ -1,0 +1,206 @@
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Tests.Utils;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace ModelContextProtocol.Tests.Server;
+
+#pragma warning disable MCPEXP002 // exercises the experimental alternate-result seam
+
+/// <summary>
+/// An alternate result a filter can return in place of a prompt result, standing in for the kind of
+/// result a future task-enabled method would produce.
+/// </summary>
+internal sealed class AlternatePromptResult : Result
+{
+    [JsonPropertyName("note")]
+    public string? Note { get; set; }
+}
+
+[JsonSerializable(typeof(AlternatePromptResult))]
+internal sealed partial class AlternateResultJsonContext : JsonSerializerContext;
+
+/// <summary>
+/// Verifies that the alternate-result seam is method-keyed rather than <c>tools/call</c>-shaped, by
+/// driving it through <see cref="RequestMethods.PromptsGet"/> and <see cref="RequestMethods.PromptsList"/>.
+/// </summary>
+public class AlternateResultFilterPromptTests(ITestOutputHelper testOutputHelper) : ClientServerTestBase(testOutputHelper)
+{
+    private static readonly JsonSerializerOptions s_serializerOptions = CreateSerializerOptions();
+
+    private readonly List<string> _promptsListFilterOrder = [];
+
+    protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
+    {
+        mcpServerBuilder.Services.Configure<McpServerOptions>(options =>
+        {
+            options.Capabilities = new() { Prompts = new() };
+
+            options.Handlers.ListPromptsHandler = static (_, _) => new(new ListPromptsResult
+            {
+                Prompts = [new Prompt { Name = "ordinary-prompt" }],
+            });
+
+            options.Handlers.GetPromptHandler = static (request, _) => new(new GetPromptResult
+            {
+                Description = $"ordinary:{request.Params?.Name}",
+            });
+
+            options.AddAlternateResultFilter<GetPromptRequestParams, GetPromptResult>(
+                RequestMethods.PromptsGet,
+                async (request, next, cancellationToken) =>
+                {
+                    if (request.Params?.Name == "alternate-prompt")
+                    {
+                        return ResultOrAlternate<GetPromptResult>.FromAlternate(
+                            new AlternatePromptResult { Note = "replaced by filter" },
+                            AlternateResultJsonContext.Default.AlternatePromptResult);
+                    }
+
+                    return await next(request, cancellationToken);
+                });
+
+            options.AddAlternateResultFilter<ListPromptsRequestParams, ListPromptsResult>(
+                RequestMethods.PromptsList,
+                async (request, next, cancellationToken) =>
+                {
+                    _promptsListFilterOrder.Add("outer");
+                    return await next(request, cancellationToken);
+                });
+
+            options.AddAlternateResultFilter<ListPromptsRequestParams, ListPromptsResult>(
+                RequestMethods.PromptsList,
+                async (request, next, cancellationToken) =>
+                {
+                    _promptsListFilterOrder.Add("inner");
+                    return await next(request, cancellationToken);
+                });
+        });
+    }
+
+    [Fact]
+    public async Task PromptsGet_AlternateFilter_ReturnsAlternateResultShape()
+    {
+        await using var client = await CreateMcpClientForServer();
+
+        var result = await client.SendRequestAsync<GetPromptRequestParams, AlternatePromptResult>(
+            RequestMethods.PromptsGet,
+            new GetPromptRequestParams { Name = "alternate-prompt" },
+            serializerOptions: s_serializerOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("replaced by filter", result.Note);
+    }
+
+    [Fact]
+    public async Task PromptsGet_AlternateFilterDelegatingToNext_ReturnsOrdinaryResult()
+    {
+        await using var client = await CreateMcpClientForServer();
+
+        var result = await client.GetPromptAsync(
+            "ordinary-prompt",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("ordinary:ordinary-prompt", result.Description);
+    }
+
+    [Fact]
+    public async Task PromptsList_AlternateFilters_RunInRegistrationOrder()
+    {
+        await using var client = await CreateMcpClientForServer();
+
+        var prompts = await client.ListPromptsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("ordinary-prompt", Assert.Single(prompts).Name);
+        Assert.Equal(["outer", "inner"], _promptsListFilterOrder);
+    }
+
+    private static JsonSerializerOptions CreateSerializerOptions()
+    {
+        JsonSerializerOptions options = new(McpJsonUtilities.DefaultOptions)
+        {
+            TypeInfoResolver = JsonTypeInfoResolver.Combine(
+                AlternateResultJsonContext.Default,
+                McpJsonUtilities.DefaultOptions.TypeInfoResolver),
+        };
+
+        options.MakeReadOnly();
+        return options;
+    }
+}
+
+/// <summary>
+/// Covers registration semantics of the method-keyed alternate-result store, including the
+/// <c>tools/call</c> view and the errors raised for unusable registrations.
+/// </summary>
+public class AlternateResultFilterRegistrationTests(ITestOutputHelper testOutputHelper) : LoggedTest(testOutputHelper)
+{
+    private static McpRequestInvocationFilter<CallToolRequestParams, ResultOrAlternate<CallToolResult>> PassThroughToolFilter =>
+        static (context, next, cancellationToken) => next(context, cancellationToken);
+
+    [Fact]
+    public void CallToolWithAlternateFilters_IsViewOverToolsCallEntry()
+    {
+        var options = new McpServerOptions();
+
+        options.AddAlternateResultFilter(RequestMethods.ToolsCall, PassThroughToolFilter);
+
+        Assert.Same(
+            options.Filters.Request.AlternateResultFilters.GetOrAdd<CallToolRequestParams, CallToolResult>(RequestMethods.ToolsCall),
+            options.Filters.Request.CallToolWithAlternateFilters);
+        Assert.Single(options.Filters.Request.CallToolWithAlternateFilters);
+    }
+
+    [Fact]
+    public void GetOrAdd_WithMismatchedResultType_Throws()
+    {
+        var options = new McpServerOptions();
+        options.AddAlternateResultFilter<GetPromptRequestParams, GetPromptResult>(
+            RequestMethods.PromptsGet,
+            static (context, next, cancellationToken) => next(context, cancellationToken));
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => options.AddAlternateResultFilter<GetPromptRequestParams, ListPromptsResult>(
+                RequestMethods.PromptsGet,
+                static (context, next, cancellationToken) => next(context, cancellationToken)));
+
+        Assert.Contains(RequestMethods.PromptsGet, ex.Message);
+        Assert.Contains(nameof(GetPromptResult), ex.Message);
+    }
+
+    [Fact]
+    public async Task Filters_ForMethodTheServerDoesNotDispatch_ThrowActionableError()
+    {
+        await using var transport = new StreamServerTransport(Stream.Null, Stream.Null);
+        var options = new McpServerOptions { Capabilities = new() { Tools = new() } };
+
+        // No prompts capability is configured, so prompts/get is never registered.
+        options.AddAlternateResultFilter<GetPromptRequestParams, GetPromptResult>(
+            RequestMethods.PromptsGet,
+            static (context, next, cancellationToken) => next(context, cancellationToken));
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => McpServer.Create(transport, options, LoggerFactory));
+
+        Assert.Contains(RequestMethods.PromptsGet, ex.Message);
+        Assert.Contains("does not", ex.Message);
+    }
+
+    [Fact]
+    public async Task EmptyRegistration_ForUndispatchedMethod_DoesNotThrow()
+    {
+        await using var transport = new StreamServerTransport(Stream.Null, Stream.Null);
+        var options = new McpServerOptions { Capabilities = new() { Tools = new() } };
+
+        // Touching the tools/call view without adding filters must not trip the validation.
+        _ = options.Filters.Request.CallToolWithAlternateFilters;
+        _ = options.Filters.Request.AlternateResultFilters.GetOrAdd<GetPromptRequestParams, GetPromptResult>(RequestMethods.PromptsGet);
+
+        await using var server = McpServer.Create(transport, options, LoggerFactory);
+
+        Assert.NotNull(server);
+    }
+}


### PR DESCRIPTION
Closes part of #1704, specifically @jeffhandley's [method-agnostic point](https://github.com/modelcontextprotocol/csharp-sdk/issues/1704#issuecomment-4973957928). @PranavSenthilnathan asked to hold this until after 2.0.0 shipped, and v2.0.0 went out on 2026-07-28, so here it is.

## Problem

`CallToolWithAlternateFilters` is `tools/call`-shaped. Adding alternate-result support for a second method means a new `<Method>WithAlternateHandler`/`<Method>WithAlternateFilters` pair plus new Core wiring every time, which is the thing the original review feedback wanted to avoid.

## What this does

Adds a method-keyed store, `AlternateResultFilterCollection`, plus:

```csharp
options.AddAlternateResultFilter<GetPromptRequestParams, GetPromptResult>(
    RequestMethods.PromptsGet, filter);
```

`CallToolWithAlternateFilters` becomes a typed view over the `tools/call` entry of that same store. Filters added through either API land in one ordered list, so the Tasks extension and `AuthorizationFilterSetup` keep working untouched. Nothing in the existing shape changes.

Built-in typed handlers now go through `SetHandlerWithAlternateSupport`, which is a no-op unless filters were registered for that method. When they were, the ordinary handler is adapted to `ResultOrAlternate<TResult>` and the filters compose around it.

## The design call I had to make

In the issue I flagged that the lifecycle logging and primitive matching inside `BuildComposedCallToolHandler` are tool-specific, so generalizing means deciding how much of that becomes per-method policy.

I went with the narrow answer: the generic seam only does adaptation and filter composition. Primitive matching, `ToolCallCompleted`/`ToolCallError` logging, and `ComposedCallToolInvocationState` all stay in the `tools/call` path. A future task-enabled method brings its own policy rather than inheriting the tool one.

Happy to go the other way if you'd rather Core owned a shared lifecycle abstraction, but that felt like it would bake tool semantics into methods that don't want them.

One behavior addition worth calling out: registering filters for a method the server doesn't dispatch now throws at construction. Without that, a typo or a missing capability silently drops the filters, which is a rough thing to debug. Empty registrations don't trip it, so just reading `CallToolWithAlternateFilters` is still free.

## Tests

`tests/ModelContextProtocol.Tests/Server/AlternateResultFilterTests.cs`, driven through `prompts/get` and `prompts/list` rather than tools, to show it isn't tool-specific:

- a filter on `prompts/get` returns a different `Result` subtype and the client sees that shape on the wire
- the same filter delegating to `next` still returns the ordinary `GetPromptResult`
- two filters on `prompts/list` run in registration order
- `CallToolWithAlternateFilters` and `AddAlternateResultFilter(RequestMethods.ToolsCall, ...)` resolve to the same list instance
- registering one method with two different result types throws
- filters for an undispatched method throw at `McpServer.Create`, and an empty registration doesn't

I also broke it twice to check the tests actually hold: forcing `SetHandlerWithAlternateSupport` to always take the ordinary path, and disabling the registration validation. Both were caught.

Local run: 2243 passed, 0 failed on `ModelContextProtocol.Tests` (net10.0), skipping the integration classes that need external processes. The `Server` namespace alone is 579 passed.

<sub>Implemented with AI assistance.</sub>
