### PR TITLE
Add typed MCP Apps metadata for resources

### DIFF
--- a/docs/concepts/apps/apps.md
+++ b/docs/concepts/apps/apps.md
@@ -31,6 +31,7 @@ The key concepts are:
 - **UI capability negotiation** — Client and server declare support via `extensions["io.modelcontextprotocol/ui"]`
 - **UI resources** — HTML content served with the MIME type `text/html;profile=mcp-app`
 - **Tool UI metadata** — Tools declare their associated UI resource in `_meta.ui`
+- **Resource UI metadata** — Resources declare CSP, permissions, domain, and display preferences in `_meta.ui`
 
 ## Associating tools with UI resources
 
@@ -58,7 +59,7 @@ builder.Services.AddMcpServer()
     .WithMcpApps();
 ```
 
-The `WithMcpApps()` call registers a post-configuration step that processes all registered tools and applies `[McpAppUi]` attribute metadata to their `_meta.ui` field automatically.
+The `WithMcpApps()` call registers a post-configuration step that processes registered tools and resources, applying their MCP Apps attributes to the corresponding `_meta.ui` fields automatically.
 
 ### Using the attribute with manual processing
 
@@ -125,6 +126,34 @@ UI resources are HTML pages registered with the MCP server using the `ui://` URI
 - **Permissions** — Sandbox permissions (scripts, forms, popups, etc.)
 - **Domain** — Dedicated origin for OAuth flows and CORS
 - **PrefersBorder** — Whether the host should render a visual border
+
+Use `[McpAppResource]` to configure this metadata without writing raw JSON:
+
+```csharp
+[McpServerResourceType]
+public static class WeatherResources
+{
+    [McpServerResource(
+        UriTemplate = "ui://weather/view.html",
+        Name = "weather-ui",
+        MimeType = McpApps.HtmlMimeType)]
+    [McpAppResource(
+        ConnectDomains = ["https://api.weather.gov"],
+        Permissions = ["geolocation"],
+        PrefersBorder = true)]
+    public static string GetWeatherUi() => File.ReadAllText("weather.html");
+}
+```
+
+Register the resource before calling `WithMcpApps()`:
+
+```csharp
+builder.Services.AddMcpServer()
+    .WithResources<WeatherResources>()
+    .WithMcpApps();
+```
+
+For resources created manually, call `McpApps.ApplyAppResourceAttributes(resource)`, or set a typed `McpUiResourceMeta` directly with `McpApps.SetResourceUi(resource, metadata)`.
 
 ## App-only tools
 

--- a/samples/WeatherAppServer/README.md
+++ b/samples/WeatherAppServer/README.md
@@ -5,7 +5,8 @@ An MCP server that demonstrates the **MCP Apps** extension by serving an interac
 ## What it shows
 
 - **`[McpAppUi]` attribute** — declaratively associates a UI resource with a tool
-- **`WithMcpApps()`** — builder extension that processes `[McpAppUi]` attributes
+- **`[McpAppResource]` attribute** — configures typed CSP and display metadata for a UI resource
+- **`WithMcpApps()`** — builder extension that processes both MCP Apps attributes
 - **UI resource** — an HTML page served via `McpServerResource` with MIME type `text/html;profile=mcp-app`
 - **Structured content** — tool results include `StructuredContent` for the UI to render
 

--- a/samples/WeatherAppServer/WeatherResources.cs
+++ b/samples/WeatherAppServer/WeatherResources.cs
@@ -10,7 +10,7 @@ public sealed class WeatherResources
     private static readonly string UiDir = Path.Combine(AppContext.BaseDirectory, "ui");
 
     [McpServerResource(UriTemplate = "ui://weather-app/forecast", Name = "weather-forecast-ui", MimeType = McpApps.HtmlMimeType)]
-    [McpMeta("ui", """{"csp":{"connectDomains":["https://api.weather.gov"]},"prefersBorder":true}""")]
+    [McpAppResource(ConnectDomains = ["https://api.weather.gov"], PrefersBorder = true)]
     [Description("Interactive weather forecast UI with city picker")]
     public static string GetWeatherForecastUi() => File.ReadAllText(Path.Combine(UiDir, "weather-forecast.html"));
 

--- a/src/ModelContextProtocol.Extensions.Apps/Server/McpAppResourceAttribute.cs
+++ b/src/ModelContextProtocol.Extensions.Apps/Server/McpAppResourceAttribute.cs
@@ -1,0 +1,60 @@
+using ModelContextProtocol.Server;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModelContextProtocol.Extensions.Apps;
+
+/// <summary>
+/// Specifies MCP Apps UI metadata for a resource method.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Apply this attribute alongside <see cref="McpServerResourceAttribute"/> to configure the
+/// Content Security Policy, sandbox permissions, domain, and visual preferences for an MCP App
+/// resource. When processed by <see cref="McpApps.ApplyAppResourceAttributes(McpServerResource)"/>,
+/// it populates the structured <c>_meta.ui</c> object in the resource's metadata.
+/// </para>
+/// <para>
+/// Explicit <c>Meta["ui"]</c> set via <see cref="McpServerResourceCreateOptions"/> or a raw
+/// <c>[McpMeta("ui", ...)]</c> attribute takes precedence over this attribute.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+/// [McpServerResource(UriTemplate = "ui://weather/view.html", MimeType = McpApps.HtmlMimeType)]
+/// [McpAppResource(ConnectDomains = ["https://api.weather.gov"], PrefersBorder = true)]
+/// public static string GetWeatherUi() =&gt; ...;
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Method)]
+[Experimental(Experimentals.Apps_DiagnosticId, UrlFormat = Experimentals.Apps_Url)]
+public sealed class McpAppResourceAttribute : Attribute
+{
+    private bool? _prefersBorder;
+
+    /// <summary>Gets or sets origins allowed for network connections.</summary>
+    public string[]? ConnectDomains { get; set; }
+
+    /// <summary>Gets or sets origins allowed for scripts, stylesheets, images, and fonts.</summary>
+    public string[]? ResourceDomains { get; set; }
+
+    /// <summary>Gets or sets origins allowed for nested frames.</summary>
+    public string[]? FrameDomains { get; set; }
+
+    /// <summary>Gets or sets allowed base URIs.</summary>
+    public string[]? BaseUris { get; set; }
+
+    /// <summary>Gets or sets browser permissions requested by the sandboxed resource.</summary>
+    public string[]? Permissions { get; set; }
+
+    /// <summary>Gets or sets the dedicated origin domain for this resource.</summary>
+    public string? Domain { get; set; }
+
+    /// <summary>Gets or sets whether the host should render a visual border around the UI.</summary>
+    public bool PrefersBorder
+    {
+        get => _prefersBorder.GetValueOrDefault();
+        set => _prefersBorder = value;
+    }
+
+    internal bool? PrefersBorderValue => _prefersBorder;
+}

--- a/src/ModelContextProtocol.Extensions.Apps/Server/McpApps.cs
+++ b/src/ModelContextProtocol.Extensions.Apps/Server/McpApps.cs
@@ -21,9 +21,11 @@ namespace ModelContextProtocol.Extensions.Apps;
 /// the connected client supports the MCP Apps extension.
 /// </para>
 /// <para>
-/// Use <see cref="SetAppUi"/> to set the <c>_meta.ui</c> metadata on a tool, or
+/// Use <see cref="SetAppUi"/> and <see cref="SetResourceUi"/> to set the <c>_meta.ui</c> metadata, or
 /// <see cref="ApplyAppUiAttributes(IEnumerable{McpServerTool})"/> to automatically process
-/// <see cref="McpAppUiAttribute"/> instances on tools created from methods.
+/// <see cref="McpAppUiAttribute"/> instances on tools created from methods. Use
+/// <see cref="ApplyAppResourceAttributes(IEnumerable{McpServerResource})"/> to process
+/// <see cref="McpAppResourceAttribute"/> instances on resources.
 /// </para>
 /// </remarks>
 [Experimental(Experimentals.Apps_DiagnosticId, UrlFormat = Experimentals.Apps_Url)]
@@ -153,15 +155,15 @@ public static class McpApps
     }
 
     /// <summary>
-    /// Sets the MCP Apps UI metadata on a resource's <see cref="ResourceTemplate.Meta"/> property.
+    /// Sets the MCP Apps UI metadata on a resource's protocol metadata.
     /// </summary>
     /// <param name="resource">The resource to set the UI metadata on.</param>
     /// <param name="resourceUi">The UI metadata to apply.</param>
     /// <returns>The same <paramref name="resource"/> instance, for chaining.</returns>
     /// <remarks>
     /// <para>
-    /// This method sets the <c>ui</c> key in the resource's <see cref="ResourceTemplate.Meta"/> object.
-    /// If a <c>ui</c> key is already present in <see cref="ResourceTemplate.Meta"/>, it is not overwritten.
+    /// This method sets the <c>ui</c> key in the resource's <see cref="ResourceTemplate.Meta"/> object and,
+    /// for non-templated resources, its <see cref="Resource.Meta"/> object. Existing <c>ui</c> metadata is not overwritten.
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="resource"/> or <paramref name="resourceUi"/> is <see langword="null"/>.</exception>
@@ -175,15 +177,102 @@ public static class McpApps
         if (resourceUi is null) throw new ArgumentNullException(nameof(resourceUi));
 #endif
 
-        var protocolResource = resource.ProtocolResourceTemplate;
-        protocolResource.Meta ??= new JsonObject();
+        var protocolResourceTemplate = resource.ProtocolResourceTemplate;
+        protocolResourceTemplate.Meta ??= new JsonObject();
+        var protocolResource = resource.ProtocolResource;
 
-        if (!protocolResource.Meta.ContainsKey("ui"))
+        if (!protocolResourceTemplate.Meta.ContainsKey("ui") && protocolResource?.Meta?.ContainsKey("ui") != true)
         {
             var uiNode = JsonSerializer.SerializeToNode(resourceUi, McpAppsJsonContext.Default.McpUiResourceMeta);
             if (uiNode is not null)
             {
-                protocolResource.Meta["ui"] = uiNode;
+                protocolResourceTemplate.Meta["ui"] = uiNode;
+            }
+        }
+
+        if (protocolResource is not null)
+        {
+            protocolResource.Meta ??= protocolResourceTemplate.Meta;
+            if (!protocolResource.Meta.ContainsKey("ui") && protocolResourceTemplate.Meta["ui"] is { } uiNode)
+            {
+                protocolResource.Meta["ui"] = uiNode.DeepClone();
+            }
+        }
+
+        return resource;
+    }
+
+    /// <summary>
+    /// Processes a collection of resources, applying <see cref="McpAppResourceAttribute"/> metadata to any
+    /// resource whose underlying method has the attribute.
+    /// </summary>
+    /// <param name="resources">The resources to process.</param>
+    /// <returns>The same <paramref name="resources"/> enumerable, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="resources"/> is <see langword="null"/>.</exception>
+    public static IEnumerable<McpServerResource> ApplyAppResourceAttributes(IEnumerable<McpServerResource> resources)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(resources);
+#else
+        if (resources is null) throw new ArgumentNullException(nameof(resources));
+#endif
+
+        foreach (var resource in resources)
+        {
+            ApplyAppResourceAttributes(resource);
+        }
+
+        return resources;
+    }
+
+    /// <summary>
+    /// Processes a single resource, applying <see cref="McpAppResourceAttribute"/> metadata if the resource's
+    /// underlying method has the attribute.
+    /// </summary>
+    /// <param name="resource">The resource to process.</param>
+    /// <returns>The same <paramref name="resource"/> instance, for chaining.</returns>
+    /// <remarks>
+    /// Existing <c>_meta.ui</c> metadata is preserved and takes precedence over the attribute.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="resource"/> is <see langword="null"/>.</exception>
+    public static McpServerResource ApplyAppResourceAttributes(McpServerResource resource)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(resource);
+#else
+        if (resource is null) throw new ArgumentNullException(nameof(resource));
+#endif
+
+        foreach (var metadataItem in resource.Metadata)
+        {
+            if (metadataItem is McpAppResourceAttribute appResourceAttribute)
+            {
+                McpUiResourceCsp? csp = null;
+                if (appResourceAttribute.ConnectDomains is not null ||
+                    appResourceAttribute.ResourceDomains is not null ||
+                    appResourceAttribute.FrameDomains is not null ||
+                    appResourceAttribute.BaseUris is not null)
+                {
+                    csp = new McpUiResourceCsp
+                    {
+                        ConnectDomains = appResourceAttribute.ConnectDomains,
+                        ResourceDomains = appResourceAttribute.ResourceDomains,
+                        FrameDomains = appResourceAttribute.FrameDomains,
+                        BaseUris = appResourceAttribute.BaseUris,
+                    };
+                }
+
+                SetResourceUi(resource, new McpUiResourceMeta
+                {
+                    Csp = csp,
+                    Permissions = appResourceAttribute.Permissions is null ? null : new McpUiResourcePermissions
+                    {
+                        Allow = appResourceAttribute.Permissions,
+                    },
+                    Domain = appResourceAttribute.Domain,
+                    PrefersBorder = appResourceAttribute.PrefersBorderValue,
+                });
+                break;
             }
         }
 

--- a/src/ModelContextProtocol.Extensions.Apps/Server/McpAppsBuilderExtensions.cs
+++ b/src/ModelContextProtocol.Extensions.Apps/Server/McpAppsBuilderExtensions.cs
@@ -13,14 +13,15 @@ namespace ModelContextProtocol.Extensions.Apps;
 public static class McpAppsBuilderExtensions
 {
     /// <summary>
-    /// Enables MCP Apps support by automatically processing <see cref="McpAppUiAttribute"/> on registered tools.
+    /// Enables MCP Apps support by automatically processing MCP Apps attributes on registered tools and resources.
     /// </summary>
     /// <param name="builder">The server builder.</param>
     /// <returns>The builder provided in <paramref name="builder"/>.</returns>
     /// <remarks>
     /// <para>
     /// Call this method after registering tools (e.g., after <c>WithTools&lt;T&gt;()</c>) to automatically
-    /// apply <see cref="McpAppUiAttribute"/> metadata to the tool's <c>_meta.ui</c> field.
+    /// apply <see cref="McpAppUiAttribute"/> and <see cref="McpAppResourceAttribute"/> metadata to the
+    /// corresponding <c>_meta.ui</c> fields.
     /// </para>
     /// <para>
     /// Tools that already have a <c>ui</c> key in their <see cref="Protocol.Tool.Meta"/> (e.g., set explicitly
@@ -64,6 +65,14 @@ public static class McpAppsBuilderExtensions
                 foreach (var tool in tools)
                 {
                     McpApps.ApplyAppUiAttributes(tool);
+                }
+            }
+
+            if (options.ResourceCollection is { IsEmpty: false } resources)
+            {
+                foreach (var resource in resources)
+                {
+                    McpApps.ApplyAppResourceAttributes(resource);
                 }
             }
         }

--- a/tests/ModelContextProtocol.AotCompatibility.TestApp/Program.cs
+++ b/tests/ModelContextProtocol.AotCompatibility.TestApp/Program.cs
@@ -11,6 +11,7 @@ var services = new ServiceCollection();
 services.AddMcpServer()
     .WithStreamServerTransport(clientToServerPipe.Reader.AsStream(), serverToClientPipe.Writer.AsStream())
     .WithTools<AotTools>()
+    .WithResources<AotResources>()
     .WithMcpApps();
 
 await using var serviceProvider = services.BuildServiceProvider();
@@ -41,6 +42,15 @@ if (result is null || !result.ToString()!.Contains("Echo: Hello World"))
     throw new Exception($"Unexpected result: {result}");
 }
 
+var resources = await client.ListResourcesAsync();
+var resource = resources.FirstOrDefault(r => r.Uri == "ui://aot/echo");
+var resourceUi = resource?.ProtocolResource.Meta?["ui"]?.AsObject();
+if (resourceUi?["csp"]?["connectDomains"]?[0]?.GetValue<string>() != "https://api.example.com" ||
+    resourceUi["prefersBorder"]?.GetValue<bool>() != true)
+{
+    throw new Exception($"Unexpected app resource UI metadata: {resourceUi}");
+}
+
 Console.WriteLine("Success!");
 
 [McpServerToolType]
@@ -49,4 +59,12 @@ internal sealed class AotTools
     [McpServerTool(Name = "Echo")]
     [McpAppUi(ResourceUri = "ui://aot/echo")]
     public static string Echo(string arg) => $"Echo: {arg}";
+}
+
+[McpServerResourceType]
+internal sealed class AotResources
+{
+    [McpServerResource(UriTemplate = "ui://aot/echo", Name = "echo-ui", MimeType = McpApps.HtmlMimeType)]
+    [McpAppResource(ConnectDomains = ["https://api.example.com"], PrefersBorder = true)]
+    public static string EchoUi() => "<html></html>";
 }

--- a/tests/ModelContextProtocol.Tests/Server/McpAppsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpAppsTests.cs
@@ -326,6 +326,67 @@ public class McpAppsTests
 
     #endregion
 
+    #region McpAppResourceAttribute via ApplyAppResourceAttributes
+
+    [Fact]
+    public void ApplyAppResourceAttributes_PopulatesStructuredUiObject()
+    {
+        var method = typeof(TestResourcesWithAppUi).GetMethod(nameof(TestResourcesWithAppUi.WeatherUi))!;
+        var resource = McpServerResource.Create(method, target: null);
+
+        McpApps.ApplyAppResourceAttributes(resource);
+
+        var uiNode = resource.ProtocolResourceTemplate.Meta?["ui"]?.AsObject();
+        Assert.NotNull(uiNode);
+        Assert.Equal("https://app.example.com", uiNode["domain"]?.GetValue<string>());
+        Assert.True(uiNode["prefersBorder"]?.GetValue<bool>());
+
+        var cspNode = uiNode["csp"]?.AsObject();
+        Assert.NotNull(cspNode);
+        Assert.Equal("https://api.weather.gov", cspNode["connectDomains"]?[0]?.GetValue<string>());
+        Assert.Equal("https://cdn.example.com", cspNode["resourceDomains"]?[0]?.GetValue<string>());
+        Assert.Equal("https://embed.example.com", cspNode["frameDomains"]?[0]?.GetValue<string>());
+        Assert.Equal("https://app.example.com", cspNode["baseUris"]?[0]?.GetValue<string>());
+
+        var permissionsNode = uiNode["permissions"]?["allow"]?.AsArray();
+        Assert.NotNull(permissionsNode);
+        Assert.Equal("geolocation", permissionsNode[0]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void ApplyAppResourceAttributes_OmittedPrefersBorder_RemainsOmitted()
+    {
+        var method = typeof(TestResourcesWithAppUi).GetMethod(nameof(TestResourcesWithAppUi.ResourceWithoutBorderPreference))!;
+        var resource = McpServerResource.Create(method, target: null);
+
+        McpApps.ApplyAppResourceAttributes(resource);
+
+        var uiNode = resource.ProtocolResourceTemplate.Meta?["ui"]?.AsObject();
+        Assert.NotNull(uiNode);
+        Assert.False(uiNode.ContainsKey("prefersBorder"));
+    }
+
+    [Fact]
+    public void ApplyAppResourceAttributes_ExplicitMeta_TakesPrecedence()
+    {
+        var method = typeof(TestResourcesWithAppUi).GetMethod(nameof(TestResourcesWithAppUi.WeatherUi))!;
+        var resource = McpServerResource.Create(method, target: null, new McpServerResourceCreateOptions
+        {
+            Meta = new JsonObject
+            {
+                ["ui"] = new JsonObject { ["domain"] = "https://explicit.example.com" },
+            },
+        });
+
+        McpApps.ApplyAppResourceAttributes(resource);
+
+        var uiNode = resource.ProtocolResourceTemplate.Meta?["ui"]?.AsObject();
+        Assert.Equal("https://explicit.example.com", uiNode?["domain"]?.GetValue<string>());
+        Assert.Single(uiNode!);
+    }
+
+    #endregion
+
     #region F7: SetAppUi
 
     [Fact]
@@ -440,6 +501,31 @@ public class McpAppsTests
     }
 
     [Fact]
+    public void WithMcpApps_AppliesAppResourceAttributes_ViaOptions()
+    {
+        var sc = new ServiceCollection();
+        sc.AddMcpServer()
+            .WithResources([typeof(TestResourcesWithAppUi)])
+            .WithMcpApps();
+
+        using var sp = sc.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptions<McpServerOptions>>().Value;
+
+        Assert.NotNull(options.ResourceCollection);
+        var weatherResource = options.ResourceCollection.Single(resource =>
+            resource.ProtocolResourceTemplate.UriTemplate == "ui://weather/view.html");
+        var uiNode = weatherResource.ProtocolResourceTemplate.Meta?["ui"]?.AsObject();
+
+        Assert.NotNull(uiNode);
+        Assert.Equal("https://api.weather.gov", uiNode["csp"]?["connectDomains"]?[0]?.GetValue<string>());
+        Assert.True(uiNode["prefersBorder"]?.GetValue<bool>());
+
+        var listedResourceUi = weatherResource.ProtocolResource?.Meta?["ui"]?.AsObject();
+        Assert.NotNull(listedResourceUi);
+        Assert.Equal("https://api.weather.gov", listedResourceUi["csp"]?["connectDomains"]?[0]?.GetValue<string>());
+    }
+
+    [Fact]
     public void WithMcpApps_EmptyToolCollection_DoesNotThrow()
     {
         var sc = new ServiceCollection();
@@ -483,6 +569,25 @@ public class McpAppsTests
         [McpServerTool]
         [McpAppUi(ResourceUri = "ui://model-only/view.html", Visibility = [McpUiToolVisibility.Model])]
         public static string ModelOnlyTool(string location) => $"Model only for {location}";
+    }
+
+    [McpServerResourceType]
+    private static class TestResourcesWithAppUi
+    {
+        [McpServerResource(UriTemplate = "ui://weather/view.html", Name = "weather_ui", MimeType = McpApps.HtmlMimeType)]
+        [McpAppResource(
+            ConnectDomains = ["https://api.weather.gov"],
+            ResourceDomains = ["https://cdn.example.com"],
+            FrameDomains = ["https://embed.example.com"],
+            BaseUris = ["https://app.example.com"],
+            Permissions = ["geolocation"],
+            Domain = "https://app.example.com",
+            PrefersBorder = true)]
+        public static string WeatherUi() => "<html></html>";
+
+        [McpServerResource(UriTemplate = "ui://weather/no-border.html", Name = "weather_ui_no_border", MimeType = McpApps.HtmlMimeType)]
+        [McpAppResource(Domain = "https://app.example.com")]
+        public static string ResourceWithoutBorderPreference() => "<html></html>";
     }
 
     #endregion


### PR DESCRIPTION
## What

- Add an `[McpAppResource]` attribute for CSP allowlists, sandbox permissions, dedicated domains, and border preferences.
- Extend `WithMcpApps()` to process registered resources as well as tools.
- Keep resource-template metadata and the cached static resource protocol object in sync.
- Replace raw JSON metadata in `WeatherAppServer` and document the typed resource workflow.
- Add unit and AOT coverage for attribute-based resource metadata.

## Why

Attribute-registered MCP App resources currently need raw `[McpMeta("ui", ...)]` JSON even though the SDK already exposes typed resource metadata models. This fills the missing attribute and builder layer so resource registration matches the existing tool experience.

## Impact

Existing explicit `_meta.ui` values continue to take precedence. Existing tool behavior is unchanged.

## Checks

- `dotnet format ModelContextProtocol.slnx --verify-no-changes` for changed C# files
- `dotnet build src/ModelContextProtocol.Extensions.Apps/ModelContextProtocol.Extensions.Apps.csproj` — net10.0, net9.0, net8.0, netstandard2.0
- `dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj --framework net10.0 --filter FullyQualifiedName~McpApps` — 37 passed
- `dotnet run --project tests/ModelContextProtocol.AotCompatibility.TestApp/ModelContextProtocol.AotCompatibility.TestApp.csproj` — success
- `dotnet build samples/WeatherAppServer/WeatherAppServer.csproj`

Closes #1636