### PR TITLE
Add ASP.NET Core per-user MCP client sample

### DIFF
--- a/ModelContextProtocol.slnx
+++ b/ModelContextProtocol.slnx
@@ -40,6 +40,7 @@
     <Project Path="docs/concepts/progress/samples/server/Progress.csproj" />
   </Folder>
   <Folder Name="/samples/">
+    <Project Path="samples/AspNetCoreMcpClient/AspNetCoreMcpClient.csproj" />
     <Project Path="samples/AspNetCoreMcpPerSessionTools/AspNetCoreMcpPerSessionTools.csproj" />
     <Project Path="samples/AspNetCoreMcpServer/AspNetCoreMcpServer.csproj" />
     <Project Path="samples/ChatWithTools/ChatWithTools.csproj" />
@@ -73,6 +74,7 @@
     <Project Path="src/ModelContextProtocol/ModelContextProtocol.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/AspNetCoreMcpClient.Tests/AspNetCoreMcpClient.Tests.csproj" />
     <Project Path="tests/ModelContextProtocol.Analyzers.Tests/ModelContextProtocol.Analyzers.Tests.csproj" />
     <Project Path="tests/ModelContextProtocol.AotCompatibility.TestApp/ModelContextProtocol.AotCompatibility.TestApp.csproj" />
     <Project Path="tests/ModelContextProtocol.AspNetCore.Tests/ModelContextProtocol.AspNetCore.Tests.csproj" />

--- a/samples/AspNetCoreMcpClient/AspNetCoreMcpClient.csproj
+++ b/samples/AspNetCoreMcpClient/AspNetCoreMcpClient.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ModelContextProtocol.Core\ModelContextProtocol.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AspNetCoreMcpClient/ElicitationBroker.cs
+++ b/samples/AspNetCoreMcpClient/ElicitationBroker.cs
@@ -74,6 +74,26 @@ public sealed class ElicitationBroker
         }
     }
 
+    /// <summary>
+    /// Cancels every pending elicitation. Call this during application shutdown so that MCP operations blocked on an
+    /// unanswered elicitation unblock and the session registry can dispose its clients.
+    /// </summary>
+    public int CancelAll()
+    {
+        lock (_lock)
+        {
+            var pending = _pending.Values.ToArray();
+            _pending.Clear();
+
+            foreach (var request in pending)
+            {
+                request.Completion.TrySetCanceled();
+            }
+
+            return pending.Length;
+        }
+    }
+
     private sealed class PendingRequest(Guid id, ElicitRequestParams? request)
     {
         public Guid Id { get; } = id;

--- a/samples/AspNetCoreMcpClient/ElicitationBroker.cs
+++ b/samples/AspNetCoreMcpClient/ElicitationBroker.cs
@@ -1,0 +1,88 @@
+using ModelContextProtocol.Protocol;
+
+namespace AspNetCoreMcpClient;
+
+/// <summary>
+/// Bridges an MCP elicitation request to an application-owned HTTP interaction.
+/// </summary>
+public sealed class ElicitationBroker
+{
+    private readonly Dictionary<string, PendingRequest> _pending = new(StringComparer.Ordinal);
+    private readonly Lock _lock = new();
+
+    public async ValueTask<ElicitResult> RequestAsync(
+        string sessionId,
+        ElicitRequestParams? request,
+        CancellationToken cancellationToken)
+    {
+        var pending = new PendingRequest(Guid.NewGuid(), request);
+
+        lock (_lock)
+        {
+            if (!_pending.TryAdd(sessionId, pending))
+            {
+                throw new InvalidOperationException("Only one elicitation can be pending for an application session.");
+            }
+        }
+
+        try
+        {
+            return await pending.Completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                if (_pending.TryGetValue(sessionId, out var current) && ReferenceEquals(current, pending))
+                {
+                    _pending.Remove(sessionId);
+                }
+            }
+        }
+    }
+
+    public PendingElicitation? GetPending(string sessionId)
+    {
+        lock (_lock)
+        {
+            return _pending.TryGetValue(sessionId, out var pending)
+                ? new PendingElicitation(pending.Id, pending.Request)
+                : null;
+        }
+    }
+
+    public bool TryRespond(string sessionId, Guid requestId, ElicitResult response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        lock (_lock)
+        {
+            return _pending.TryGetValue(sessionId, out var pending) &&
+                pending.Id == requestId &&
+                pending.Completion.TrySetResult(response);
+        }
+    }
+
+    public void Cancel(string sessionId)
+    {
+        lock (_lock)
+        {
+            if (_pending.Remove(sessionId, out var pending))
+            {
+                pending.Completion.TrySetCanceled();
+            }
+        }
+    }
+
+    private sealed class PendingRequest(Guid id, ElicitRequestParams? request)
+    {
+        public Guid Id { get; } = id;
+
+        public ElicitRequestParams? Request { get; } = request;
+
+        public TaskCompletionSource<ElicitResult> Completion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}
+
+public sealed record PendingElicitation(Guid Id, ElicitRequestParams? Request);

--- a/samples/AspNetCoreMcpClient/InlineProgress.cs
+++ b/samples/AspNetCoreMcpClient/InlineProgress.cs
@@ -1,0 +1,6 @@
+namespace AspNetCoreMcpClient;
+
+public sealed class InlineProgress<T>(Action<T> report) : IProgress<T>
+{
+    public void Report(T value) => report(value);
+}

--- a/samples/AspNetCoreMcpClient/McpClientCleanupService.cs
+++ b/samples/AspNetCoreMcpClient/McpClientCleanupService.cs
@@ -1,0 +1,22 @@
+namespace AspNetCoreMcpClient;
+
+public sealed class McpClientCleanupService(
+    SessionClientRegistry<McpClientConnection> registry,
+    IConfiguration configuration,
+    ILogger<McpClientCleanupService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = TimeSpan.FromMinutes(configuration.GetValue("McpServer:CleanupIntervalMinutes", 1));
+        using var timer = new PeriodicTimer(interval);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+        {
+            var removed = await registry.RemoveIdleAsync().ConfigureAwait(false);
+            if (removed > 0)
+            {
+                logger.LogInformation("Disposed {Count} idle MCP client sessions.", removed);
+            }
+        }
+    }
+}

--- a/samples/AspNetCoreMcpClient/McpClientConnection.cs
+++ b/samples/AspNetCoreMcpClient/McpClientConnection.cs
@@ -1,0 +1,20 @@
+using ModelContextProtocol.Client;
+
+namespace AspNetCoreMcpClient;
+
+public sealed class McpClientConnection(McpClient client, HttpClientTransport transport) : IAsyncDisposable
+{
+    public McpClient Client { get; } = client;
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await Client.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            await transport.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/samples/AspNetCoreMcpClient/Program.cs
+++ b/samples/AspNetCoreMcpClient/Program.cs
@@ -2,6 +2,7 @@ using AspNetCoreMcpClient;
 using ModelContextProtocol;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
+using System.Collections.Concurrent;
 using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -63,6 +64,18 @@ builder.Services.AddHostedService<McpClientCleanupService>();
 
 var app = builder.Build();
 
+// Disposing the registry waits for each session's in-flight operation to finish. A tool call blocked on an unanswered
+// elicitation would never finish, so release those requests before shutdown disposes the singleton registry.
+app.Lifetime.ApplicationStopping.Register(() =>
+{
+    var broker = app.Services.GetRequiredService<ElicitationBroker>();
+    var canceled = broker.CancelAll();
+    if (canceled > 0)
+    {
+        app.Logger.LogInformation("Canceled {Count} pending elicitations during shutdown.", canceled);
+    }
+});
+
 app.MapGet("/tools", async (
     HttpContext context,
     SessionClientRegistry<McpClientConnection> registry,
@@ -89,8 +102,9 @@ app.MapPost("/tools/{toolName}", async (
         ? arguments.Value.Deserialize<Dictionary<string, object?>>()
         : null;
 
-    var progressUpdates = new List<ProgressNotificationValue>();
-    var progress = new InlineProgress<ProgressNotificationValue>(value => progressUpdates.Add(value));
+    // Progress notifications arrive on the MCP session's message loop, so use a thread-safe collection.
+    var progressUpdates = new ConcurrentQueue<ProgressNotificationValue>();
+    var progress = new InlineProgress<ProgressNotificationValue>(progressUpdates.Enqueue);
     var result = await registry.ExecuteAsync(
         sessionId,
         async (connection, token) => await connection.Client.CallToolAsync(

--- a/samples/AspNetCoreMcpClient/Program.cs
+++ b/samples/AspNetCoreMcpClient/Program.cs
@@ -1,0 +1,146 @@
+using AspNetCoreMcpClient;
+using ModelContextProtocol;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using System.Text.Json;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var endpoint = new Uri(builder.Configuration["McpServer:Endpoint"] ?? "http://localhost:3001");
+var idleTimeout = TimeSpan.FromMinutes(builder.Configuration.GetValue("McpServer:IdleTimeoutMinutes", 20));
+
+builder.Services.AddHttpClient("mcp-server");
+builder.Services.AddSingleton<ElicitationBroker>();
+builder.Services.AddSingleton(serviceProvider =>
+{
+    var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+    var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+    var elicitationBroker = serviceProvider.GetRequiredService<ElicitationBroker>();
+
+    return new SessionClientRegistry<McpClientConnection>(
+        async (sessionId, cancellationToken) =>
+        {
+            var httpClient = httpClientFactory.CreateClient("mcp-server");
+            var transport = new HttpClientTransport(
+                new()
+                {
+                    Endpoint = endpoint,
+                    Name = $"ASP.NET Core session {sessionId}",
+                    TransportMode = HttpTransportMode.StreamableHttp,
+                },
+                httpClient,
+                loggerFactory,
+                ownsHttpClient: true);
+
+            try
+            {
+                var client = await McpClient.CreateAsync(
+                    transport,
+                    new()
+                    {
+                        ClientInfo = new() { Name = "AspNetCoreMcpClient", Version = "1.0.0" },
+                        Handlers = new()
+                        {
+                            ElicitationHandler = (request, token) =>
+                                elicitationBroker.RequestAsync(sessionId, request, token),
+                        },
+                    },
+                    loggerFactory,
+                    cancellationToken);
+
+                return new McpClientConnection(client, transport);
+            }
+            catch
+            {
+                await transport.DisposeAsync();
+                throw;
+            }
+        },
+        TimeProvider.System,
+        idleTimeout);
+});
+builder.Services.AddHostedService<McpClientCleanupService>();
+
+var app = builder.Build();
+
+app.MapGet("/tools", async (
+    HttpContext context,
+    SessionClientRegistry<McpClientConnection> registry,
+    CancellationToken cancellationToken) =>
+{
+    var sessionId = GetDemoSessionId(context);
+    var tools = await registry.ExecuteAsync(
+        sessionId,
+        async (connection, token) => await connection.Client.ListToolsAsync(cancellationToken: token),
+        cancellationToken);
+
+    return tools.Select(tool => new { tool.Name, tool.Description });
+});
+
+app.MapPost("/tools/{toolName}", async (
+    string toolName,
+    JsonElement? arguments,
+    HttpContext context,
+    SessionClientRegistry<McpClientConnection> registry,
+    CancellationToken cancellationToken) =>
+{
+    var sessionId = GetDemoSessionId(context);
+    var toolArguments = arguments is { ValueKind: JsonValueKind.Object }
+        ? arguments.Value.Deserialize<Dictionary<string, object?>>()
+        : null;
+
+    var progressUpdates = new List<ProgressNotificationValue>();
+    var progress = new InlineProgress<ProgressNotificationValue>(value => progressUpdates.Add(value));
+    var result = await registry.ExecuteAsync(
+        sessionId,
+        async (connection, token) => await connection.Client.CallToolAsync(
+            toolName,
+            toolArguments,
+            progress,
+            cancellationToken: token),
+        cancellationToken);
+
+    return Results.Ok(new { Result = result, Progress = progressUpdates });
+});
+
+app.MapGet("/elicitation", (HttpContext context, ElicitationBroker broker) =>
+{
+    var pending = broker.GetPending(GetDemoSessionId(context));
+    return pending is null ? Results.NoContent() : Results.Ok(pending);
+});
+
+app.MapPost("/elicitation/{requestId:guid}", (
+    Guid requestId,
+    ElicitResult response,
+    HttpContext context,
+    ElicitationBroker broker) =>
+{
+    return broker.TryRespond(GetDemoSessionId(context), requestId, response)
+        ? Results.Accepted()
+        : Results.NotFound();
+});
+
+app.MapDelete("/session", async (
+    HttpContext context,
+    SessionClientRegistry<McpClientConnection> registry,
+    ElicitationBroker broker) =>
+{
+    var sessionId = GetDemoSessionId(context);
+    broker.Cancel(sessionId);
+    return await registry.RemoveAsync(sessionId) ? Results.NoContent() : Results.NotFound();
+});
+
+app.Run();
+
+static string GetDemoSessionId(HttpContext context)
+{
+    const string HeaderName = "X-Demo-User";
+    var sessionId = context.Request.Headers[HeaderName].ToString();
+    if (string.IsNullOrWhiteSpace(sessionId) || sessionId.Length > 128)
+    {
+        throw new BadHttpRequestException($"Provide a non-empty {HeaderName} header of at most 128 characters.");
+    }
+
+    // A production application should derive this key from authenticated server-side identity/session state.
+    return sessionId;
+}

--- a/samples/AspNetCoreMcpClient/README.md
+++ b/samples/AspNetCoreMcpClient/README.md
@@ -1,0 +1,57 @@
+# ASP.NET Core MCP client with per-user sessions
+
+This sample shows an ASP.NET Core Web API acting as an MCP client while keeping one MCP connection per application user session. It is intended for applications that need session continuity for server-to-client features such as elicitation and progress notifications.
+
+The sample deliberately separates the **application session** from the MCP protocol session. `SessionClientRegistry<TClient>` owns the mapping and provides:
+
+- lazy, single initialization of a client for each application session;
+- serialization of operations within one session while allowing different sessions to run concurrently;
+- explicit session removal and deterministic asynchronous disposal;
+- automatic removal of idle sessions; and
+- cleanup of every remaining client during application shutdown.
+
+## Run the sample
+
+Start an HTTP MCP server, such as `AspNetCoreMcpServer`, then run this project:
+
+```bash
+dotnet run --project samples/AspNetCoreMcpServer
+dotnet run --project samples/AspNetCoreMcpClient
+```
+
+The default MCP endpoint is `http://localhost:3001`. Change `McpServer:Endpoint` in `appsettings.json` when needed.
+
+The HTTP examples use `X-Demo-User` solely to make session reuse visible without adding an authentication system:
+
+```bash
+curl -H "X-Demo-User: alice" http://localhost:5000/tools
+
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-Demo-User: alice" \
+  -d '{"message":"hello"}' \
+  http://localhost:5000/tools/echo
+
+curl -X DELETE -H "X-Demo-User: alice" http://localhost:5000/session
+```
+
+Use the URL printed by `dotnet run` if it differs from port 5000.
+
+## Elicitation flow
+
+When the MCP server sends an elicitation request during a tool call, `ElicitationBroker` holds that request while the application's frontend collects an answer:
+
+1. The frontend polls `GET /elicitation` with the same application-session identity.
+2. A `200` response contains the pending request and its ID; `204` means there is no pending request.
+3. The frontend posts an `ElicitResult` to `POST /elicitation/{requestId}`.
+4. The original tool call resumes and returns its response.
+
+The broker intentionally permits one pending elicitation per application session because the registry serializes that session's MCP operations.
+
+## Production considerations
+
+- **Never trust a caller-provided session header.** Replace `X-Demo-User` with a key derived from authenticated, server-side identity or session state. Do not use access tokens or other secrets as dictionary keys.
+- The registry is in-memory and therefore single-node. For multiple application instances, use sticky routing so one user's requests reach the owning process, or implement distributed ownership and session resumption. A distributed cache alone cannot store a live `McpClient` connection.
+- Choose an idle timeout that fits both application behavior and upstream resource limits. Explicitly remove the session at logout when possible.
+- Operations are serialized per user to protect application-level session state. If your use case permits concurrent MCP requests, adjust the registry policy rather than creating duplicate clients.
+- The sample collects progress updates for a compact response. A real frontend would normally stream them with Server-Sent Events, WebSockets, or another application channel.

--- a/samples/AspNetCoreMcpClient/README.md
+++ b/samples/AspNetCoreMcpClient/README.md
@@ -48,6 +48,8 @@ When the MCP server sends an elicitation request during a tool call, `Elicitatio
 
 The broker intentionally permits one pending elicitation per application session because the registry serializes that session's MCP operations.
 
+Because the registry waits for a session's in-flight operation before disposing its client, a tool call blocked on an unanswered elicitation would otherwise stall `DELETE /session` and application shutdown. `DELETE /session` cancels the session's pending elicitation first, and the sample registers an `ApplicationStopping` callback that cancels all pending elicitations before the registry is disposed.
+
 ## Production considerations
 
 - **Never trust a caller-provided session header.** Replace `X-Demo-User` with a key derived from authenticated, server-side identity or session state. Do not use access tokens or other secrets as dictionary keys.

--- a/samples/AspNetCoreMcpClient/SessionClientRegistry.cs
+++ b/samples/AspNetCoreMcpClient/SessionClientRegistry.cs
@@ -1,0 +1,196 @@
+using System.Collections.Concurrent;
+
+namespace AspNetCoreMcpClient;
+
+/// <summary>
+/// Owns one asynchronously disposable client per application session and serializes operations within each session.
+/// </summary>
+/// <typeparam name="TClient">The client type stored for each session.</typeparam>
+public sealed class SessionClientRegistry<TClient> : IAsyncDisposable
+    where TClient : IAsyncDisposable
+{
+    private readonly ConcurrentDictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+    private readonly Func<string, CancellationToken, Task<TClient>> _clientFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _idleTimeout;
+    private int _disposed;
+
+    public SessionClientRegistry(
+        Func<string, CancellationToken, Task<TClient>> clientFactory,
+        TimeProvider timeProvider,
+        TimeSpan idleTimeout)
+    {
+        ArgumentNullException.ThrowIfNull(clientFactory);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(idleTimeout, TimeSpan.Zero);
+
+        _clientFactory = clientFactory;
+        _timeProvider = timeProvider;
+        _idleTimeout = idleTimeout;
+    }
+
+    /// <summary>
+    /// Runs an operation against the session's client. Operations for different sessions can run concurrently, while
+    /// operations for the same session are serialized.
+    /// </summary>
+    public async Task<TResult> ExecuteAsync<TResult>(
+        string sessionId,
+        Func<TClient, CancellationToken, ValueTask<TResult>> operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentNullException.ThrowIfNull(operation);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+        while (true)
+        {
+            var entry = _entries.GetOrAdd(sessionId, _ => new Entry(_timeProvider.GetUtcNow()));
+            await entry.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                if (entry.Removed)
+                {
+                    continue;
+                }
+
+                if (Volatile.Read(ref _disposed) != 0)
+                {
+                    RemoveExact(sessionId, entry);
+                    entry.Removed = true;
+                    throw new ObjectDisposedException(GetType().FullName);
+                }
+
+                if (entry.Client is null)
+                {
+                    try
+                    {
+                        entry.Client = await _clientFactory(sessionId, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        RemoveExact(sessionId, entry);
+                        entry.Removed = true;
+                        throw;
+                    }
+                }
+
+                entry.LastAccess = _timeProvider.GetUtcNow();
+                try
+                {
+                    return await operation(entry.Client, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    entry.LastAccess = _timeProvider.GetUtcNow();
+                }
+            }
+            finally
+            {
+                entry.Gate.Release();
+            }
+        }
+    }
+
+    /// <summary>Removes and disposes a session client, if one exists.</summary>
+    public async Task<bool> RemoveAsync(string sessionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+
+        if (!_entries.TryGetValue(sessionId, out var entry) || !RemoveExact(sessionId, entry))
+        {
+            return false;
+        }
+
+        await DisposeEntryAsync(entry).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>Removes clients that have not been used within the configured idle timeout.</summary>
+    public async Task<int> RemoveIdleAsync()
+    {
+        var removed = 0;
+        var now = _timeProvider.GetUtcNow();
+
+        foreach (var pair in _entries)
+        {
+            var entry = pair.Value;
+            if (!await entry.Gate.WaitAsync(0).ConfigureAwait(false))
+            {
+                continue;
+            }
+
+            try
+            {
+                if (!entry.Removed && now - entry.LastAccess >= _idleTimeout && RemoveExact(pair.Key, entry))
+                {
+                    entry.Removed = true;
+                    if (entry.Client is not null)
+                    {
+                        await entry.Client.DisposeAsync().ConfigureAwait(false);
+                        entry.Client = default;
+                    }
+
+                    removed++;
+                }
+            }
+            finally
+            {
+                entry.Gate.Release();
+            }
+        }
+
+        return removed;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        while (!_entries.IsEmpty)
+        {
+            foreach (var pair in _entries)
+            {
+                if (RemoveExact(pair.Key, pair.Value))
+                {
+                    await DisposeEntryAsync(pair.Value).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    private bool RemoveExact(string sessionId, Entry entry) =>
+        ((ICollection<KeyValuePair<string, Entry>>)_entries).Remove(new(sessionId, entry));
+
+    private static async Task DisposeEntryAsync(Entry entry)
+    {
+        await entry.Gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            entry.Removed = true;
+            if (entry.Client is not null)
+            {
+                await entry.Client.DisposeAsync().ConfigureAwait(false);
+                entry.Client = default;
+            }
+        }
+        finally
+        {
+            entry.Gate.Release();
+        }
+    }
+
+    private sealed class Entry(DateTimeOffset lastAccess)
+    {
+        public SemaphoreSlim Gate { get; } = new(1, 1);
+
+        public TClient? Client { get; set; }
+
+        public DateTimeOffset LastAccess { get; set; } = lastAccess;
+
+        public bool Removed { get; set; }
+    }
+}

--- a/samples/AspNetCoreMcpClient/appsettings.json
+++ b/samples/AspNetCoreMcpClient/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "McpServer": {
+    "Endpoint": "http://localhost:3001",
+    "IdleTimeoutMinutes": 20,
+    "CleanupIntervalMinutes": 1
+  }
+}

--- a/tests/AspNetCoreMcpClient.Tests/AspNetCoreMcpClient.Tests.csproj
+++ b/tests/AspNetCoreMcpClient.Tests/AspNetCoreMcpClient.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\samples\AspNetCoreMcpClient\AspNetCoreMcpClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AspNetCoreMcpClient.Tests/ElicitationBrokerTests.cs
+++ b/tests/AspNetCoreMcpClient.Tests/ElicitationBrokerTests.cs
@@ -1,0 +1,36 @@
+using AspNetCoreMcpClient;
+using ModelContextProtocol.Protocol;
+
+namespace AspNetCoreMcpClient.Tests;
+
+public class ElicitationBrokerTests
+{
+    [Fact]
+    public async Task Response_CompletesMatchingPendingRequest()
+    {
+        var broker = new ElicitationBroker();
+        var requestTask = broker.RequestAsync("alice", new() { Message = "Choose" }, TestContext.Current.CancellationToken).AsTask();
+        var pending = broker.GetPending("alice");
+
+        Assert.NotNull(pending);
+        var expected = new ElicitResult { Action = "accept" };
+        Assert.True(broker.TryRespond("alice", pending.Id, expected));
+
+        Assert.Same(expected, await requestTask);
+        Assert.Null(broker.GetPending("alice"));
+    }
+
+    [Fact]
+    public async Task Cancellation_RemovesPendingRequest()
+    {
+        var broker = new ElicitationBroker();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var requestTask = broker.RequestAsync("alice", new() { Message = "Choose" }, cts.Token).AsTask();
+
+        Assert.NotNull(broker.GetPending("alice"));
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
+        Assert.Null(broker.GetPending("alice"));
+    }
+}

--- a/tests/AspNetCoreMcpClient.Tests/ElicitationBrokerTests.cs
+++ b/tests/AspNetCoreMcpClient.Tests/ElicitationBrokerTests.cs
@@ -33,4 +33,20 @@ public class ElicitationBrokerTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
         Assert.Null(broker.GetPending("alice"));
     }
+
+    [Fact]
+    public async Task CancelAll_ReleasesEveryPendingRequest()
+    {
+        var broker = new ElicitationBroker();
+        var alice = broker.RequestAsync("alice", new() { Message = "Choose" }, TestContext.Current.CancellationToken).AsTask();
+        var bob = broker.RequestAsync("bob", new() { Message = "Choose" }, TestContext.Current.CancellationToken).AsTask();
+
+        Assert.Equal(2, broker.CancelAll());
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => alice);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => bob);
+        Assert.Null(broker.GetPending("alice"));
+        Assert.Null(broker.GetPending("bob"));
+        Assert.Equal(0, broker.CancelAll());
+    }
 }

--- a/tests/AspNetCoreMcpClient.Tests/GlobalUsings.cs
+++ b/tests/AspNetCoreMcpClient.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/AspNetCoreMcpClient.Tests/SessionClientRegistryTests.cs
+++ b/tests/AspNetCoreMcpClient.Tests/SessionClientRegistryTests.cs
@@ -1,0 +1,111 @@
+using AspNetCoreMcpClient;
+using Microsoft.Extensions.Time.Testing;
+
+namespace AspNetCoreMcpClient.Tests;
+
+public class SessionClientRegistryTests
+{
+    [Fact]
+    public async Task ConcurrentOperationsForOneSession_CreateOneClientAndDoNotOverlap()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var factoryCalls = 0;
+        var concurrentOperations = 0;
+        var maximumConcurrency = 0;
+        var releaseFirstOperation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstOperationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var registry = new SessionClientRegistry<FakeClient>(
+            (_, _) => Task.FromResult(new FakeClient(Interlocked.Increment(ref factoryCalls))),
+            TimeProvider.System,
+            TimeSpan.FromMinutes(5));
+
+        async ValueTask<int> Operation(FakeClient client, CancellationToken _)
+        {
+            var current = Interlocked.Increment(ref concurrentOperations);
+            maximumConcurrency = Math.Max(maximumConcurrency, current);
+            firstOperationStarted.TrySetResult();
+            await releaseFirstOperation.Task.WaitAsync(cancellationToken);
+            Interlocked.Decrement(ref concurrentOperations);
+            return client.Id;
+        }
+
+        var first = registry.ExecuteAsync("alice", Operation, cancellationToken);
+        await firstOperationStarted.Task.WaitAsync(cancellationToken);
+        var second = registry.ExecuteAsync("alice", Operation, cancellationToken);
+        releaseFirstOperation.SetResult();
+
+        var results = await Task.WhenAll(first, second);
+
+        Assert.Equal([1, 1], results);
+        Assert.Equal(1, factoryCalls);
+        Assert.Equal(1, maximumConcurrency);
+    }
+
+    [Fact]
+    public async Task DifferentSessions_CanRunConcurrently()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var concurrentOperations = 0;
+        var bothStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var registry = new SessionClientRegistry<FakeClient>(
+            (_, _) => Task.FromResult(new FakeClient(1)),
+            TimeProvider.System,
+            TimeSpan.FromMinutes(5));
+
+        async ValueTask<int> Operation(FakeClient _, CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref concurrentOperations) == 2)
+            {
+                bothStarted.SetResult();
+            }
+
+            await bothStarted.Task.WaitAsync(cancellationToken);
+            Interlocked.Decrement(ref concurrentOperations);
+            return 1;
+        }
+
+        await Task.WhenAll(
+            registry.ExecuteAsync("alice", Operation, cancellationToken),
+            registry.ExecuteAsync("bob", Operation, cancellationToken));
+    }
+
+    [Fact]
+    public async Task RemoveAndIdleCleanup_DisposeClients()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var timeProvider = new FakeTimeProvider();
+        var clients = new List<FakeClient>();
+        await using var registry = new SessionClientRegistry<FakeClient>(
+            (_, _) =>
+            {
+                var client = new FakeClient(clients.Count + 1);
+                clients.Add(client);
+                return Task.FromResult(client);
+            },
+            timeProvider,
+            TimeSpan.FromMinutes(5));
+
+        await registry.ExecuteAsync("explicit", static (client, _) => ValueTask.FromResult(client.Id), cancellationToken);
+        await registry.ExecuteAsync("idle", static (client, _) => ValueTask.FromResult(client.Id), cancellationToken);
+
+        Assert.True(await registry.RemoveAsync("explicit"));
+        timeProvider.Advance(TimeSpan.FromMinutes(6));
+        Assert.Equal(1, await registry.RemoveIdleAsync());
+        Assert.All(clients, client => Assert.True(client.IsDisposed));
+    }
+
+    private sealed class FakeClient(int id) : IAsyncDisposable
+    {
+        public int Id { get; } = id;
+
+        public bool IsDisposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a compiled ASP.NET Core Web API sample that keeps one MCP client connection per application user/session
- serialize operations within a session while allowing different sessions to run concurrently
- bridge MCP elicitation requests to application-owned HTTP endpoints
- dispose sessions explicitly, after idle expiration, and during application shutdown
- document identity, scale-out, resource, and progress-streaming considerations
- add focused tests for concurrent creation, reuse, per-session serialization, cross-session concurrency, cleanup, and elicitation completion/cancellation

## Why

ASP.NET Core applications need an application-lifetime owner for stateful MCP clients. The SDK can correlate concurrent protocol messages, but the application still needs to decide who owns each live connection, how frontend interaction reaches an elicitation handler, and when the connection is disposed. This sample makes those responsibilities explicit without presenting the in-memory registry as a distributed production store.

## Validation

- `dotnet test tests/AspNetCoreMcpClient.Tests/AspNetCoreMcpClient.Tests.csproj --no-restore`
  - 5 passed
- `dotnet format tests/AspNetCoreMcpClient.Tests/AspNetCoreMcpClient.Tests.csproj --verify-no-changes --no-restore`
- `git diff --check`

Closes #1126