### PR TITLE
Release v2.2.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <PackageProjectUrl>https://csharp.sdk.modelcontextprotocol.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/modelcontextprotocol/csharp-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>ModelContextProtocol</Authors>
     <Copyright>© Model Context Protocol a Series of LF Projects, LLC.</Copyright>

--- a/src/PACKAGE.md
+++ b/src/PACKAGE.md
@@ -4,7 +4,7 @@
 
 The official C# SDK for the [Model Context Protocol](https://modelcontextprotocol.io/), enabling .NET applications, services, and libraries to implement and interact with MCP clients and servers. Please visit the [API documentation](https://csharp.sdk.modelcontextprotocol.io/api/ModelContextProtocol.html) for more details on available functionality.
 
-See the [release notes](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v2.1.0) for what's new in this version.
+See the [release notes](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v2.2.0) for what's new in this version.
 
 ## Packages
 


### PR DESCRIPTION
# Release v2.2.0

This release adds hybrid stateful/stateless HTTP serving so legacy initialize clients and modern sessionless clients can share an endpoint, and fixes a malformed header-decoding edge case.

## Release Notes

### What’s Changed

* Fix McpHeaderEncoder.DecodeValue throwing on the degenerate base64 wrapper #1805 by @latent-9
* Add HttpServerSessionMode for hybrid stateful/stateless HTTP serving #1796 by @saicharanpardhu (co-authored by @Copilot @jeffhandley)

### Test Improvements

* Fix duplicated word in test comment #1809 by @latent-9

### Repository Infrastructure Updates

* Enable package validation for the MCP extension packages #1793 by @jeffhandley (co-authored by @Copilot)
* Add a release-manager agent that orchestrates the release skills #1794 by @jeffhandley (co-authored by @Copilot)
* Bump Anthropic from 12.39.0 to 12.40.0 #1808
* Bump @hono/node-server from 1.19.14 to 2.1.0 in the npm_and_yarn group across 1 directory #1812
* Fix dead relative link to versioning docs in bump-version skill #1807 by @latent-9

### Acknowledgements

* @latent-9 made their first contribution in #1807
* @saicharanpardhu made their first contribution in #1796
* @saicharanpardhu submitted issue #1777 (resolved by #1796)
* @jeffhandley @tarekgh @halter73 reviewed pull requests

**Full Changelog**: https://github.com/modelcontextprotocol/csharp-sdk/compare/v2.1.0...v2.2.0

---

## API Compatibility Report

All five packages pass against baseline `v2.0.0`. No suppressions were generated, retained, removed, or modified.

| Package | Baseline | Generated | Retained / removed | Release pack |
|---|---:|---:|---:|---|
| ModelContextProtocol.Core | 2.0.0 | 0 | 0 / 0 | ✅ |
| ModelContextProtocol | 2.0.0 | 0 | 0 / 0 | ✅ |
| ModelContextProtocol.AspNetCore | 2.0.0 | 0 | 0 / 0 | ✅ |
| ModelContextProtocol.Extensions.Apps | 2.0.0 | 0 | 0 / 0 | ✅ |
| ModelContextProtocol.Extensions.Tasks | 2.0.0 | 0 | 0 / 0 | ✅ |

## API Diff Report

### ModelContextProtocol.Core

No public API differences from `v2.1.0`.

### ModelContextProtocol

No public API differences from `v2.1.0`.

### ModelContextProtocol.AspNetCore

```diff
  namespace ModelContextProtocol.AspNetCore
  {
      public class HttpServerTransportOptions
      {
+         public ModelContextProtocol.AspNetCore.HttpServerSessionMode? SessionMode { get; set; }
      }
+     public sealed class HttpServerSessionMode
+     {
+         public const ModelContextProtocol.AspNetCore.HttpServerSessionMode Stateful = 1;
+         public const ModelContextProtocol.AspNetCore.HttpServerSessionMode StatefulForInitializeClients = 2;
+         public const ModelContextProtocol.AspNetCore.HttpServerSessionMode Stateless = 0;
+         public int value__;
+     }
  }
```

> [!NOTE]
> This release-preparation content was generated with GitHub Copilot.
