### PR TITLE
Add WithAppTool helper for MCP Apps

### DIFF
--- a/docs/concepts/apps/apps.md
+++ b/docs/concepts/apps/apps.md
@@ -48,9 +48,10 @@ builder.Services.AddMcpServer()
 
 The `resourceUri` argument is authoritative and must be a concrete, absolute `ui://` URI; URI templates are not accepted.
 If the tool options already contain `_meta.ui.resourceUri`, it must be a string that exactly matches the argument, while other UI metadata is preserved.
-The HTML handler may be synchronous or asynchronous and can accept a `CancellationToken` through the existing resource-handler binding.
+The HTML handler must return `string`, `Task<string>`, or `ValueTask<string>`. It can have no parameters or accept a single `CancellationToken`.
 
-When multiple app tools use the same resource URI, the existing resource collection semantics apply: the first registered HTML handler serves that URI.
+When multiple app tools use the exact same resource URI, the first registered HTML handler serves that URI.
+Equivalent URI spellings and collisions with resources registered through the lower-level APIs are rejected when server options are resolved, so every tool link identifies the HTML resource created by `WithAppTool`.
 Use the lower-level registration APIs when the tool or resource needs additional configuration.
 
 ### Using attributes with registered tool types

--- a/docs/concepts/apps/apps.md
+++ b/docs/concepts/apps/apps.md
@@ -34,9 +34,23 @@ The key concepts are:
 
 ## Associating tools with UI resources
 
-### Using the builder extension (recommended)
+### Registering a tool and its UI resource together (recommended)
 
-The simplest approach is to apply `[McpAppUi]` attributes to your tool methods and call `WithMcpApps()` on the server builder:
+`WithAppTool` creates the tool, links it to a `ui://` resource, registers the HTML content with the MCP Apps MIME type, and enables MCP Apps support:
+
+```csharp
+builder.Services.AddMcpServer()
+    .WithAppTool(
+        (string location) => $"Weather for {location}",
+        "ui://weather/view.html",
+        () => File.ReadAllText("weather.html"));
+```
+
+Use the lower-level registration APIs when the tool or resource needs additional configuration.
+
+### Using attributes with registered tool types
+
+For tools declared in a type, apply `[McpAppUi]` attributes to the tool methods and call `WithMcpApps()` on the server builder:
 
 ```csharp
 [McpServerToolType]

--- a/docs/concepts/apps/apps.md
+++ b/docs/concepts/apps/apps.md
@@ -46,6 +46,11 @@ builder.Services.AddMcpServer()
         () => File.ReadAllText("weather.html"));
 ```
 
+The `resourceUri` argument is authoritative and must be a concrete, absolute `ui://` URI; URI templates are not accepted.
+If the tool options already contain `_meta.ui.resourceUri`, it must exactly match the argument, while other UI metadata is preserved.
+The HTML handler may be synchronous or asynchronous and can accept a `CancellationToken` through the existing resource-handler binding.
+
+When multiple app tools use the same resource URI, the existing resource collection semantics apply: the first registered HTML handler serves that URI.
 Use the lower-level registration APIs when the tool or resource needs additional configuration.
 
 ### Using attributes with registered tool types

--- a/docs/concepts/apps/apps.md
+++ b/docs/concepts/apps/apps.md
@@ -47,7 +47,7 @@ builder.Services.AddMcpServer()
 ```
 
 The `resourceUri` argument is authoritative and must be a concrete, absolute `ui://` URI; URI templates are not accepted.
-If the tool options already contain `_meta.ui.resourceUri`, it must exactly match the argument, while other UI metadata is preserved.
+If the tool options already contain `_meta.ui.resourceUri`, it must be a string that exactly matches the argument, while other UI metadata is preserved.
 The HTML handler may be synchronous or asynchronous and can accept a `CancellationToken` through the existing resource-handler binding.
 
 When multiple app tools use the same resource URI, the existing resource collection semantics apply: the first registered HTML handler serves that URI.

--- a/src/ModelContextProtocol.Extensions.Apps/Server/McpAppsBuilderExtensions.cs
+++ b/src/ModelContextProtocol.Extensions.Apps/Server/McpAppsBuilderExtensions.cs
@@ -13,6 +13,83 @@ namespace ModelContextProtocol.Extensions.Apps;
 public static class McpAppsBuilderExtensions
 {
     /// <summary>
+    /// Registers a tool together with the HTML resource it renders.
+    /// </summary>
+    /// <param name="builder">The server builder.</param>
+    /// <param name="method">The tool method to expose.</param>
+    /// <param name="resourceUri">The <c>ui://</c> resource URI associated with the tool.</param>
+    /// <param name="htmlFactory">A callback that returns the HTML for the UI resource.</param>
+    /// <param name="toolOptions">Optional options used when creating the tool.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/>, <paramref name="method"/>, <paramref name="resourceUri"/>, or
+    /// <paramref name="htmlFactory"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException"><paramref name="resourceUri"/> is empty or consists only of whitespace.</exception>
+    /// <remarks>
+    /// <para>
+    /// This is the compact equivalent of creating a tool with <see cref="McpServerTool.Create(Delegate, McpServerToolCreateOptions?)"/>,
+    /// applying <see cref="McpApps.SetAppUi(McpServerTool, McpUiToolMeta)"/>, and creating a resource with
+    /// <see cref="McpServerResource.Create(Delegate, McpServerResourceCreateOptions?)"/>. The resource is registered with
+    /// <see cref="McpApps.HtmlMimeType"/>, and the returned HTML is wrapped by the existing resource result conversion.
+    /// </para>
+    /// <para>
+    /// Calling this method also enables <see cref="WithMcpApps(IMcpServerBuilder)"/> so the server advertises MCP Apps support.
+    /// Existing <see cref="McpServerToolCreateOptions.Meta"/> UI metadata is preserved, as it is with
+    /// <see cref="McpApps.SetAppUi(McpServerTool, McpUiToolMeta)"/>.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    /// builder.Services
+    ///     .AddMcpServer()
+    ///     .WithAppTool(
+    ///         (string location) =&gt; $&quot;Weather for {location}&quot;,
+    ///         &quot;ui://weather/view.html&quot;,
+    ///         () =&gt; File.ReadAllText(&quot;weather.html&quot;));
+    /// </code>
+    /// </example>
+    public static IMcpServerBuilder WithAppTool(
+        this IMcpServerBuilder builder,
+        Delegate method,
+        string resourceUri,
+        Func<string> htmlFactory,
+        McpServerToolCreateOptions? toolOptions = null)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(resourceUri);
+        ArgumentNullException.ThrowIfNull(htmlFactory);
+#else
+        if (builder is null) throw new ArgumentNullException(nameof(builder));
+        if (method is null) throw new ArgumentNullException(nameof(method));
+        if (resourceUri is null) throw new ArgumentNullException(nameof(resourceUri));
+        if (htmlFactory is null) throw new ArgumentNullException(nameof(htmlFactory));
+#endif
+        if (string.IsNullOrWhiteSpace(resourceUri))
+        {
+            throw new ArgumentException("Value cannot be empty or composed entirely of whitespace.", nameof(resourceUri));
+        }
+
+        var tool = McpApps.SetAppUi(
+            McpServerTool.Create(method, toolOptions),
+            new McpUiToolMeta { ResourceUri = resourceUri });
+        var resource = McpServerResource.Create(
+            htmlFactory,
+            new McpServerResourceCreateOptions
+            {
+                UriTemplate = resourceUri,
+                MimeType = McpApps.HtmlMimeType,
+            });
+
+        return builder
+            .WithTools([tool])
+            .WithResources([resource])
+            .WithMcpApps();
+    }
+
+    /// <summary>
     /// Enables MCP Apps support by automatically processing <see cref="McpAppUiAttribute"/> on registered tools.
     /// </summary>
     /// <param name="builder">The server builder.</param>

--- a/src/ModelContextProtocol.Extensions.Apps/Server/McpAppsBuilderExtensions.cs
+++ b/src/ModelContextProtocol.Extensions.Apps/Server/McpAppsBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -19,7 +20,11 @@ public static class McpAppsBuilderExtensions
     /// <param name="builder">The server builder.</param>
     /// <param name="method">The tool method to expose.</param>
     /// <param name="resourceUri">The absolute <c>ui://</c> resource URI associated with the tool.</param>
-    /// <param name="htmlFactory">A resource handler that returns the HTML, synchronously or asynchronously.</param>
+    /// <param name="htmlFactory">
+    /// A resource handler that returns the HTML as a <see cref="string"/>, <see cref="Task{TResult}"/> of
+    /// <see cref="string"/>, or <see cref="ValueTask{TResult}"/> of <see cref="string"/>. It may have no parameters
+    /// or a single <see cref="CancellationToken"/> parameter.
+    /// </param>
     /// <param name="toolOptions">Optional options used when creating the tool.</param>
     /// <returns>The builder provided in <paramref name="builder"/>.</returns>
     /// <exception cref="ArgumentNullException">
@@ -27,8 +32,12 @@ public static class McpAppsBuilderExtensions
     /// <paramref name="htmlFactory"/> is <see langword="null"/>.
     /// </exception>
     /// <exception cref="ArgumentException">
-    /// <paramref name="resourceUri"/> is not an absolute, non-templated <c>ui://</c> URI, or the tool's existing
+    /// <paramref name="resourceUri"/> is not an absolute, non-templated <c>ui://</c> URI,
+    /// <paramref name="htmlFactory"/> has an unsupported signature, or the tool's existing
     /// <c>_meta.ui.resourceUri</c> value is not a string that exactly matches it.
+    /// </exception>
+    /// <exception cref="OptionsValidationException">
+    /// The app tool's name or resource URI conflicts with another registration when server options are resolved.
     /// </exception>
     /// <remarks>
     /// <para>
@@ -86,13 +95,15 @@ public static class McpAppsBuilderExtensions
             throw new ArgumentException("The resource URI must be a valid absolute URI using the ui:// scheme.", nameof(resourceUri));
         }
 
+        ValidateHtmlFactory(htmlFactory);
+
         var tool = McpApps.SetAppUi(
             McpServerTool.Create(method, toolOptions),
             new McpUiToolMeta { ResourceUri = resourceUri });
 
         if (tool.ProtocolTool.Meta?["ui"] is not JsonObject uiMetadata)
         {
-            throw new ArgumentException("The tool's _meta.ui value must be an object.", nameof(resourceUri));
+            throw new ArgumentException("The tool's _meta.ui value must be an object.", nameof(toolOptions));
         }
 
         if (uiMetadata.ContainsKey("resourceUri"))
@@ -101,14 +112,14 @@ public static class McpAppsBuilderExtensions
             if (resourceUriNode is not JsonValue resourceUriValue ||
                 !resourceUriValue.TryGetValue(out string? existingResourceUri))
             {
-                throw new ArgumentException("The tool's _meta.ui.resourceUri value must be a string.", nameof(resourceUri));
+                throw new ArgumentException("The tool's _meta.ui.resourceUri value must be a string.", nameof(toolOptions));
             }
 
             if (!string.Equals(existingResourceUri, resourceUri, StringComparison.Ordinal))
             {
                 throw new ArgumentException(
                     $"The tool's UI resource URI '{existingResourceUri}' does not match the registered resource URI '{resourceUri}'.",
-                    nameof(resourceUri));
+                    nameof(toolOptions));
             }
         }
 
@@ -122,10 +133,158 @@ public static class McpAppsBuilderExtensions
                 MimeType = McpApps.HtmlMimeType,
             });
 
+        builder.Services.AddSingleton(new AppToolRegistration(tool, resource, resourceUri));
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<McpServerOptions>, AppToolOptionsValidator>());
+
         return builder
             .WithTools([tool])
             .WithResources([resource])
             .WithMcpApps();
+    }
+
+    private static void ValidateHtmlFactory(Delegate htmlFactory)
+    {
+        Type returnType = htmlFactory.Method.ReturnType;
+        if (returnType != typeof(string) &&
+            returnType != typeof(Task<string>) &&
+            returnType != typeof(ValueTask<string>))
+        {
+            throw new ArgumentException(
+                "The HTML factory must return string, Task<string>, or ValueTask<string>.",
+                nameof(htmlFactory));
+        }
+
+        var parameters = htmlFactory.Method.GetParameters();
+        if (parameters.Length > 1 ||
+            (parameters.Length == 1 && parameters[0].ParameterType != typeof(CancellationToken)))
+        {
+            throw new ArgumentException(
+                "The HTML factory must have no parameters or a single CancellationToken parameter.",
+                nameof(htmlFactory));
+        }
+    }
+
+    private sealed class AppToolRegistration(
+        McpServerTool tool,
+        McpServerResource resource,
+        string resourceUri)
+    {
+        public McpServerTool Tool { get; } = tool;
+
+        public McpServerResource Resource { get; } = resource;
+
+        public string ResourceUri { get; } = resourceUri;
+    }
+
+    private sealed class AppToolOptionsValidator(
+        IEnumerable<AppToolRegistration> registrations,
+        IEnumerable<McpServerTool> registeredTools,
+        IEnumerable<McpServerResource> registeredResources) : IValidateOptions<McpServerOptions>
+    {
+        private readonly AppToolRegistration[] _registrations = registrations.ToArray();
+        private readonly McpServerTool[] _registeredTools = registeredTools.ToArray();
+        private readonly McpServerResource[] _registeredResources = registeredResources.ToArray();
+
+        public ValidateOptionsResult Validate(string? name, McpServerOptions options)
+        {
+            if (!string.IsNullOrEmpty(name))
+            {
+                return ValidateOptionsResult.Skip;
+            }
+
+            foreach (AppToolRegistration registration in _registrations)
+            {
+                string toolName = registration.Tool.ProtocolTool.Name;
+                if (_registeredTools.Count(tool => string.Equals(
+                    tool.ProtocolTool.Name,
+                    toolName,
+                    StringComparison.Ordinal)) > 1)
+                {
+                    return ValidateOptionsResult.Fail(
+                        $"The app tool name '{toolName}' is already registered. App tool names must be unique.");
+                }
+
+                AppToolRegistration? equivalentRegistration = _registrations.FirstOrDefault(candidate =>
+                    !ReferenceEquals(candidate, registration) &&
+                    !string.Equals(candidate.ResourceUri, registration.ResourceUri, StringComparison.Ordinal) &&
+                    ResourceUrisEqual(candidate.ResourceUri, registration.ResourceUri));
+                if (equivalentRegistration is not null)
+                {
+                    return ValidateOptionsResult.Fail(
+                        $"The app resource URIs '{registration.ResourceUri}' and '{equivalentRegistration.ResourceUri}' " +
+                        "identify the same resource but use different spellings. Use one exact URI for all linked tools.");
+                }
+
+                foreach (McpServerResource registeredResource in _registeredResources)
+                {
+                    if (ResourceUrisEqual(
+                            registeredResource.ProtocolResourceTemplate?.UriTemplate,
+                            registration.ResourceUri) &&
+                        !_registrations.Any(candidate => ReferenceEquals(candidate.Resource, registeredResource)))
+                    {
+                        return ValidateOptionsResult.Fail(
+                            $"The app resource URI '{registration.ResourceUri}' is already registered by a lower-level resource. " +
+                            "Each app resource URI must be owned by WithAppTool.");
+                    }
+                }
+
+                if (options.ToolCollection is null ||
+                    !options.ToolCollection.TryGetPrimitive(toolName, out McpServerTool? selectedTool) ||
+                    !ReferenceEquals(selectedTool, registration.Tool))
+                {
+                    return ValidateOptionsResult.Fail(
+                        $"The app tool name '{toolName}' is already registered and does not resolve to this WithAppTool registration.");
+                }
+
+                if (selectedTool.ProtocolTool.Meta?["ui"] is not JsonObject uiMetadata ||
+                    uiMetadata["resourceUri"] is not JsonValue resourceUriValue ||
+                    !resourceUriValue.TryGetValue(out string? selectedResourceUri) ||
+                    !string.Equals(selectedResourceUri, registration.ResourceUri, StringComparison.Ordinal))
+                {
+                    return ValidateOptionsResult.Fail(
+                        $"The app tool '{toolName}' must link to the registered resource URI '{registration.ResourceUri}'.");
+                }
+
+                if (options.ResourceCollection is null ||
+                    !options.ResourceCollection.TryGetPrimitive(
+                        registration.ResourceUri,
+                        out McpServerResource? selectedResource) ||
+                    selectedResource?.ProtocolResourceTemplate is not { } resourceTemplate ||
+                    !_registrations.Any(candidate =>
+                        string.Equals(candidate.ResourceUri, registration.ResourceUri, StringComparison.Ordinal) &&
+                        ReferenceEquals(candidate.Resource, selectedResource)) ||
+                    !string.Equals(
+                        resourceTemplate.UriTemplate,
+                        registration.ResourceUri,
+                        StringComparison.Ordinal) ||
+                    !string.Equals(
+                        resourceTemplate.MimeType,
+                        McpApps.HtmlMimeType,
+                        StringComparison.Ordinal))
+                {
+                    return ValidateOptionsResult.Fail(
+                        $"The app tool '{toolName}' does not resolve to its HTML resource '{registration.ResourceUri}'.");
+                }
+            }
+
+            return ValidateOptionsResult.Success;
+        }
+
+        private static bool ResourceUrisEqual(string? first, string? second)
+        {
+            if (first is not null &&
+                second is not null &&
+                !first.Contains('{') &&
+                !second.Contains('{') &&
+                Uri.TryCreate(first, UriKind.Absolute, out Uri? firstUri) &&
+                Uri.TryCreate(second, UriKind.Absolute, out Uri? secondUri))
+            {
+                return firstUri == secondUri;
+            }
+
+            return string.Equals(first, second, StringComparison.Ordinal);
+        }
     }
 
     /// <summary>

--- a/src/ModelContextProtocol.Extensions.Apps/Server/McpAppsBuilderExtensions.cs
+++ b/src/ModelContextProtocol.Extensions.Apps/Server/McpAppsBuilderExtensions.cs
@@ -27,8 +27,8 @@ public static class McpAppsBuilderExtensions
     /// <paramref name="htmlFactory"/> is <see langword="null"/>.
     /// </exception>
     /// <exception cref="ArgumentException">
-    /// <paramref name="resourceUri"/> is not an absolute, non-templated <c>ui://</c> URI, or conflicts with the
-    /// tool's existing <c>_meta.ui.resourceUri</c> value.
+    /// <paramref name="resourceUri"/> is not an absolute, non-templated <c>ui://</c> URI, or the tool's existing
+    /// <c>_meta.ui.resourceUri</c> value is not a string that exactly matches it.
     /// </exception>
     /// <remarks>
     /// <para>
@@ -40,7 +40,7 @@ public static class McpAppsBuilderExtensions
     /// <para>
     /// Calling this method also enables <see cref="WithMcpApps(IMcpServerBuilder)"/> so the server advertises MCP Apps support.
     /// Existing <see cref="McpServerToolCreateOptions.Meta"/> UI metadata is preserved. If it already contains
-    /// <c>ui.resourceUri</c>, that value must exactly match <paramref name="resourceUri"/>.
+    /// <c>ui.resourceUri</c>, that value must be a string that exactly matches <paramref name="resourceUri"/>.
     /// </para>
     /// </remarks>
     /// <example>
@@ -95,8 +95,9 @@ public static class McpAppsBuilderExtensions
             throw new ArgumentException("The tool's _meta.ui value must be an object.", nameof(resourceUri));
         }
 
-        if (uiMetadata["resourceUri"] is { } resourceUriNode)
+        if (uiMetadata.ContainsKey("resourceUri"))
         {
+            JsonNode? resourceUriNode = uiMetadata["resourceUri"];
             if (resourceUriNode is not JsonValue resourceUriValue ||
                 !resourceUriValue.TryGetValue(out string? existingResourceUri))
             {

--- a/src/ModelContextProtocol.Extensions.Apps/Server/McpAppsBuilderExtensions.cs
+++ b/src/ModelContextProtocol.Extensions.Apps/Server/McpAppsBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
 
 namespace ModelContextProtocol.Extensions.Apps;
 
@@ -17,15 +18,18 @@ public static class McpAppsBuilderExtensions
     /// </summary>
     /// <param name="builder">The server builder.</param>
     /// <param name="method">The tool method to expose.</param>
-    /// <param name="resourceUri">The <c>ui://</c> resource URI associated with the tool.</param>
-    /// <param name="htmlFactory">A callback that returns the HTML for the UI resource.</param>
+    /// <param name="resourceUri">The absolute <c>ui://</c> resource URI associated with the tool.</param>
+    /// <param name="htmlFactory">A resource handler that returns the HTML, synchronously or asynchronously.</param>
     /// <param name="toolOptions">Optional options used when creating the tool.</param>
     /// <returns>The builder provided in <paramref name="builder"/>.</returns>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="builder"/>, <paramref name="method"/>, <paramref name="resourceUri"/>, or
     /// <paramref name="htmlFactory"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="ArgumentException"><paramref name="resourceUri"/> is empty or consists only of whitespace.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="resourceUri"/> is not an absolute, non-templated <c>ui://</c> URI, or conflicts with the
+    /// tool's existing <c>_meta.ui.resourceUri</c> value.
+    /// </exception>
     /// <remarks>
     /// <para>
     /// This is the compact equivalent of creating a tool with <see cref="McpServerTool.Create(Delegate, McpServerToolCreateOptions?)"/>,
@@ -35,8 +39,8 @@ public static class McpAppsBuilderExtensions
     /// </para>
     /// <para>
     /// Calling this method also enables <see cref="WithMcpApps(IMcpServerBuilder)"/> so the server advertises MCP Apps support.
-    /// Existing <see cref="McpServerToolCreateOptions.Meta"/> UI metadata is preserved, as it is with
-    /// <see cref="McpApps.SetAppUi(McpServerTool, McpUiToolMeta)"/>.
+    /// Existing <see cref="McpServerToolCreateOptions.Meta"/> UI metadata is preserved. If it already contains
+    /// <c>ui.resourceUri</c>, that value must exactly match <paramref name="resourceUri"/>.
     /// </para>
     /// </remarks>
     /// <example>
@@ -53,7 +57,7 @@ public static class McpAppsBuilderExtensions
         this IMcpServerBuilder builder,
         Delegate method,
         string resourceUri,
-        Func<string> htmlFactory,
+        Delegate htmlFactory,
         McpServerToolCreateOptions? toolOptions = null)
     {
 #if NET
@@ -67,14 +71,48 @@ public static class McpAppsBuilderExtensions
         if (resourceUri is null) throw new ArgumentNullException(nameof(resourceUri));
         if (htmlFactory is null) throw new ArgumentNullException(nameof(htmlFactory));
 #endif
-        if (string.IsNullOrWhiteSpace(resourceUri))
+        if (resourceUri.Contains('{') || resourceUri.Contains('}'))
         {
-            throw new ArgumentException("Value cannot be empty or composed entirely of whitespace.", nameof(resourceUri));
+            throw new ArgumentException("The resource URI must identify a concrete UI resource and cannot be a URI template.", nameof(resourceUri));
+        }
+
+        if (string.IsNullOrWhiteSpace(resourceUri) ||
+            !Uri.TryCreate(resourceUri, UriKind.Absolute, out Uri? parsedUri) ||
+            !parsedUri.IsWellFormedOriginalString() ||
+            !parsedUri.Scheme.Equals("ui", StringComparison.OrdinalIgnoreCase) ||
+            !resourceUri.StartsWith("ui://", StringComparison.OrdinalIgnoreCase) ||
+            (parsedUri.Host.Length == 0 && parsedUri.AbsolutePath.Length <= 1))
+        {
+            throw new ArgumentException("The resource URI must be a valid absolute URI using the ui:// scheme.", nameof(resourceUri));
         }
 
         var tool = McpApps.SetAppUi(
             McpServerTool.Create(method, toolOptions),
             new McpUiToolMeta { ResourceUri = resourceUri });
+
+        if (tool.ProtocolTool.Meta?["ui"] is not JsonObject uiMetadata)
+        {
+            throw new ArgumentException("The tool's _meta.ui value must be an object.", nameof(resourceUri));
+        }
+
+        if (uiMetadata["resourceUri"] is { } resourceUriNode)
+        {
+            if (resourceUriNode is not JsonValue resourceUriValue ||
+                !resourceUriValue.TryGetValue(out string? existingResourceUri))
+            {
+                throw new ArgumentException("The tool's _meta.ui.resourceUri value must be a string.", nameof(resourceUri));
+            }
+
+            if (!string.Equals(existingResourceUri, resourceUri, StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    $"The tool's UI resource URI '{existingResourceUri}' does not match the registered resource URI '{resourceUri}'.",
+                    nameof(resourceUri));
+            }
+        }
+
+        uiMetadata["resourceUri"] = resourceUri;
+
         var resource = McpServerResource.Create(
             htmlFactory,
             new McpServerResourceCreateOptions

--- a/tests/ModelContextProtocol.Tests/Server/McpAppsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpAppsTests.cs
@@ -503,20 +503,24 @@ public class McpAppsTests
     }
 
     [Fact]
-    public async Task WithAppTool_PreservesExplicitToolUiMetadata()
+    public async Task WithAppTool_PreservesMatchingToolUiMetadata()
     {
         var services = new ServiceCollection();
         services.AddMcpServer()
             .WithAppTool(
                 () => "result",
-                "ui://default/view.html",
+                "ui://explicit/view.html",
                 () => "<html />",
                 new McpServerToolCreateOptions
                 {
                     Name = "app_tool",
                     Meta = new JsonObject
                     {
-                        ["ui"] = new JsonObject { ["resourceUri"] = "ui://explicit/view.html" },
+                        ["ui"] = new JsonObject
+                        {
+                            ["resourceUri"] = "ui://explicit/view.html",
+                            ["visibility"] = new JsonArray(McpUiToolVisibility.App),
+                        },
                     },
                 });
 
@@ -524,10 +528,62 @@ public class McpAppsTests
         var tool = Assert.Single(serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value.ToolCollection!);
 
         Assert.Equal("ui://explicit/view.html", tool.ProtocolTool.Meta?["ui"]?["resourceUri"]?.GetValue<string>());
+        Assert.Equal(McpUiToolVisibility.App, tool.ProtocolTool.Meta?["ui"]?["visibility"]?[0]?.GetValue<string>());
     }
 
     [Fact]
-    public async Task WithAppTool_DuplicateResourceUriUsesExistingCollectionSemantics()
+    public async Task WithAppTool_AddsResourceUriToExistingToolUiMetadata()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer()
+            .WithAppTool(
+                () => "result",
+                "ui://weather/view.html",
+                () => "<html />",
+                new McpServerToolCreateOptions
+                {
+                    Name = "app_tool",
+                    Meta = new JsonObject
+                    {
+                        ["ui"] = new JsonObject
+                        {
+                            ["visibility"] = new JsonArray(McpUiToolVisibility.Model),
+                        },
+                    },
+                });
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var tool = Assert.Single(serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value.ToolCollection!);
+
+        Assert.Equal("ui://weather/view.html", tool.ProtocolTool.Meta?["ui"]?["resourceUri"]?.GetValue<string>());
+        Assert.Equal(McpUiToolVisibility.Model, tool.ProtocolTool.Meta?["ui"]?["visibility"]?[0]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void WithAppTool_RejectsConflictingToolUiMetadata()
+    {
+        var builder = new ServiceCollection().AddMcpServer();
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.WithAppTool(
+            () => "result",
+            "ui://weather/view.html",
+            () => "<html />",
+            new McpServerToolCreateOptions
+            {
+                Name = "app_tool",
+                Meta = new JsonObject
+                {
+                    ["ui"] = new JsonObject { ["resourceUri"] = "ui://other/view.html" },
+                },
+            }));
+
+        Assert.Equal("resourceUri", exception.ParamName);
+        Assert.Contains("ui://other/view.html", exception.Message);
+        Assert.Contains("ui://weather/view.html", exception.Message);
+    }
+
+    [Fact]
+    public async Task WithAppTool_DuplicateResourceUriKeepsSingleResource()
     {
         var services = new ServiceCollection();
         services.AddMcpServer()
@@ -551,7 +607,25 @@ public class McpAppsTests
         Assert.Throws<ArgumentNullException>(() => builder.WithAppTool(null!, "ui://test", htmlFactory));
         Assert.Throws<ArgumentNullException>(() => builder.WithAppTool(method, null!, htmlFactory));
         Assert.Throws<ArgumentNullException>(() => builder.WithAppTool(method, "ui://test", null!));
-        Assert.Throws<ArgumentException>(() => builder.WithAppTool(method, "  ", htmlFactory));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData("weather/view.html")]
+    [InlineData("https://weather.example/view.html")]
+    [InlineData("ui:/weather/view.html")]
+    [InlineData("ui://")]
+    [InlineData("ui://weather/{view}.html")]
+    public void WithAppTool_RejectsInvalidResourceUri(string resourceUri)
+    {
+        var builder = new ServiceCollection().AddMcpServer();
+        Delegate method = () => "result";
+        Func<string> htmlFactory = () => "html";
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.WithAppTool(method, resourceUri, htmlFactory));
+
+        Assert.Equal("resourceUri", exception.ParamName);
     }
 
     #endregion

--- a/tests/ModelContextProtocol.Tests/Server/McpAppsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpAppsTests.cs
@@ -577,7 +577,7 @@ public class McpAppsTests
                 },
             }));
 
-        Assert.Equal("resourceUri", exception.ParamName);
+        Assert.Equal("toolOptions", exception.ParamName);
         Assert.Contains("must be a string", exception.Message);
     }
 
@@ -599,9 +599,157 @@ public class McpAppsTests
                 },
             }));
 
-        Assert.Equal("resourceUri", exception.ParamName);
+        Assert.Equal("toolOptions", exception.ParamName);
         Assert.Contains("ui://other/view.html", exception.Message);
         Assert.Contains("ui://weather/view.html", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WithAppTool_RejectsLowLevelResourceCollision(bool registerLowLevelResourceFirst)
+    {
+        const string ResourceUri = "ui://shared/view.html";
+        var services = new ServiceCollection();
+        var builder = services.AddMcpServer();
+        var lowLevelResource = McpServerResource.Create(
+            () => "low-level",
+            new() { UriTemplate = ResourceUri, MimeType = "text/plain" });
+
+        if (registerLowLevelResourceFirst)
+        {
+            builder.WithResources([lowLevelResource]);
+        }
+
+        builder.WithAppTool(
+            () => "app",
+            ResourceUri,
+            () => "<html>app</html>",
+            new() { Name = "app_tool" });
+
+        if (!registerLowLevelResourceFirst)
+        {
+            builder.WithResources([lowLevelResource]);
+        }
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value);
+
+        Assert.Contains(ResourceUri, exception.Message);
+        Assert.Contains("already registered", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("ui://weather/view.html", "ui://WEATHER/view.html")]
+    [InlineData("ui://weather/literal%7Bview%7D.html", "ui://weather/literal%7bview%7d.html")]
+    [InlineData("ui://weather/a/../view.html", "ui://weather/view.html")]
+    [InlineData("ui://weather/view.html#one", "ui://weather/view.html#two")]
+    [InlineData("ui://weather/%76iew.html", "ui://weather/view.html")]
+    public async Task WithAppTool_RejectsEquivalentResourceUrisWithDifferentSpelling(
+        string firstResourceUri,
+        string secondResourceUri)
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer()
+            .WithAppTool(() => "first", firstResourceUri, () => "first", new() { Name = "first" })
+            .WithAppTool(() => "second", secondResourceUri, () => "second", new() { Name = "second" });
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value);
+
+        Assert.Contains(firstResourceUri, exception.Message);
+        Assert.Contains(secondResourceUri, exception.Message);
+        Assert.Contains("same resource", exception.Message);
+    }
+
+    [Fact]
+    public async Task WithAppTool_AllowsDistinctResourceQueries()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer()
+            .WithAppTool(() => "first", "ui://weather/view.html?mode=compact", () => "first", new() { Name = "first" })
+            .WithAppTool(() => "second", "ui://weather/view.html?mode=full", () => "second", new() { Name = "second" });
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
+
+        Assert.Equal(2, options.ToolCollection!.Count);
+        Assert.Equal(2, options.ResourceCollection!.Count);
+    }
+
+    [Fact]
+    public async Task WithAppTool_RejectsPostConfiguredResourceLinkMismatch()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer()
+            .WithAppTool(
+                () => "result",
+                "ui://weather/view.html",
+                () => "<html />",
+                new() { Name = "app_tool" });
+        services.PostConfigure<McpServerOptions>(options =>
+        {
+            McpServerTool tool = Assert.Single(options.ToolCollection!);
+            tool.ProtocolTool.Meta!["ui"]!["resourceUri"] = "ui://other/view.html";
+        });
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value);
+
+        Assert.Contains("app_tool", exception.Message);
+        Assert.Contains("ui://weather/view.html", exception.Message);
+    }
+
+    [Fact]
+    public async Task WithAppTool_RejectsDuplicateToolName()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer()
+            .WithAppTool(() => "first", "ui://first/view.html", () => "first", new() { Name = "shared" })
+            .WithAppTool(() => "second", "ui://second/view.html", () => "second", new() { Name = "shared" });
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value);
+
+        Assert.Contains("shared", exception.Message);
+        Assert.Contains("already registered", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WithAppTool_RejectsLowLevelToolCollision(bool registerLowLevelToolFirst)
+    {
+        var services = new ServiceCollection();
+        var builder = services.AddMcpServer();
+        var lowLevelTool = McpServerTool.Create(() => "low-level", new() { Name = "shared" });
+
+        if (registerLowLevelToolFirst)
+        {
+            builder.WithTools([lowLevelTool]);
+        }
+
+        builder.WithAppTool(
+            () => "app",
+            "ui://shared/view.html",
+            () => "<html>app</html>",
+            new() { Name = "shared" });
+
+        if (!registerLowLevelToolFirst)
+        {
+            builder.WithTools([lowLevelTool]);
+        }
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value);
+
+        Assert.Contains("shared", exception.Message);
+        Assert.Contains("already registered", exception.Message);
     }
 
     [Fact]
@@ -629,6 +777,36 @@ public class McpAppsTests
         Assert.Throws<ArgumentNullException>(() => builder.WithAppTool(null!, "ui://test", htmlFactory));
         Assert.Throws<ArgumentNullException>(() => builder.WithAppTool(method, null!, htmlFactory));
         Assert.Throws<ArgumentNullException>(() => builder.WithAppTool(method, "ui://test", null!));
+    }
+
+    [Fact]
+    public void WithAppTool_RejectsHtmlFactoryWithUnsupportedReturnType()
+    {
+        var builder = new ServiceCollection().AddMcpServer();
+        Func<ReadResourceResult> htmlFactory = () => new();
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.WithAppTool(
+            () => "result",
+            "ui://weather/view.html",
+            htmlFactory));
+
+        Assert.Equal("htmlFactory", exception.ParamName);
+        Assert.Contains("string", exception.Message);
+    }
+
+    [Fact]
+    public void WithAppTool_RejectsHtmlFactoryWithNonCancellationParameter()
+    {
+        var builder = new ServiceCollection().AddMcpServer();
+        Func<string, string> htmlFactory = value => value;
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.WithAppTool(
+            () => "result",
+            "ui://weather/view.html",
+            htmlFactory));
+
+        Assert.Equal("htmlFactory", exception.ParamName);
+        Assert.Contains(nameof(CancellationToken), exception.Message);
     }
 
     [Theory]

--- a/tests/ModelContextProtocol.Tests/Server/McpAppsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpAppsTests.cs
@@ -560,6 +560,28 @@ public class McpAppsTests
     }
 
     [Fact]
+    public void WithAppTool_RejectsNullToolUiResourceUri()
+    {
+        var builder = new ServiceCollection().AddMcpServer();
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.WithAppTool(
+            () => "result",
+            "ui://weather/view.html",
+            () => "<html />",
+            new McpServerToolCreateOptions
+            {
+                Name = "app_tool",
+                Meta = new JsonObject
+                {
+                    ["ui"] = new JsonObject { ["resourceUri"] = null },
+                },
+            }));
+
+        Assert.Equal("resourceUri", exception.ParamName);
+        Assert.Contains("must be a string", exception.Message);
+    }
+
+    [Fact]
     public void WithAppTool_RejectsConflictingToolUiMetadata()
     {
         var builder = new ServiceCollection().AddMcpServer();
@@ -626,6 +648,29 @@ public class McpAppsTests
         var exception = Assert.Throws<ArgumentException>(() => builder.WithAppTool(method, resourceUri, htmlFactory));
 
         Assert.Equal("resourceUri", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task WithAppTool_AcceptsEncodedBracesAsLiteralUriContent()
+    {
+        const string ResourceUri = "ui://weather/literal%7Bview%7D.html";
+        var services = new ServiceCollection();
+        services.AddMcpServer()
+            .WithAppTool(
+                () => "result",
+                ResourceUri,
+                () => "<html />",
+                new() { Name = "app_tool" });
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
+        var tool = Assert.Single(options.ToolCollection!);
+        var resource = Assert.Single(options.ResourceCollection!);
+
+        Assert.Equal(ResourceUri, tool.ProtocolTool.Meta?["ui"]?["resourceUri"]?.GetValue<string>());
+        Assert.Equal(ResourceUri, resource.ProtocolResourceTemplate.UriTemplate);
+        Assert.False(resource.IsTemplated);
+        Assert.True(resource.IsMatch(ResourceUri));
     }
 
     #endregion

--- a/tests/ModelContextProtocol.Tests/Server/McpAppsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpAppsTests.cs
@@ -470,6 +470,92 @@ public class McpAppsTests
 
     #endregion
 
+    #region WithAppTool
+
+    [Fact]
+    public async Task WithAppTool_RegistersLinkedToolAndHtmlResource()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer()
+            .WithAppTool(
+                (string location) => $"Weather for {location}",
+                "ui://weather/view.html",
+                () => "<html>weather</html>",
+                new McpServerToolCreateOptions
+                {
+                    Name = "weather",
+                    Description = "Gets weather",
+                    Meta = new JsonObject { ["custom"] = "value" },
+                });
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
+        var tool = Assert.Single(options.ToolCollection!);
+        var resource = Assert.Single(options.ResourceCollection!);
+
+        Assert.Equal("weather", tool.ProtocolTool.Name);
+        Assert.Equal("Gets weather", tool.ProtocolTool.Description);
+        Assert.Equal("value", tool.ProtocolTool.Meta?["custom"]?.GetValue<string>());
+        Assert.Equal("ui://weather/view.html", tool.ProtocolTool.Meta?["ui"]?["resourceUri"]?.GetValue<string>());
+        Assert.Equal("ui://weather/view.html", resource.ProtocolResourceTemplate.UriTemplate);
+        Assert.Equal(McpApps.HtmlMimeType, resource.ProtocolResourceTemplate.MimeType);
+        Assert.Contains(McpApps.ExtensionId, options.Capabilities!.Extensions!.Keys);
+    }
+
+    [Fact]
+    public async Task WithAppTool_PreservesExplicitToolUiMetadata()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer()
+            .WithAppTool(
+                () => "result",
+                "ui://default/view.html",
+                () => "<html />",
+                new McpServerToolCreateOptions
+                {
+                    Name = "app_tool",
+                    Meta = new JsonObject
+                    {
+                        ["ui"] = new JsonObject { ["resourceUri"] = "ui://explicit/view.html" },
+                    },
+                });
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var tool = Assert.Single(serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value.ToolCollection!);
+
+        Assert.Equal("ui://explicit/view.html", tool.ProtocolTool.Meta?["ui"]?["resourceUri"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task WithAppTool_DuplicateResourceUriUsesExistingCollectionSemantics()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer()
+            .WithAppTool(() => "first", "ui://shared/view.html", () => "first", new() { Name = "first" })
+            .WithAppTool(() => "second", "ui://shared/view.html", () => "second", new() { Name = "second" });
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
+
+        Assert.Equal(2, options.ToolCollection!.Count);
+        Assert.Single(options.ResourceCollection!);
+    }
+
+    [Fact]
+    public void WithAppTool_RejectsMissingConfiguration()
+    {
+        var builder = new ServiceCollection().AddMcpServer();
+        Func<string> htmlFactory = () => "html";
+        Delegate method = () => "result";
+
+        Assert.Throws<ArgumentNullException>(() => builder.WithAppTool(null!, "ui://test", htmlFactory));
+        Assert.Throws<ArgumentNullException>(() => builder.WithAppTool(method, null!, htmlFactory));
+        Assert.Throws<ArgumentNullException>(() => builder.WithAppTool(method, "ui://test", null!));
+        Assert.Throws<ArgumentException>(() => builder.WithAppTool(method, "  ", htmlFactory));
+    }
+
+    #endregion
+
     #region Test helper types
 
     [McpServerToolType]

--- a/tests/ModelContextProtocol.Tests/Server/McpAppsWithAppToolIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpAppsWithAppToolIntegrationTests.cs
@@ -6,6 +6,7 @@ using ModelContextProtocol.Extensions.Apps;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
+using System.Text.Json.Nodes;
 
 namespace ModelContextProtocol.Tests.Server;
 
@@ -17,6 +18,8 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
 {
     private const string AppResourceUri = "ui://weather/view.html";
     private const string AppHtml = "<html><body>weather</body></html>";
+    private const string ValueTaskResourceUri = "ui://weather/details.html";
+    private const string ValueTaskHtml = "<html><body>weather details</body></html>";
 
     public McpAppsWithAppToolIntegrationTests(ITestOutputHelper testOutputHelper)
         : base(testOutputHelper)
@@ -26,8 +29,23 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
     protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
     {
         mcpServerBuilder
-            .WithAppTool(AppTools.GetWeather, AppResourceUri, AppTools.GetHtmlAsync)
-            .WithAppTool(AppTools.GetWeatherSummary, AppResourceUri, static () => "<html><body>ignored</body></html>");
+            .WithAppTool(
+                AppTools.GetWeather,
+                AppResourceUri,
+                AppTools.GetHtmlAsync,
+                new McpServerToolCreateOptions
+                {
+                    Meta = new JsonObject
+                    {
+                        ["ui"] = new JsonObject
+                        {
+                            ["resourceUri"] = AppResourceUri,
+                            ["visibility"] = new JsonArray(McpUiToolVisibility.App),
+                        },
+                    },
+                })
+            .WithAppTool(AppTools.GetWeatherSummary, AppResourceUri, static () => "<html><body>ignored</body></html>")
+            .WithAppTool(AppTools.GetWeatherDetails, ValueTaskResourceUri, AppTools.GetValueTaskHtmlAsync);
     }
 
     [Fact]
@@ -36,12 +54,13 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
         await using McpClient client = await CreateMcpClientForServer();
 
         var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Equal(2, tools.Count);
+        Assert.Equal(3, tools.Count);
         var tool = Assert.Single(tools, t => t.Name == "weather");
 
         Assert.Equal("weather", tool.Name);
         Assert.Equal("Gets weather for a location", tool.Description);
         Assert.Equal("ui://weather/view.html", tool.ProtocolTool.Meta?["ui"]?["resourceUri"]?.GetValue<string>());
+        Assert.Equal(McpUiToolVisibility.App, tool.ProtocolTool.Meta?["ui"]?["visibility"]?[0]?.GetValue<string>());
         Assert.Contains("location", tool.ProtocolTool.InputSchema.GetProperty("properties").EnumerateObject().Select(p => p.Name));
 
         var result = await client.CallToolAsync(
@@ -59,13 +78,16 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
         await using McpClient client = await CreateMcpClientForServer();
 
         var resources = await client.ListResourcesAsync(cancellationToken: TestContext.Current.CancellationToken);
-        var resource = Assert.Single(resources);
+        Assert.Equal(2, resources.Count);
+        var resource = Assert.Single(resources, resource => resource.Uri == AppResourceUri);
         Assert.Equal(AppResourceUri, resource.Uri);
         Assert.Equal(McpApps.HtmlMimeType, resource.MimeType);
 
         var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
-        Assert.All(tools, tool =>
-            Assert.Equal(resource.Uri, tool.ProtocolTool.Meta?["ui"]?["resourceUri"]?.GetValue<string>()));
+        Assert.Equal(
+            2,
+            tools.Count(tool =>
+                tool.ProtocolTool.Meta?["ui"]?["resourceUri"]?.GetValue<string>() == resource.Uri));
 
         var result = await client.ReadResourceAsync(
             resource.Uri,
@@ -75,6 +97,21 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
         Assert.Equal(resource.Uri, content.Uri);
         Assert.Equal(McpApps.HtmlMimeType, content.MimeType);
         Assert.Equal(AppHtml, content.Text);
+    }
+
+    [Fact]
+    public async Task WithAppTool_RoundTripsValueTaskHtmlHandler()
+    {
+        await using McpClient client = await CreateMcpClientForServer();
+
+        var result = await client.ReadResourceAsync(
+            ValueTaskResourceUri,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var content = Assert.IsType<TextResourceContents>(Assert.Single(result.Contents));
+        Assert.Equal(ValueTaskResourceUri, content.Uri);
+        Assert.Equal(McpApps.HtmlMimeType, content.MimeType);
+        Assert.Equal(ValueTaskHtml, content.Text);
     }
 
     private static class AppTools
@@ -87,10 +124,20 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
         [Description("Gets a weather summary")]
         public static string GetWeatherSummary() => "Weather summary";
 
+        [McpServerTool(Name = "weather_details")]
+        [Description("Gets weather details")]
+        public static string GetWeatherDetails() => "Weather details";
+
         public static Task<string> GetHtmlAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(AppHtml);
+        }
+
+        public static ValueTask<string> GetValueTaskHtmlAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return new(ValueTaskHtml);
         }
     }
 }

--- a/tests/ModelContextProtocol.Tests/Server/McpAppsWithAppToolIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpAppsWithAppToolIntegrationTests.cs
@@ -1,0 +1,79 @@
+#pragma warning disable MCPEXP003
+
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Extensions.Apps;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace ModelContextProtocol.Tests.Server;
+
+/// <summary>
+/// Verifies that <see cref="McpAppsBuilderExtensions.WithAppTool"/> preserves the
+/// tool and resource behavior across a client/server round trip.
+/// </summary>
+public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
+{
+    public McpAppsWithAppToolIntegrationTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
+    {
+        mcpServerBuilder.WithAppTool(
+            AppTools.GetWeather,
+            "ui://weather/view.html",
+            static () => "<html><body>weather</body></html>");
+    }
+
+    [Fact]
+    public async Task WithAppTool_RoundTripsToolMetadataAndParameters()
+    {
+        await using McpClient client = await CreateMcpClientForServer();
+
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var tool = Assert.Single(tools);
+
+        Assert.Equal("weather", tool.Name);
+        Assert.Equal("Gets weather for a location", tool.Description);
+        Assert.Equal("ui://weather/view.html", tool.ProtocolTool.Meta?["ui"]?["resourceUri"]?.GetValue<string>());
+        Assert.Contains("location", tool.ProtocolTool.InputSchema.GetProperty("properties").EnumerateObject().Select(p => p.Name));
+
+        var result = await client.CallToolAsync(
+            "weather",
+            new Dictionary<string, object?> { ["location"] = "Paris" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content));
+        Assert.Equal("Weather for Paris", text.Text);
+    }
+
+    [Fact]
+    public async Task WithAppTool_UsesAppMimeTypeAndFactoryContent()
+    {
+        await using McpClient client = await CreateMcpClientForServer();
+
+        var resources = await client.ListResourcesAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var resource = Assert.Single(resources);
+        Assert.Equal("ui://weather/view.html", resource.Uri);
+        Assert.Equal(McpApps.HtmlMimeType, resource.MimeType);
+
+        var result = await client.ReadResourceAsync(
+            resource.Uri,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var content = Assert.IsType<TextResourceContents>(Assert.Single(result.Contents));
+        Assert.Equal(resource.Uri, content.Uri);
+        Assert.Equal(McpApps.HtmlMimeType, content.MimeType);
+        Assert.Equal("<html><body>weather</body></html>", content.Text);
+    }
+
+    private static class AppTools
+    {
+        [McpServerTool(Name = "weather")]
+        [Description("Gets weather for a location")]
+        public static string GetWeather(string location) => $"Weather for {location}";
+    }
+}

--- a/tests/ModelContextProtocol.Tests/Server/McpAppsWithAppToolIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpAppsWithAppToolIntegrationTests.cs
@@ -15,6 +15,9 @@ namespace ModelContextProtocol.Tests.Server;
 /// </summary>
 public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
 {
+    private const string AppResourceUri = "ui://weather/view.html";
+    private const string AppHtml = "<html><body>weather</body></html>";
+
     public McpAppsWithAppToolIntegrationTests(ITestOutputHelper testOutputHelper)
         : base(testOutputHelper)
     {
@@ -22,10 +25,9 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
 
     protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
     {
-        mcpServerBuilder.WithAppTool(
-            AppTools.GetWeather,
-            "ui://weather/view.html",
-            static () => "<html><body>weather</body></html>");
+        mcpServerBuilder
+            .WithAppTool(AppTools.GetWeather, AppResourceUri, AppTools.GetHtmlAsync)
+            .WithAppTool(AppTools.GetWeatherSummary, AppResourceUri, static () => "<html><body>ignored</body></html>");
     }
 
     [Fact]
@@ -34,7 +36,8 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
         await using McpClient client = await CreateMcpClientForServer();
 
         var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
-        var tool = Assert.Single(tools);
+        Assert.Equal(2, tools.Count);
+        var tool = Assert.Single(tools, t => t.Name == "weather");
 
         Assert.Equal("weather", tool.Name);
         Assert.Equal("Gets weather for a location", tool.Description);
@@ -51,14 +54,18 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
     }
 
     [Fact]
-    public async Task WithAppTool_UsesAppMimeTypeAndFactoryContent()
+    public async Task WithAppTool_DuplicateResourceUriUsesFirstHtmlHandler()
     {
         await using McpClient client = await CreateMcpClientForServer();
 
         var resources = await client.ListResourcesAsync(cancellationToken: TestContext.Current.CancellationToken);
         var resource = Assert.Single(resources);
-        Assert.Equal("ui://weather/view.html", resource.Uri);
+        Assert.Equal(AppResourceUri, resource.Uri);
         Assert.Equal(McpApps.HtmlMimeType, resource.MimeType);
+
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.All(tools, tool =>
+            Assert.Equal(resource.Uri, tool.ProtocolTool.Meta?["ui"]?["resourceUri"]?.GetValue<string>()));
 
         var result = await client.ReadResourceAsync(
             resource.Uri,
@@ -67,7 +74,7 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
         var content = Assert.IsType<TextResourceContents>(Assert.Single(result.Contents));
         Assert.Equal(resource.Uri, content.Uri);
         Assert.Equal(McpApps.HtmlMimeType, content.MimeType);
-        Assert.Equal("<html><body>weather</body></html>", content.Text);
+        Assert.Equal(AppHtml, content.Text);
     }
 
     private static class AppTools
@@ -75,5 +82,15 @@ public sealed class McpAppsWithAppToolIntegrationTests : ClientServerTestBase
         [McpServerTool(Name = "weather")]
         [Description("Gets weather for a location")]
         public static string GetWeather(string location) => $"Weather for {location}";
+
+        [McpServerTool(Name = "weather_summary")]
+        [Description("Gets a weather summary")]
+        public static string GetWeatherSummary() => "Weather summary";
+
+        public static Task<string> GetHtmlAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(AppHtml);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1607

## Summary

Add an ergonomic `WithAppTool` helper for registering an MCP Apps tool and its linked HTML resource in one call.

The helper composes the existing tool, resource, and MCP Apps registration paths while keeping the lower-level `WithTools` and `WithResources` APIs unchanged.

## Behavior

- Requires a concrete absolute `ui://` resource URI.
- Rejects malformed URIs and URI templates.
- Uses `resourceUri` as the authoritative tool/resource link.
- Rejects conflicting existing `_meta.ui.resourceUri` metadata.
- Preserves other existing UI metadata.
- Registers resources with `text/html;profile=mcp-app`.
- Supports synchronous and asynchronous HTML factories returning:
  - `string`
  - `Task<string>`
  - `ValueTask<string>`
- HTML factories may optionally accept a single `CancellationToken`.
- Duplicate registrations using the exact same URI remain supported; the first registered HTML handler is used deterministically.
- Conflicting tool names, equivalent URI spellings, and collisions with lower-level resource registrations are rejected during options validation.

## Testing

- MCP Apps focused tests: **65 passed, 0 failed**
- Apps Release builds for `net10.0`, `net9.0`, `net8.0`, and `netstandard2.0`: **0 warnings, 0 errors**
- Scoped whitespace format verification: **passed**
- Full non-Manual suite: 2,385 passed, 4 skipped, 0 failed。

GitHub Actions are currently waiting for maintainer approval (`action_required`), so no hosted CI result is available yet.