### PR TITLE
Fix McpHeaderEncoder.DecodeValue throwing on the degenerate base64 wrapper

### DIFF
--- a/src/ModelContextProtocol.Core/Protocol/McpHeaderEncoder.cs
+++ b/src/ModelContextProtocol.Core/Protocol/McpHeaderEncoder.cs
@@ -126,7 +126,8 @@ public static class McpHeaderEncoder
 
         // Check for Base64 wrapper. The spec requires the sentinel markers to be
         // case-sensitive and exactly lowercase per SEP-2243.
-        if (headerValue.StartsWith(Base64Prefix, StringComparison.Ordinal) &&
+        if (headerValue.Length >= Base64Prefix.Length + Base64Suffix.Length &&
+            headerValue.StartsWith(Base64Prefix, StringComparison.Ordinal) &&
             headerValue.EndsWith(Base64Suffix, StringComparison.Ordinal))
         {
             var base64Content = headerValue.Substring(

--- a/tests/ModelContextProtocol.Tests/Client/McpHeaderEncoderTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpHeaderEncoderTests.cs
@@ -105,6 +105,16 @@ public class McpHeaderEncoderTests
     }
 
     [Fact]
+    public void DecodeValue_DegenerateWrapper_ReturnsLiteralValue()
+    {
+        // "=?base64?=" matches both the prefix "=?base64?" and the suffix "?=" because they
+        // overlap on the shared '?', but it is too short to contain any base64 content. It must be
+        // returned as-is rather than throwing when the wrapper is stripped.
+        var result = McpHeaderEncoder.DecodeValue("=?base64?=");
+        Assert.Equal("=?base64?=", result);
+    }
+
+    [Fact]
     public void DecodeValue_CaseSensitivePrefix_ReturnsLiteralValue()
     {
         // Per SEP-2243: sentinel markers are case-sensitive and MUST appear exactly as shown (lowercase).


### PR DESCRIPTION
`McpHeaderEncoder.DecodeValue` throws `ArgumentOutOfRangeException` on the input `"=?base64?="` instead of returning it unchanged, which contradicts its own contract ("returns the original value" when the value is not a valid base64 wrapper) and its never-throw test suite.

The wrapper uses prefix `"=?base64?"` (ends with `?`) and suffix `"?="` (starts with `?`), which overlap on the shared `?`. So `"=?base64?="` (length 10) satisfies both `StartsWith(prefix)` and `EndsWith(suffix)`. The inner length is then computed as `Length - Prefix.Length - Suffix.Length` = `10 - 9 - 2` = `-1`, and `Substring(9, -1)` throws. Because that `Substring` is outside the `try`, the exception propagates.

This is reachable from a client-supplied header (for example `Mcp-Name: =?base64?=`): every character is a valid header character, so it passes validation and reaches `DecodeValue`, turning an intended graceful rejection into an unhandled exception.

Fix: guard the wrapper branch with a minimum-length check, so a value too short to hold any content falls through to the literal return (the same behavior as `DecodeValue_MissingSuffix_ReturnsLiteralValue`). Added a regression test.
