### PR TITLE
Fix duplicated word in test comment

### DIFF
--- a/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryConnection.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryConnection.cs
@@ -92,7 +92,7 @@ public sealed class KestrelInMemoryConnection : ConnectionContext
 
         protected override void Dispose(bool disposing)
         {
-            // Signal to the server the the client has closed the connection, and dispose the client-half of the Pipes.
+            // Signal to the server the client has closed the connection, and dispose the client-half of the Pipes.
             ThreadPool.UnsafeQueueUserWorkItem(static cts => ((CancellationTokenSource)cts!).Cancel(), connectionClosedCts);
             duplexPipe.Input.Complete();
             duplexPipe.Output.Complete();


### PR DESCRIPTION
Minor typo in a code comment: the word `the` is duplicated ("the the client") in the `Dispose` comment of `tests/ModelContextProtocol.AspNetCore.Tests/Utils/KestrelInMemoryConnection.cs`. No code change.
