### PR TITLE
Fix dead relative link to versioning docs in bump-version skill

### DIFF
--- a/.github/skills/bump-version/references/semver-assessment.md
+++ b/.github/skills/bump-version/references/semver-assessment.md
@@ -62,7 +62,7 @@ While the candidate version uses a prerelease suffix (e.g., `X.Y.Z-preview.N`, `
 
 Going to GA drops the suffix entirely: `2.0.0-rc.2` → `2.0.0`.
 
-This is purely about how to *compute* the next version. It does **not** declare any new policy about what kinds of changes are permitted between previews — refer to the existing [versioning documentation](../../../../docs/versioning.html) for breaking-change policy.
+This is purely about how to *compute* the next version. It does **not** declare any new policy about what kinds of changes are permitted between previews — refer to the existing [versioning documentation](../../../../docs/versioning.md) for breaking-change policy.
 
 ### Branch context
 


### PR DESCRIPTION
The `bump-version` skill links to the versioning policy with a relative path that does not exist:

```
[versioning documentation](../../../../docs/versioning.html)
```

From `.github/skills/bump-version/references/`, that resolves to `docs/versioning.html` at the repo root, and there is no such file. `docs/` holds the DocFX sources (CONTRIBUTING.md: "This project uses DocFX to generate its conceptual and reference documentation"), so `.html` is build output that never gets committed. The only file there is `docs/versioning.md`, so the link 404s on GitHub.

The `.html` extension looks like it was copied from line 7 of the same file, which correctly uses the absolute site URL `https://csharp.sdk.modelcontextprotocol.io/versioning.html`. That line is left untouched.

Two other skill files already refer to the policy by its repo path, both writing it as `docs/versioning.md`:

- `.github/skills/breaking-changes/references/classification.md:68`
- `.github/skills/prepare-release/SKILL.md:183`

Only the relative link is changed.
