### PR TITLE
Fix protocol version tag for stateless server spans

### DIFF
--- a/src/ModelContextProtocol.Core/McpSessionHandler.cs
+++ b/src/ModelContextProtocol.Core/McpSessionHandler.cs
@@ -962,9 +962,10 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
             tags.Add("network.protocol.name", "http");
         }
 
-        if (NegotiatedProtocolVersion is not null)
+        string? protocolVersion = (message as JsonRpcRequest)?.Context?.ProtocolVersion ?? NegotiatedProtocolVersion;
+        if (protocolVersion is not null)
         {
-            tags.Add("mcp.protocol.version", NegotiatedProtocolVersion);
+            tags.Add("mcp.protocol.version", protocolVersion);
         }
 
         if (activity is { IsAllDataRequested: true })

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStatelessTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStatelessTests.cs
@@ -2,6 +2,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using OpenTelemetry.Trace;
+using System.Diagnostics;
 
 namespace ModelContextProtocol.AspNetCore.Tests;
 
@@ -9,6 +11,38 @@ public class MapMcpStatelessTests(ITestOutputHelper outputHelper) : MapMcpStream
 {
     protected override bool UseStreamableHttp => true;
     protected override bool Stateless => true;
+
+    [Fact]
+    public async Task ServerActivity_IncludesPerRequestProtocolVersion()
+    {
+        var activities = new List<Activity>();
+
+        using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource("Experimental.ModelContextProtocol")
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        Builder.Services.AddMcpServer()
+            .WithHttpTransport(ConfigureStateless)
+            .WithTools([McpServerTool.Create(() => "ok", new() { Name = "test-tool" })]);
+
+        await using var app = Builder.Build();
+        app.MapMcp();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        await using var client = await ConnectAsync(configureClient: options =>
+            options.ProtocolVersion = McpProtocolVersions.July2026ProtocolVersion);
+
+        await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        tracerProvider.ForceFlush();
+
+        var serverListToolsActivity = Assert.Single(activities, activity =>
+            activity.DisplayName == "tools/list" && activity.Kind == ActivityKind.Server);
+
+        Assert.Contains(serverListToolsActivity.Tags, tag =>
+            tag.Key == "mcp.protocol.version" &&
+            tag.Value == McpProtocolVersions.July2026ProtocolVersion);
+    }
 
     [Fact]
     public async Task EnablePollingAsync_ThrowsInvalidOperationException_InStatelessMode()

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStatelessTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStatelessTests.cs
@@ -12,10 +12,27 @@ public class MapMcpStatelessTests(ITestOutputHelper outputHelper) : MapMcpStream
     protected override bool UseStreamableHttp => true;
     protected override bool Stateless => true;
 
-    [Fact]
-    public async Task ServerActivity_IncludesPerRequestProtocolVersion()
+    // In stateless mode each HTTP request is served by a fresh, un-negotiated McpServer, so the
+    // session-level NegotiatedProtocolVersion is null when the server span is tagged. The tag must
+    // therefore come from the per-request MCP-Protocol-Version header / _meta value. Exercising more
+    // than one version proves the tag tracks the per-request value rather than coincidentally matching
+    // a single hard-coded version (and would regress to an absent tag if the per-request fallback were
+    // removed, since the negotiated value is null at tagging time).
+    [Theory]
+    [InlineData("2025-11-25")]
+    [InlineData("2026-07-28")]
+    public async Task ServerActivity_TagsPerRequestProtocolVersion_InStatelessMode(string protocolVersion)
     {
         var activities = new List<Activity>();
+        string? capturedNegotiatedProtocolVersion = null;
+
+        var protocolVersionTool = McpServerTool.Create(
+            (RequestContext<CallToolRequestParams> context) =>
+            {
+                capturedNegotiatedProtocolVersion = context.Server.NegotiatedProtocolVersion;
+                return "ok";
+            },
+            new() { Name = "stateless-capture-version" });
 
         using (var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
             .AddSource("Experimental.ModelContextProtocol")
@@ -24,22 +41,26 @@ public class MapMcpStatelessTests(ITestOutputHelper outputHelper) : MapMcpStream
         {
             Builder.Services.AddMcpServer()
                 .WithHttpTransport(ConfigureStateless)
-                .WithTools([McpServerTool.Create(() => "ok", new() { Name = "test-tool" })]);
+                .WithTools([protocolVersionTool]);
 
             await using var app = Builder.Build();
             app.MapMcp();
             await app.StartAsync(TestContext.Current.CancellationToken);
 
             await using var client = await ConnectAsync(configureClient: options =>
-                options.ProtocolVersion = McpProtocolVersions.July2026ProtocolVersion);
+                options.ProtocolVersion = protocolVersion);
 
-            await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+            await client.CallToolAsync("stateless-capture-version", cancellationToken: TestContext.Current.CancellationToken);
         }
 
         Assert.Contains(activities, activity =>
-            activity.DisplayName == "tools/list" &&
+            activity.DisplayName == "tools/call stateless-capture-version" &&
             activity.Kind == ActivityKind.Server &&
-            activity.GetTagItem("mcp.protocol.version") as string == McpProtocolVersions.July2026ProtocolVersion);
+            activity.GetTagItem("mcp.protocol.version") as string == protocolVersion);
+
+        // Once the per-request version is applied, the request-scoped server settles on that same version,
+        // so the value tagged on the span and the version the session ends up negotiating agree.
+        Assert.Equal(protocolVersion, capturedNegotiatedProtocolVersion);
     }
 
     [Fact]

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStatelessTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStatelessTests.cs
@@ -17,24 +17,24 @@ public class MapMcpStatelessTests(ITestOutputHelper outputHelper) : MapMcpStream
     {
         var activities = new List<Activity>();
 
-        using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+        using (var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
             .AddSource("Experimental.ModelContextProtocol")
             .AddInMemoryExporter(activities)
-            .Build();
+            .Build())
+        {
+            Builder.Services.AddMcpServer()
+                .WithHttpTransport(ConfigureStateless)
+                .WithTools([McpServerTool.Create(() => "ok", new() { Name = "test-tool" })]);
 
-        Builder.Services.AddMcpServer()
-            .WithHttpTransport(ConfigureStateless)
-            .WithTools([McpServerTool.Create(() => "ok", new() { Name = "test-tool" })]);
+            await using var app = Builder.Build();
+            app.MapMcp();
+            await app.StartAsync(TestContext.Current.CancellationToken);
 
-        await using var app = Builder.Build();
-        app.MapMcp();
-        await app.StartAsync(TestContext.Current.CancellationToken);
+            await using var client = await ConnectAsync(configureClient: options =>
+                options.ProtocolVersion = McpProtocolVersions.July2026ProtocolVersion);
 
-        await using var client = await ConnectAsync(configureClient: options =>
-            options.ProtocolVersion = McpProtocolVersions.July2026ProtocolVersion);
-
-        await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
-        tracerProvider.ForceFlush();
+            await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        }
 
         var serverListToolsActivity = Assert.Single(activities, activity =>
             activity.DisplayName == "tools/list" && activity.Kind == ActivityKind.Server);

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStatelessTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStatelessTests.cs
@@ -36,12 +36,10 @@ public class MapMcpStatelessTests(ITestOutputHelper outputHelper) : MapMcpStream
             await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
         }
 
-        var serverListToolsActivity = Assert.Single(activities, activity =>
-            activity.DisplayName == "tools/list" && activity.Kind == ActivityKind.Server);
-
-        Assert.Contains(serverListToolsActivity.Tags, tag =>
-            tag.Key == "mcp.protocol.version" &&
-            tag.Value == McpProtocolVersions.July2026ProtocolVersion);
+        Assert.Contains(activities, activity =>
+            activity.DisplayName == "tools/list" &&
+            activity.Kind == ActivityKind.Server &&
+            activity.GetTagItem("mcp.protocol.version") as string == McpProtocolVersions.July2026ProtocolVersion);
     }
 
     [Fact]

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStreamableHttpTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpStreamableHttpTests.cs
@@ -6,7 +6,9 @@ using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Tests.Utils;
+using OpenTelemetry.Trace;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Net;
 using System.Security.Claims;
 using System.Threading;
@@ -44,6 +46,60 @@ public class MapMcpStreamableHttpTests(ITestOutputHelper outputHelper) : MapMcpT
         await using var mcpClient = await ConnectAsync(requestPath);
 
         Assert.Equal("TestCustomRouteServer", mcpClient.ServerInfo.Name);
+    }
+
+    // 2025-11-25 is negotiated through the initialize handshake, so in the (default) stateful configuration
+    // the session-level NegotiatedProtocolVersion is populated and the client sends a matching
+    // MCP-Protocol-Version header on every follow-up request. This asserts the span carries the negotiated
+    // version and that the tagged value agrees with the session's NegotiatedProtocolVersion.
+    //
+    // A scenario where the per-request and negotiated versions differ is intentionally not asserted here:
+    // a single MCP session must not change protocol versions, so the server rejects a follow-up request
+    // whose header/_meta version differs from the negotiated one, and a conformant client never sends a
+    // differing header. Reaching that divergence would require a hand-crafted request on an invalid
+    // (failing) code path and would pin the current ordering of tagging relative to version-change
+    // validation. Instead the two inputs to the tag are covered independently: the per-request path in
+    // stateless mode (MapMcpStatelessTests, where NegotiatedProtocolVersion is null at tagging time) and the
+    // negotiated-only fallback over a header-less transport (DiagnosticTests).
+    [Fact]
+    public async Task ServerActivity_TagsNegotiatedProtocolVersion()
+    {
+        var activities = new List<Activity>();
+        string? capturedNegotiatedProtocolVersion = null;
+
+        var protocolVersionTool = McpServerTool.Create(
+            (RequestContext<CallToolRequestParams> context) =>
+            {
+                capturedNegotiatedProtocolVersion = context.Server.NegotiatedProtocolVersion;
+                return "ok";
+            },
+            new() { Name = "negotiated-capture-version" });
+
+        using (var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource("Experimental.ModelContextProtocol")
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            Builder.Services.AddMcpServer()
+                .WithHttpTransport(ConfigureStateless)
+                .WithTools([protocolVersionTool]);
+
+            await using var app = Builder.Build();
+            app.MapMcp();
+            await app.StartAsync(TestContext.Current.CancellationToken);
+
+            await using var client = await ConnectAsync(configureClient: options =>
+                options.ProtocolVersion = "2025-11-25");
+
+            await client.CallToolAsync("negotiated-capture-version", cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        Assert.Contains(activities, activity =>
+            activity.DisplayName == "tools/call negotiated-capture-version" &&
+            activity.Kind == ActivityKind.Server &&
+            activity.GetTagItem("mcp.protocol.version") as string == "2025-11-25");
+
+        Assert.Equal("2025-11-25", capturedNegotiatedProtocolVersion);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

* Use the per-request protocol version when tagging server activities before session-level negotiation state is populated
* Add stateless HTTP coverage for the 2026-07-28 protocol version tag

Fixes #1800

## Testing

* Focused stateless protocol-version activity test: 1 passed
* ModelContextProtocol.Tests DiagnosticTests on net10.0: 3 passed
* MapMcpStatelessTests on net10.0: 32 passed, 20 skipped as expected