### PR TITLE
Fix HTTP fallback error handling

### DIFF
--- a/src/ModelContextProtocol.Core/Client/AutoDetectingClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/AutoDetectingClientSessionTransport.cs
@@ -77,16 +77,19 @@ internal sealed partial class AutoDetectingClientSessionTransport : ITransport
             else if (await StreamableHttpClientSessionTransport.TryReadJsonRpcErrorAsync(response, cancellationToken).ConfigureAwait(false) is { } parsedError)
             {
                 // A JSON-RPC error envelope in the body means the peer IS a Streamable HTTP server.
-                // It just rejected our specific request (e.g., -32022 UnsupportedProtocolVersion,
-                // -32021 MissingRequiredClientCapability, -32020 HeaderMismatch, or any other
-                // application-level error). Don't fall back to SSE — that would mask the real signal
-                // and surface a misleading "session id required" error from the SSE GET path.
-                // Adopt the Streamable HTTP transport and throw the structured exception so the
-                // connect-time fallback logic can react per spec PR #2844. Setting ActiveTransport
-                // first makes the catch filter below leave the now-owned transport alone.
+                // Adopt it before surfacing the failure so the catch filter leaves the now-owned
+                // transport alone, and never mask the response by attempting deprecated SSE.
                 LogUsingStreamableHttp(_name);
                 ActiveTransport = streamableHttpTransport;
-                throw McpSessionHandler.CreateRemoteProtocolExceptionFromError(parsedError);
+
+                if (StreamableHttpClientSessionTransport.ShouldSurfaceJsonRpcErrorAsProtocolException(response.StatusCode, parsedError))
+                {
+                    throw McpSessionHandler.CreateRemoteProtocolExceptionFromError(parsedError);
+                }
+
+                // TryReadJsonRpcErrorAsync buffered the content, so this preserves the same response
+                // body and status without consuming the network stream a second time.
+                throw await HttpResponseMessageExtensions.CreateHttpRequestExceptionWithBodyAsync(response, cancellationToken).ConfigureAwait(false);
             }
             else
             {

--- a/src/ModelContextProtocol.Core/Client/McpClientImpl.cs
+++ b/src/ModelContextProtocol.Core/Client/McpClientImpl.cs
@@ -367,14 +367,6 @@ internal sealed partial class McpClientImpl : McpClient
                         // fallback): falling back to initialize wouldn't fix a malformed envelope.
                         throw;
                     }
-                    catch (McpProtocolException ex) when (
-                        ex.ErrorCode == McpErrorCode.InvalidRequest &&
-                        ex.Message.Contains(McpHttpHeaders.SessionId, StringComparison.Ordinal))
-                    {
-                        // Local transport validation: a 2026-07-28+ response must not carry HTTP session state.
-                        // This is not evidence of an initialize-handshake server, so do not fall back.
-                        throw;
-                    }
                     catch (McpProtocolException)
                     {
                         // Per spec PR #2844, the fallback MUST NOT be keyed to a single error code.

--- a/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs
@@ -80,8 +80,7 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
         // for robustness. Servers occasionally emit them with 4xx codes other than 400.
         if (!response.IsSuccessStatusCode &&
             await TryReadJsonRpcErrorAsync(response, cancellationToken).ConfigureAwait(false) is { } parsedError &&
-            (response.StatusCode == HttpStatusCode.BadRequest ||
-             IsPerRequestMetadataProtocolErrorCode((McpErrorCode)parsedError.Error.Code)))
+            ShouldSurfaceJsonRpcErrorAsProtocolException(response.StatusCode, parsedError))
         {
             throw McpSessionHandler.CreateRemoteProtocolExceptionFromError(parsedError);
         }
@@ -89,10 +88,11 @@ internal sealed partial class StreamableHttpClientSessionTransport : TransportBa
         await response.EnsureSuccessStatusCodeWithResponseBodyAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private static bool IsPerRequestMetadataProtocolErrorCode(McpErrorCode code) =>
-        code is McpErrorCode.UnsupportedProtocolVersion
-             or McpErrorCode.MissingRequiredClientCapability
-             or McpErrorCode.HeaderMismatch;
+    internal static bool ShouldSurfaceJsonRpcErrorAsProtocolException(HttpStatusCode statusCode, JsonRpcError error) =>
+        statusCode == HttpStatusCode.BadRequest ||
+        (McpErrorCode)error.Error.Code is McpErrorCode.UnsupportedProtocolVersion
+                                          or McpErrorCode.MissingRequiredClientCapability
+                                          or McpErrorCode.HeaderMismatch;
 
     /// <summary>
     /// Reads a JSON-RPC error envelope from an <c>application/json</c> response body, returning

--- a/tests/ModelContextProtocol.AspNetCore.Tests/July2026ProtocolHttpFallbackTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/July2026ProtocolHttpFallbackTests.cs
@@ -57,7 +57,7 @@ public class July2026ProtocolHttpFallbackTests(ITestOutputHelper outputHelper) :
         base.Dispose();
     }
 
-    private async Task StartServerAsync(RequestDelegate handler)
+    private async Task StartServerAsync(RequestDelegate handler, bool acceptGet = false)
     {
         Builder.Services.Configure<JsonOptions>(options =>
         {
@@ -65,7 +65,14 @@ public class July2026ProtocolHttpFallbackTests(ITestOutputHelper outputHelper) :
         });
 
         _app = Builder.Build();
-        _app.MapPost("/mcp", handler);
+        if (acceptGet)
+        {
+            _app.MapMethods("/mcp", [HttpMethods.Get, HttpMethods.Post], handler);
+        }
+        else
+        {
+            _app.MapPost("/mcp", handler);
+        }
         await _app.StartAsync(TestContext.Current.CancellationToken);
     }
 
@@ -300,6 +307,63 @@ public class July2026ProtocolHttpFallbackTests(ITestOutputHelper outputHelper) :
 
         Assert.Equal(McpErrorCode.HeaderMismatch, exception.ErrorCode);
         Assert.False(initializeReceived);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    public async Task AutoDetect_OnNonModernJsonRpcErrorOutside400_PreservesHttpFailure_NoFallback(HttpStatusCode statusCode)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var initializeRequests = 0;
+        var sseGetRequests = 0;
+
+        await StartServerAsync(async context =>
+        {
+            if (HttpMethods.IsGet(context.Request.Method))
+            {
+                sseGetRequests++;
+                context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+                return;
+            }
+
+            var message = await JsonSerializer.DeserializeAsync(
+                context.Request.Body,
+                GetJsonTypeInfo<JsonRpcMessage>(),
+                ct);
+
+            if (message is JsonRpcRequest { Method: RequestMethods.Initialize })
+            {
+                initializeRequests++;
+            }
+
+            await WriteJsonRpcErrorAsync(
+                context,
+                statusCode,
+                code: (int)McpErrorCode.InvalidRequest,
+                message: "non-modern structured error");
+        }, acceptGet: true);
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new("http://localhost:5000/mcp"),
+            TransportMode = HttpTransportMode.AutoDetect,
+        }, HttpClient, LoggerFactory);
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(async () =>
+        {
+            await using var client = await McpClient.CreateAsync(
+                transport,
+                new McpClientOptions(),
+                loggerFactory: LoggerFactory,
+                cancellationToken: ct);
+        });
+
+        Assert.Equal(statusCode, exception.StatusCode);
+        Assert.Contains("non-modern structured error", exception.Message);
+        Assert.Equal(0, initializeRequests);
+        Assert.Equal(0, sseGetRequests);
     }
 
     [Fact]

--- a/tests/ModelContextProtocol.Tests/Client/July2026ProtocolFallbackTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/July2026ProtocolFallbackTests.cs
@@ -240,6 +240,28 @@ public class July2026ProtocolFallbackTests(ITestOutputHelper testOutputHelper) :
     }
 
     [Theory]
+    [InlineData(HttpTransportMode.StreamableHttp)]
+    [InlineData(HttpTransportMode.AutoDetect)]
+    public async Task Client_OnStructuredInvalidRequestFromHttpProbe_FallsBackTo_Initialize(
+        HttpTransportMode transportMode)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var initializeReceived = false;
+
+        using var mockHttpHandler = new MockHttpHandler();
+        using var httpClient = new HttpClient(mockHttpHandler);
+        mockHttpHandler.RequestHandler = CreateStructuredInvalidRequestProbeServer(
+            () => initializeReceived = true);
+
+        await using var transport = CreateTransport(httpClient, transportMode);
+        await using var client = await McpClient.CreateAsync(transport, new McpClientOptions(),
+            loggerFactory: LoggerFactory, cancellationToken: ct);
+
+        Assert.True(initializeReceived);
+        Assert.Equal(McpProtocolVersions.November2025ProtocolVersion, client.NegotiatedProtocolVersion);
+    }
+
+    [Theory]
     [InlineData(HttpStatusCode.InternalServerError, HttpTransportMode.StreamableHttp)]
     [InlineData(HttpStatusCode.Forbidden, HttpTransportMode.StreamableHttp)]
     [InlineData(HttpStatusCode.InternalServerError, HttpTransportMode.AutoDetect)]
@@ -315,6 +337,47 @@ public class July2026ProtocolFallbackTests(ITestOutputHelper testOutputHelper) :
                 default:
                     return EmptyResponse(HttpStatusCode.Accepted);
             }
+        };
+
+    private static Func<HttpRequestMessage, Task<HttpResponseMessage>> CreateStructuredInvalidRequestProbeServer(
+        Action onInitialize)
+        => async request =>
+        {
+            if (request.Method == HttpMethod.Get)
+                return EmptyResponse(HttpStatusCode.MethodNotAllowed);
+
+            var body = await request.Content!.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            if (!doc.RootElement.TryGetProperty("method", out var methodElement))
+                return EmptyResponse(HttpStatusCode.Accepted);
+
+            if (methodElement.GetString() == RequestMethods.ServerDiscover)
+            {
+                var id = doc.RootElement.GetProperty("id").GetRawText();
+                var error = "{\"jsonrpc\":\"2.0\",\"id\":" + id
+                    + ",\"error\":{\"code\":-32600,\"message\":\"Mcp-Session-Id header is required\"}}";
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent(error, Encoding.UTF8, "application/json"),
+                };
+            }
+
+            if (methodElement.GetString() == RequestMethods.Initialize)
+            {
+                onInitialize();
+                var id = doc.RootElement.GetProperty("id").GetRawText();
+                var result = "{\"jsonrpc\":\"2.0\",\"id\":" + id
+                    + ",\"result\":{\"protocolVersion\":\"" + McpProtocolVersions.November2025ProtocolVersion
+                    + "\",\"capabilities\":{},\"serverInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}";
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(result, Encoding.UTF8, "application/json"),
+                };
+                response.Headers.Add("mcp-session-id", "test-session");
+                return response;
+            }
+
+            return EmptyResponse(HttpStatusCode.Accepted);
         };
 
     private static HttpResponseMessage EmptyResponse(HttpStatusCode status)


### PR DESCRIPTION
Structured HTTP 400 responses containing non-modern JSON-RPC errors now fall back from `server/discover` to `initialize` for both Streamable HTTP and AutoDetect.

AutoDetect now preserves HTTP semantics for structured non-modern JSON-RPC errors returned with non-400 statuses such as 401, 403, and 500. These responses remain `HttpRequestException`s with their status and body, without attempting `initialize` or deprecated SSE fallback. Streamable HTTP and AutoDetect share the same status/error-code classification so their behavior remains consistent.

The first fix is intentionally simple despite the architectural alternatives discussed in #1790. #1692 initially added a local transport validation exception when a modern response carried `Mcp-Session-Id`, together with a catch that prevented fallback for that exception. A later commit in the same PR updated the spec behavior to ignore unexpected session IDs and removed the local exception, but inadvertently left the catch behind. Removing that stale catch restores the intended fallback behavior; no provenance architecture or exception subclass is needed.

Validation:
- `dotnet build --nologo` passed.
- `July2026ProtocolFallbackTests`: 20/20 passed on net472, net8.0, net9.0, and net10.0.
- `July2026ProtocolHttpFallbackTests`: 8/8 passed on net8.0, net9.0, and net10.0.
- Broader managed test runs from the implementation sessions passed. The conformance CLI was blocked only by the local Node v21.6.2 environment lacking `fs.globSync`; this was not a code regression.

Fixes #1790

> [!NOTE]
> This pull request description was drafted with GitHub Copilot.