### PR TITLE
Make Streamable HTTP status mapping deterministic

### DIFF
--- a/src/Common/StreamableHttpResponseStartFeature.cs
+++ b/src/Common/StreamableHttpResponseStartFeature.cs
@@ -1,0 +1,26 @@
+using ModelContextProtocol.Protocol;
+
+namespace ModelContextProtocol;
+
+internal static class StreamableHttpResponseStartFeature
+{
+    private const string ResponseStartingCallbackKey = "ModelContextProtocol.StreamableHttp.ResponseStartingCallback";
+
+    public static void Set(JsonRpcMessage message, Action<JsonRpcMessage> callback)
+    {
+        message.Context ??= new();
+        (message.Context.Items ??= new Dictionary<string, object?>())[ResponseStartingCallbackKey] = callback;
+    }
+
+    public static Action<JsonRpcMessage>? Take(JsonRpcMessage message)
+    {
+        if (message.Context?.Items is not { } items ||
+            !items.TryGetValue(ResponseStartingCallbackKey, out var value))
+        {
+            return null;
+        }
+
+        items.Remove(ResponseStartingCallbackKey);
+        return (Action<JsonRpcMessage>)value!;
+    }
+}

--- a/src/ModelContextProtocol.AspNetCore/ModelContextProtocol.AspNetCore.csproj
+++ b/src/ModelContextProtocol.AspNetCore/ModelContextProtocol.AspNetCore.csproj
@@ -26,6 +26,7 @@
     <Compile Include="..\Common\Obsoletions.cs" Link="Obsoletions.cs" />
     <Compile Include="..\Common\McpHttpHeaders.cs" Link="McpHttpHeaders.cs" />
     <Compile Include="..\Common\McpProtocolVersions.cs" Link="McpProtocolVersions.cs" />
+    <Compile Include="..\Common\StreamableHttpResponseStartFeature.cs" Link="StreamableHttpResponseStartFeature.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
+++ b/src/ModelContextProtocol.AspNetCore/StreamableHttpHandler.cs
@@ -153,14 +153,13 @@ internal sealed class StreamableHttpHandler(
 
         await using var _ = await session.AcquireReferenceAsync(context.RequestAborted);
 
-        Func<JsonRpcMessage?, ValueTask>? onResponseStarting = null;
         if (RequiresPerRequestMetadataProtocol(context))
         {
             // SEP-2575 maps some JSON-RPC error codes onto HTTP statuses (404 for a method the server
-            // does not implement, 400 for missing-capability and unsupported-version rejections). The
-            // status line can only be chosen before the first response byte, so the transport defers
-            // its eager header flush and reports the first response message here.
-            onResponseStarting = firstMessage =>
+            // does not implement, 400 for missing-capability and unsupported-version rejections).
+            // Wait for the actual first JSON-RPC message so this mapping is deterministic regardless
+            // of how long the request handler takes.
+            StreamableHttpResponseStartFeature.Set(message, firstMessage =>
             {
                 if (firstMessage is JsonRpcError { Error: { } errorDetail } && !context.Response.HasStarted)
                 {
@@ -173,13 +172,12 @@ internal sealed class StreamableHttpHandler(
                         _ => context.Response.StatusCode,
                     };
                 }
-
-                return default;
-            };
+            });
         }
 
         InitializeSseResponse(context);
-        var wroteResponse = await session.Transport.HandlePostRequestAsync(message, context.Response.Body, onResponseStarting, context.RequestAborted);
+        var wroteResponse = await session.Transport.HandlePostRequestAsync(
+            message, context.Response.Body, context.RequestAborted);
         if (!wroteResponse)
         {
             // We wound up writing nothing, so there should be no Content-Type response header.

--- a/src/ModelContextProtocol.Core/ModelContextProtocol.Core.csproj
+++ b/src/ModelContextProtocol.Core/ModelContextProtocol.Core.csproj
@@ -34,6 +34,7 @@
     <Compile Include="..\Common\EncodingUtilities.cs" Link="EncodingUtilities.cs" />
     <Compile Include="..\Common\McpHttpHeaders.cs" Link="McpHttpHeaders.cs" />
     <Compile Include="..\Common\McpProtocolVersions.cs" Link="McpProtocolVersions.cs" />
+    <Compile Include="..\Common\StreamableHttpResponseStartFeature.cs" Link="StreamableHttpResponseStartFeature.cs" />
     <Compile Include="..\Common\HttpResponseMessageExtensions.cs" Link="HttpResponseMessageExtensions.cs" />
     <Compile Include="..\Common\ServerSentEvents\**\*.cs" Link="ServerSentEvents\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>

--- a/src/ModelContextProtocol.Core/Server/StreamableHttpPostTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamableHttpPostTransport.cs
@@ -16,13 +16,14 @@ internal sealed partial class StreamableHttpPostTransport(
     Stream responseStream,
     CancellationToken sessionCancellationToken,
     ILogger logger,
-    Func<JsonRpcMessage?, ValueTask>? onResponseStarting = null) : ITransport
+    StreamableHttpResponseStartOptions? responseStartOptions = null) : ITransport
 {
     private readonly SemaphoreSlim _messageLock = new(1, 1);
     private readonly TaskCompletionSource<bool> _httpResponseTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly SseEventWriter _httpSseWriter = new(responseStream);
 
     private TaskCompletionSource<bool>? _storeStreamTcs;
+    private List<SseItem<JsonRpcMessage?>>? _pendingHttpSseItems;
 #pragma warning disable MCP9006 // Stateful Streamable HTTP resumability types are obsolete but still wired up internally.
     private ISseEventStreamWriter? _storeSseWriter;
 #pragma warning restore MCP9006
@@ -76,104 +77,46 @@ internal sealed partial class StreamableHttpPostTransport(
             return false;
         }
 
-        CancellationTokenSource? deferredFlushCts = null;
-        Task? deferredFlushTask = null;
-        bool deferHeaderFlush = false;
         using (await _messageLock.LockAsync(cancellationToken).ConfigureAwait(false))
         {
             var primingItem = await TryStartSseEventStreamAsync(_pendingRequest).ConfigureAwait(false);
             if (primingItem.HasValue)
             {
-                await NotifyResponseStartingAsync(firstMessage: null).ConfigureAwait(false);
-                await _httpSseWriter.WriteAsync(primingItem.Value, cancellationToken).ConfigureAwait(false);
+                if (responseStartOptions is null)
+                {
+                    StartHttpResponse(firstMessage: null);
+                    await _httpSseWriter.WriteAsync(primingItem.Value, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    QueuePendingHttpSseItem(primingItem.Value);
+                }
             }
-            else if (onResponseStarting is null)
+            else if (responseStartOptions is null)
             {
                 // If there's no priming write, flush the stream to ensure HTTP response headers are
                 // sent to the client now that the server is ready to process the request.
                 // This prevents HttpClient timeout for long-running requests.
+                StartHttpResponse(firstMessage: null);
                 await responseStream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
-            else
-            {
-                deferHeaderFlush = true;
-            }
 
-            // Ensure that we've sent the priming event before processing the incoming request.
+            // Legacy responses send the priming event before processing the request. A response
+            // waiting for its first JSON-RPC message keeps the event queued until that message arrives.
             await parentTransport.MessageWriter.WriteAsync(message, cancellationToken).ConfigureAwait(false);
         }
 
-        if (deferHeaderFlush)
-        {
-            // Defer the flush (and the header commit it implies) so the callback can still choose
-            // the HTTP status line for an immediate JSON-RPC error. Start the bounded grace period
-            // only after the request has been queued for dispatch.
-            deferredFlushCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            deferredFlushTask = DeferredHeaderFlushAsync(deferredFlushCts.Token);
-        }
-
-        try
-        {
-            // Wait for the response to be written before returning from the handler.
-            // This keeps the HTTP response open until the final response message is sent.
-            await _httpResponseTcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            if (deferredFlushCts is not null)
-            {
-                deferredFlushCts.Cancel();
-                await deferredFlushTask!.ConfigureAwait(false);
-                deferredFlushCts.Dispose();
-            }
-        }
+        // Wait for the response to be written before returning from the handler.
+        // This keeps the HTTP response open until the final response message is sent.
+        await _httpResponseTcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         return true;
     }
 
     /// <summary>
-    /// Bounds the deferred header flush: after a short grace window, flushes the response headers
-    /// if no response message has been written yet. Immediate rejections land well inside the
-    /// window, so the response-starting callback can still map their JSON-RPC error codes onto the
-    /// HTTP status line; a handler that runs longer commits the headers here so clients see them
-    /// promptly (long-running tool calls must not trip HttpClient's response timeout).
+    /// Notifies the HTTP application exactly once, immediately before the first response write.
     /// </summary>
-    private async Task DeferredHeaderFlushAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            await Task.Delay(DeferredHeaderFlushGrace, cancellationToken).ConfigureAwait(false);
-            using var _ = await _messageLock.LockAsync(cancellationToken).ConfigureAwait(false);
-            if (!_httpResponseStarted && !_httpResponseCompleted)
-            {
-                await NotifyResponseStartingAsync(firstMessage: null).ConfigureAwait(false);
-                await responseStream.FlushAsync(cancellationToken).ConfigureAwait(false);
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // The response was written or the request ended before the grace window elapsed.
-        }
-        catch (Exception ex)
-        {
-            // Surface the failure to the awaiting HandlePostAsync when possible. If the response
-            // future has already been resolved (the response started or completed on another path),
-            // TrySetException is a no-op, so log here to keep the deferred-flush failure diagnosable.
-            if (!_httpResponseTcs.TrySetException(ex))
-            {
-                LogDeferredHeaderFlushFailed(ex);
-            }
-        }
-    }
-
-    /// <summary>How long the response-header flush may be deferred waiting for the first response message.</summary>
-    internal static readonly TimeSpan DeferredHeaderFlushGrace = TimeSpan.FromMilliseconds(250);
-
-    /// <summary>
-    /// Invokes the response-starting callback exactly once, immediately before the first write to
-    /// the HTTP response stream, so the HTTP application can still set the response status line.
-    /// </summary>
-    private async ValueTask NotifyResponseStartingAsync(JsonRpcMessage? firstMessage)
+    private void StartHttpResponse(JsonRpcMessage? firstMessage)
     {
         if (_httpResponseStarted)
         {
@@ -181,9 +124,27 @@ internal sealed partial class StreamableHttpPostTransport(
         }
 
         _httpResponseStarted = true;
-        if (onResponseStarting is not null)
+        if (responseStartOptions is not null)
         {
-            await onResponseStarting(firstMessage).ConfigureAwait(false);
+            responseStartOptions.OnResponseStarting(
+                firstMessage ?? throw new InvalidOperationException("A JSON-RPC message is required to start this response."));
+        }
+    }
+
+    private void QueuePendingHttpSseItem(SseItem<JsonRpcMessage?> item)
+        => (_pendingHttpSseItems ??= []).Add(item);
+
+    private async ValueTask WritePendingHttpSseItemsAsync(CancellationToken cancellationToken)
+    {
+        if (_pendingHttpSseItems is not { } pendingItems)
+        {
+            return;
+        }
+
+        _pendingHttpSseItems = null;
+        foreach (var item in pendingItems)
+        {
+            await _httpSseWriter.WriteAsync(item, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -222,7 +183,8 @@ internal sealed partial class StreamableHttpPostTransport(
 
                 try
                 {
-                    await NotifyResponseStartingAsync(message).ConfigureAwait(false);
+                    StartHttpResponse(message);
+                    await WritePendingHttpSseItemsAsync(cancellationToken).ConfigureAwait(false);
                     await _httpSseWriter.WriteAsync(item, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
@@ -266,8 +228,15 @@ internal sealed partial class StreamableHttpPostTransport(
         // Write to the response stream if it still exists.
         if (!_httpResponseCompleted)
         {
-            await NotifyResponseStartingAsync(firstMessage: null).ConfigureAwait(false);
-            await _httpSseWriter.WriteAsync(primingItem, cancellationToken).ConfigureAwait(false);
+            if (responseStartOptions is not null && !_httpResponseStarted)
+            {
+                QueuePendingHttpSseItem(primingItem);
+            }
+            else
+            {
+                StartHttpResponse(firstMessage: null);
+                await _httpSseWriter.WriteAsync(primingItem, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         // Set the mode to 'Polling' so that the replay stream ends as soon as all available messages have been sent.
@@ -276,8 +245,12 @@ internal sealed partial class StreamableHttpPostTransport(
         await _storeSseWriter.SetModeAsync(SseEventStreamMode.Polling, cancellationToken).ConfigureAwait(false);
 #pragma warning restore MCP9006
 
-        // Signal completion so HandlePostAsync can return.
-        _httpResponseTcs.TrySetResult(true);
+        // A response waiting for its first JSON-RPC message cannot complete until that message has
+        // started the response and flushed any queued priming events.
+        if (responseStartOptions is null || _httpResponseStarted)
+        {
+            _httpResponseTcs.TrySetResult(true);
+        }
     }
 
     private async ValueTask<SseItem<JsonRpcMessage?>?> TryStartSseEventStreamAsync(RequestId requestId)
@@ -342,7 +315,4 @@ internal sealed partial class StreamableHttpPostTransport(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to dispose SSE event stream writer.")]
     private partial void LogStoreStreamDisposalFailed(Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to flush deferred Streamable HTTP response headers.")]
-    private partial void LogDeferredHeaderFlushFailed(Exception exception);
 }

--- a/src/ModelContextProtocol.Core/Server/StreamableHttpResponseStartOptions.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamableHttpResponseStartOptions.cs
@@ -1,0 +1,8 @@
+using ModelContextProtocol.Protocol;
+
+namespace ModelContextProtocol.Server;
+
+internal sealed class StreamableHttpResponseStartOptions(Action<JsonRpcMessage> onResponseStarting)
+{
+    public Action<JsonRpcMessage> OnResponseStarting { get; } = onResponseStarting;
+}

--- a/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
+++ b/src/ModelContextProtocol.Core/Server/StreamableHttpServerTransport.cs
@@ -207,39 +207,19 @@ public sealed partial class StreamableHttpServerTransport : ITransport
     /// If an authenticated <see cref="ClaimsPrincipal"/> sent the message, that can be included in the <see cref="JsonRpcMessage.Context"/>.
     /// No other part of the context should be set.
     /// </remarks>
-    public Task<bool> HandlePostRequestAsync(JsonRpcMessage message, Stream responseStream, CancellationToken cancellationToken = default)
-        => HandlePostRequestAsync(message, responseStream, onResponseStarting: null, cancellationToken);
-
-    /// <summary>
-    /// Handles a Streamable HTTP POST request, processing the JSON-RPC message and writing any
-    /// JSON-RPC responses to the response stream.
-    /// This overload additionally reports the first JSON-RPC message written to the response via
-    /// <paramref name="onResponseStarting"/>, before any response bytes are written, so the HTTP
-    /// application can still choose the response status line (SEP-2575 maps some JSON-RPC error
-    /// codes to HTTP statuses). When <paramref name="onResponseStarting"/> is provided, the eager
-    /// response-header flush that normally precedes request processing is deferred until that first
-    /// message; the callback receives <see langword="null"/> when the first write is not a JSON-RPC
-    /// message (e.g. a resumability priming event).
-    /// The status line can only be influenced by the FIRST write: when a handler streams a
-    /// notification (e.g. progress) before failing, or runs past the transport's bounded
-    /// header-flush grace window, the status is already committed and a later JSON-RPC error
-    /// rides the committed status.
-    /// </summary>
-    /// <param name="message">The JSON-RPC message to process.</param>
-    /// <param name="responseStream">The response stream to write any JSON-RPC responses to.</param>
-    /// <param name="onResponseStarting">Callback invoked once, immediately before the first write to <paramref name="responseStream"/>.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>
-    /// <see langword="true"/> if data was written to the response body.
-    /// <see langword="false"/> if nothing was written because the request body did not contain any <see cref="JsonRpcRequest"/> messages to respond to.
-    /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="message"/> or <paramref name="responseStream"/> is <see langword="null"/>.</exception>
-    public async Task<bool> HandlePostRequestAsync(JsonRpcMessage message, Stream responseStream, Func<JsonRpcMessage?, ValueTask>? onResponseStarting, CancellationToken cancellationToken)
+    public async Task<bool> HandlePostRequestAsync(
+        JsonRpcMessage message,
+        Stream responseStream,
+        CancellationToken cancellationToken = default)
     {
         Throw.IfNull(message);
         Throw.IfNull(responseStream);
 
-        var postTransport = new StreamableHttpPostTransport(this, responseStream, _transportDisposedCts.Token, _logger, onResponseStarting);
+        var onResponseStarting = StreamableHttpResponseStartFeature.Take(message);
+        var responseStartOptions = onResponseStarting is null
+            ? null
+            : new StreamableHttpResponseStartOptions(onResponseStarting);
+        var postTransport = new StreamableHttpPostTransport(this, responseStream, _transportDisposedCts.Token, _logger, responseStartOptions);
         using var postCts = CancellationTokenSource.CreateLinkedTokenSource(_transportDisposedCts.Token, cancellationToken);
         await using (postTransport.ConfigureAwait(false))
         {

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpTests.cs
@@ -237,12 +237,11 @@ public abstract partial class MapMcpTests(ITestOutputHelper testOutputHelper) : 
     }
 
     [Fact]
-    public async Task LongRunningToolCall_DoesNotTimeout_WhenNoEventStreamStore()
+    public async Task LegacyLongRunningToolCall_DoesNotTimeout_WhenNoEventStreamStore()
     {
-        // Regression test for: Tool calls that last over HttpClient timeout without producing
-        // intermediate notifications will timeout because HttpClient doesn't see the 200 response
-        // until the first message is written. When primingItem is null (no ISseEventStreamStore),
-        // we should flush the response stream so HttpClient sees the 200 immediately.
+        // Legacy protocol revisions do not map JSON-RPC errors onto the HTTP status line, so the
+        // response headers should be flushed before a long-running handler emits its first message.
+        // The 2026-07-28 revision intentionally waits for that message to map SEP-2575 statuses.
 
         Builder.Services.AddMcpServer().WithHttpTransport(ConfigureStateless).WithTools<LongRunningTools>();
 
@@ -274,7 +273,11 @@ public abstract partial class MapMcpTests(ITestOutputHelper testOutputHelper) : 
                     TransportMode = transportMode,
                 }, shortTimeoutClient, LoggerFactory);
 
-                await using var mcpClient = await McpClient.CreateAsync(transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+                await using var mcpClient = await McpClient.CreateAsync(
+                    transport,
+                    new McpClientOptions { ProtocolVersion = McpProtocolVersions.November2025ProtocolVersion },
+                    LoggerFactory,
+                    TestContext.Current.CancellationToken);
 
                 // Call a tool that takes 2 seconds - this should succeed despite the 1 second HttpClient timeout
                 // because the response stream is flushed immediately after receiving the request

--- a/tests/ModelContextProtocol.AspNetCore.Tests/RawHttpConformanceTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/RawHttpConformanceTests.cs
@@ -23,8 +23,18 @@ public class RawHttpConformanceTests(ITestOutputHelper outputHelper) : KestrelIn
 
     private WebApplication? _app;
 
-    private async Task StartAsync(string? protocolVersion = null)
+    private async Task StartAsync(string? protocolVersion = null, McpServerTool? additionalTool = null)
     {
+        List<McpServerTool> tools =
+        [
+            McpServerTool.Create((string text) => $"echo:{text}", new() { Name = "echo" }),
+        ];
+
+        if (additionalTool is not null)
+        {
+            tools.Add(additionalTool);
+        }
+
         Builder.Services
             .AddMcpServer(options =>
             {
@@ -32,7 +42,7 @@ public class RawHttpConformanceTests(ITestOutputHelper outputHelper) : KestrelIn
                 options.ProtocolVersion = protocolVersion;
             })
             .WithHttpTransport()
-            .WithTools([McpServerTool.Create((string text) => $"echo:{text}", new() { Name = "echo" })])
+            .WithTools(tools)
             .WithTools<CapabilityTools>();
 
         _app = Builder.Build();
@@ -187,7 +197,7 @@ public class RawHttpConformanceTests(ITestOutputHelper outputHelper) : KestrelIn
     }
 
     [Fact]
-    public async Task July2026Post_MissingRequiredCapability_Returns400()
+    public async Task July2026Post_SlowMissingRequiredCapability_Returns400()
     {
         await StartAsync();
 
@@ -205,6 +215,58 @@ public class RawHttpConformanceTests(ITestOutputHelper outputHelper) : KestrelIn
         var json = await ReadJsonResponseAsync(response, TestContext.Current.CancellationToken);
         Assert.Equal(19, json["id"]!.GetValue<long>());
         Assert.Equal((int)McpErrorCode.MissingRequiredClientCapability, json["error"]!["code"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public async Task LegacyPost_LongRunningHandler_FlushesResponseHeadersPromptly()
+    {
+        var handlerStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHandler = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var longRunningTool = McpServerTool.Create(
+            async (CancellationToken cancellationToken) =>
+            {
+                handlerStarted.TrySetResult(true);
+                await releaseHandler.Task.WaitAsync(cancellationToken);
+                return "released";
+            },
+            new() { Name = "wait_for_release" });
+        await StartAsync(additionalTool: longRunningTool);
+
+        var initializeBody = @"{""jsonrpc"":""2.0"",""id"":1,""method"":""initialize"",""params"":{""protocolVersion"":""2025-11-25"",""capabilities"":{},""clientInfo"":{""name"":""initialize-handshake"",""version"":""1.0""}}}";
+        using (var initializeRequest = new HttpRequestMessage(HttpMethod.Post, "") { Content = JsonContent(initializeBody) })
+        using (var initializeResponse = await HttpClient.SendAsync(initializeRequest, TestContext.Current.CancellationToken))
+        {
+            Assert.Equal(HttpStatusCode.OK, initializeResponse.StatusCode);
+        }
+
+        var body = @"{""jsonrpc"":""2.0"",""id"":2,""method"":""tools/call"",""params"":{""name"":""wait_for_release"",""arguments"":{}}}";
+        using var request = new HttpRequestMessage(HttpMethod.Post, "") { Content = JsonContent(body) };
+        request.Headers.Add(ProtocolVersionHeader, McpProtocolVersions.November2025ProtocolVersion);
+        var responseTask = HttpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            TestContext.Current.CancellationToken);
+
+        await handlerStarted.Task.WaitAsync(TestConstants.DefaultTimeout, TestContext.Current.CancellationToken);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await responseTask.WaitAsync(
+                TestConstants.HttpClientPollingTimeout,
+                TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            releaseHandler.TrySetResult(true);
+        }
+
+        using (response)
+        {
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var json = await ReadJsonResponseAsync(response, TestContext.Current.CancellationToken);
+            Assert.Equal("released", json["result"]!["content"]![0]!["text"]!.GetValue<string>());
+        }
     }
 
     [Fact]
@@ -501,9 +563,13 @@ public class RawHttpConformanceTests(ITestOutputHelper outputHelper) : KestrelIn
     private sealed class CapabilityTools
     {
         [McpServerTool(Name = "requires_sampling")]
-        public static string RequiresSampling() =>
+        public static async Task<string> RequiresSampling(CancellationToken cancellationToken)
+        {
+            // Reproduce the old 250 ms header-grace race before returning the SEP-2575 error.
+            await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
             throw new MissingRequiredClientCapabilityException(
                 new ClientCapabilities { Sampling = new() },
                 "sampling capability required but not declared by client");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- remove the 250 ms deferred-header grace timer and its lifecycle/logging code
- wait for the actual first JSON-RPC message on 2026-07-28 requests before committing headers, so SEP-2575 error-to-HTTP status mapping is deterministic under load
- preserve eager response-header flushing for legacy protocol revisions
- remove the new public callback overload and carry the ASP.NET Core response-start hook through an internal request-context feature
- buffer SSE priming/polling writes until the first JSON-RPC message on the deferred path, keeping response start exactly-once under the transport lock

This intentionally leaves quiet 2026-07-28 handlers subject to the caller's `HttpClient` timeout unless they emit an inline message such as progress. It does not add `StartResponseAsync`; a Streamable HTTP-only API on `RequestContext<T>` needs a separate design.

## Validation

- `dotnet build` passes with 0 warnings and 0 errors
- focused header/status regressions pass on .NET 8, 9, and 10
- all in-repo test suites pass across their target frameworks
- the external `DockerEverythingServerTests.Sampling_Sse_EverythingServer` remains environment-blocked because the configured running server does not expose `trigger-sampling-request`; the restored npm everything-server integration tests pass

> [!NOTE]
> This pull request description was generated with GitHub Copilot.