### PR TITLE
Gate application result fields by protocol version

### DIFF
--- a/src/ModelContextProtocol.Core/McpSessionHandler.cs
+++ b/src/ModelContextProtocol.Core/McpSessionHandler.cs
@@ -533,16 +533,40 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
         }
 
         RequestHandlerResult handlerResult = await handler(request, cancellationToken).ConfigureAwait(false);
-        JsonNode? result = _requestHandlers.PrepareForEmission(request, handlerResult);
-
-        await SendMessageAsync(new JsonRpcResponse
+        var response = new JsonRpcResponse
         {
             Id = request.Id,
-            Result = result,
+            Result = handlerResult.Json,
             Context = request.Context,
-        }, cancellationToken).ConfigureAwait(false);
+        };
 
-        return result;
+        Func<JsonRpcMessage, JsonRpcMessage>? prepareForEmission = handlerResult.IsProtocolResult ?
+            message => PrepareResponseForEmission(request, handlerResult, message) :
+            null;
+        await SendMessageAsync(response, prepareForEmission, cancellationToken).ConfigureAwait(false);
+
+        return handlerResult.Json;
+    }
+
+    private JsonRpcMessage PrepareResponseForEmission(
+        JsonRpcRequest request,
+        RequestHandlerResult handlerResult,
+        JsonRpcMessage message)
+    {
+        if (message is not JsonRpcResponse response || response.Id != request.Id)
+        {
+            return message;
+        }
+
+        return new JsonRpcResponse
+        {
+            JsonRpc = response.JsonRpc,
+            Id = response.Id,
+            Result = _requestHandlers.PrepareForEmission(
+                request,
+                handlerResult with { Json = response.Result?.DeepClone() }),
+            Context = response.Context,
+        };
     }
 
     /// <summary>
@@ -805,7 +829,13 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
         }
     }
 
-    public async Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
+    public Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default) =>
+        SendMessageAsync(message, prepareForEmission: null, cancellationToken);
+
+    private async Task SendMessageAsync(
+        JsonRpcMessage message,
+        Func<JsonRpcMessage, JsonRpcMessage>? prepareForEmission,
+        CancellationToken cancellationToken)
     {
         Throw.IfNull(message);
 
@@ -844,7 +874,7 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
                 AddTags(ref tags, activity, message, method, target);
             }
 
-            await SendToRelatedTransportAsync(message, cancellationToken).ConfigureAwait(false);
+            await SendToRelatedTransportAsync(message, cancellationToken, prepareForEmission).ConfigureAwait(false);
 
             // If the sent notification was a cancellation notification, cancel the pending request's await, as either the
             // server won't be sending a response, or per the specification, the response should be ignored. There are inherent
@@ -870,14 +900,19 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
     // The JsonRpcMessage should be sent over the RelatedTransport if set. This is used to support the
     // Streamable HTTP transport where the specification states that the server SHOULD include JSON-RPC responses in
     // the HTTP response body for the POST request containing the corresponding JSON-RPC request.
-    private Task SendToRelatedTransportAsync(JsonRpcMessage message, CancellationToken cancellationToken)
+    private Task SendToRelatedTransportAsync(
+        JsonRpcMessage message,
+        CancellationToken cancellationToken,
+        Func<JsonRpcMessage, JsonRpcMessage>? prepareForEmission = null)
         => _outgoingMessageFilter((msg, ct) =>
         {
-            if (msg is JsonRpcRequest request)
+            JsonRpcMessage messageToSend = prepareForEmission?.Invoke(msg) ?? msg;
+
+            if (messageToSend is JsonRpcRequest request)
             {
                 if (_logger.IsEnabled(LogLevel.Trace))
                 {
-                    LogSendingRequestSensitive(EndpointName, request.Method, JsonSerializer.Serialize(msg, McpJsonUtilities.JsonContext.Default.JsonRpcMessage));
+                    LogSendingRequestSensitive(EndpointName, request.Method, JsonSerializer.Serialize(messageToSend, McpJsonUtilities.JsonContext.Default.JsonRpcMessage));
                 }
                 else
                 {
@@ -888,7 +923,7 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
             {
                 if (_logger.IsEnabled(LogLevel.Trace))
                 {
-                    LogSendingMessageSensitive(EndpointName, JsonSerializer.Serialize(msg, McpJsonUtilities.JsonContext.Default.JsonRpcMessage));
+                    LogSendingMessageSensitive(EndpointName, JsonSerializer.Serialize(messageToSend, McpJsonUtilities.JsonContext.Default.JsonRpcMessage));
                 }
                 else
                 {
@@ -896,7 +931,7 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
                 }
             }
 
-            return (msg.Context?.RelatedTransport ?? _transport).SendMessageAsync(msg, ct);
+            return (messageToSend.Context?.RelatedTransport ?? _transport).SendMessageAsync(messageToSend, ct);
         })(message, cancellationToken);
 
     private static CancelledNotificationParams? GetCancelledNotificationParams(JsonNode? notificationParams)

--- a/src/ModelContextProtocol.Core/McpSessionHandler.cs
+++ b/src/ModelContextProtocol.Core/McpSessionHandler.cs
@@ -532,7 +532,8 @@ internal sealed partial class McpSessionHandler : IAsyncDisposable
             throw new McpProtocolException($"Method '{request.Method}' is not available.", McpErrorCode.MethodNotFound);
         }
 
-        JsonNode? result = await handler(request, cancellationToken).ConfigureAwait(false);
+        RequestHandlerResult handlerResult = await handler(request, cancellationToken).ConfigureAwait(false);
+        JsonNode? result = _requestHandlers.PrepareForEmission(request, handlerResult);
 
         await SendMessageAsync(new JsonRpcResponse
         {

--- a/src/ModelContextProtocol.Core/RequestHandlers.cs
+++ b/src/ModelContextProtocol.Core/RequestHandlers.cs
@@ -5,8 +5,18 @@ using System.Text.Json.Serialization.Metadata;
 
 namespace ModelContextProtocol;
 
-internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, CancellationToken, Task<JsonNode?>>>
+internal readonly record struct RequestHandlerResult(JsonNode? Json, bool IsProtocolResult = false, bool IsCacheable = false);
+
+internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, CancellationToken, Task<RequestHandlerResult>>>
 {
+    private readonly Func<JsonRpcRequest, RequestHandlerResult, JsonNode?>? _prepareResponseForEmission;
+
+    public RequestHandlers(Func<JsonRpcRequest, RequestHandlerResult, JsonNode?>? prepareResponseForEmission = null) =>
+        _prepareResponseForEmission = prepareResponseForEmission;
+
+    public JsonNode? PrepareForEmission(JsonRpcRequest request, RequestHandlerResult result) =>
+        _prepareResponseForEmission?.Invoke(request, result) ?? result.Json;
+
     /// <summary>
     /// Registers a handler for incoming requests of a specific method in the MCP protocol.
     /// </summary>
@@ -41,8 +51,9 @@ internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, 
         this[method] = async (request, cancellationToken) =>
         {
             TParams typedRequest = JsonSerializer.Deserialize(request.Params, requestTypeInfo)!;
-            object? result = await handler(typedRequest, request, cancellationToken).ConfigureAwait(false);
-            return JsonSerializer.SerializeToNode(result, responseTypeInfo);
+            TResult result = await handler(typedRequest, request, cancellationToken).ConfigureAwait(false);
+            JsonNode? resultNode = JsonSerializer.SerializeToNode(result, responseTypeInfo);
+            return new(resultNode, result is Result, result is ICacheableResult);
         };
     }
 
@@ -70,10 +81,14 @@ internal sealed class RequestHandlers : Dictionary<string, Func<JsonRpcRequest, 
 
             if (augmented.IsAlternate)
             {
-                return JsonSerializer.SerializeToNode(augmented.Alternate!, augmented.AlternateTypeInfo!);
+                var result = augmented.Alternate!;
+                JsonNode? resultNode = JsonSerializer.SerializeToNode(result, augmented.AlternateTypeInfo!);
+                return new(resultNode, IsProtocolResult: true, IsCacheable: result is ICacheableResult);
             }
 
-            return JsonSerializer.SerializeToNode(augmented.Result!, responseTypeInfo);
+            var immediateResult = augmented.Result!;
+            JsonNode? immediateResultNode = JsonSerializer.SerializeToNode(immediateResult, responseTypeInfo);
+            return new(immediateResultNode, IsProtocolResult: true, IsCacheable: immediateResult is ICacheableResult);
         };
     }
 #pragma warning restore MCPEXP002

--- a/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
@@ -33,6 +33,7 @@ internal sealed partial class McpServerImpl : McpServer
     private readonly SemaphoreSlim _disposeLock = new(1, 1);
     private readonly ConcurrentDictionary<string, MrtrContinuation> _mrtrContinuations = new();
     private readonly ConcurrentDictionary<RequestId, MrtrContext> _mrtrContextsByRequestId = new();
+    private readonly ConcurrentDictionary<string, byte> _protocolIncompatibleResultFieldsWarnedMethods = new();
     private static readonly string[] s_perRequestMetadataKeys =
     [
         MetaKeys.ProtocolVersion,
@@ -1882,7 +1883,8 @@ internal sealed partial class McpServerImpl : McpServer
             }
         }
 
-        if (strippedFields is not null)
+        if (strippedFields is not null &&
+            _protocolIncompatibleResultFieldsWarnedMethods.TryAdd(request.Method, 0))
         {
             ProtocolIncompatibleResultFieldsOmitted(
                 _endpointName,

--- a/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
+++ b/src/ModelContextProtocol.Core/Server/McpServerImpl.cs
@@ -94,7 +94,7 @@ internal sealed partial class McpServerImpl : McpServer
         UpdateEndpointNameWithClientInfo();
 
         _notificationHandlers = new();
-        _requestHandlers = [];
+        _requestHandlers = new(PrepareResultForEmission);
 
         // Configure all request handlers based on the supplied options.
         ServerCapabilities = new();
@@ -1190,10 +1190,8 @@ internal sealed partial class McpServerImpl : McpServer
 #pragma warning restore MCPEXP002
     }
 
-    private void SetRawHandler(string method, Func<JsonRpcRequest, CancellationToken, ValueTask<JsonNode?>> handler)
-    {
-        _requestHandlers[method] = (request, ct) => handler(request, ct).AsTask();
-    }
+    private void SetRawHandler(string method, Func<JsonRpcRequest, CancellationToken, ValueTask<JsonNode?>> handler) =>
+        _requestHandlers[method] = async (request, ct) => new(await handler(request, ct).ConfigureAwait(false));
 
     private void ConfigureResources(McpServerOptions options)
     {
@@ -1851,57 +1849,57 @@ internal sealed partial class McpServerImpl : McpServer
         return server;
     }
 
+    private JsonNode? PrepareResultForEmission(JsonRpcRequest request, RequestHandlerResult result)
+    {
+        if (!result.IsProtocolResult || result.Json is not JsonObject resultObject)
+        {
+            return result.Json;
+        }
+
+        if (IsJuly2026OrLaterProtocolRequest(request))
+        {
+            resultObject["resultType"] ??= "complete";
+            if (result.IsCacheable)
+            {
+                resultObject["ttlMs"] ??= 0;
+                resultObject["cacheScope"] ??= "private";
+            }
+
+            return resultObject;
+        }
+
+        string? strippedFields = resultObject.Remove("resultType") ? "resultType" : null;
+        if (result.IsCacheable)
+        {
+            if (resultObject.Remove("ttlMs"))
+            {
+                strippedFields = strippedFields is null ? "ttlMs" : $"{strippedFields}, ttlMs";
+            }
+
+            if (resultObject.Remove("cacheScope"))
+            {
+                strippedFields = strippedFields is null ? "cacheScope" : $"{strippedFields}, cacheScope";
+            }
+        }
+
+        if (strippedFields is not null)
+        {
+            ProtocolIncompatibleResultFieldsOmitted(
+                _endpointName,
+                request.Method,
+                strippedFields,
+                request.Context?.ProtocolVersion ?? NegotiatedProtocolVersion);
+        }
+
+        return resultObject;
+    }
+
     private void SetHandler<TParams, TResult>(
         string method,
         McpRequestHandler<TParams, TResult> handler,
         JsonTypeInfo<TParams> requestTypeInfo,
         JsonTypeInfo<TResult> responseTypeInfo)
     {
-        // SEP-2549: results that carry caching hints (tools/list, prompts/list, resources/list,
-        // resources/templates/list, and resources/read) declare ttlMs and cacheScope as required fields.
-        // When a handler leaves them unset, fill in conservative defaults (immediately stale and not
-        // shareable) so the wire form always carries the fields while preserving today's "don't cache"
-        // behavior. Any value supplied by the handler or a filter is left untouched.
-        if (typeof(ICacheableResult).IsAssignableFrom(typeof(TResult)))
-        {
-            var innerHandler = handler;
-            handler = async (request, cancellationToken) =>
-            {
-                var result = await innerHandler(request, cancellationToken).ConfigureAwait(false);
-
-                // ttlMs and cacheScope are 2026-07-28 result fields; only stamp them when the request
-                // was negotiated under that revision or later. Earlier revisions (e.g. 2025-11-25) reject
-                // these as unrecognized keys (issue #1721).
-                if (result is ICacheableResult cacheable && IsJuly2026OrLaterProtocolRequest(request.JsonRpcRequest))
-                {
-                    cacheable.TimeToLive ??= TimeSpan.Zero;
-                    cacheable.CacheScope ??= CacheScope.Private;
-                }
-
-                return result;
-            };
-        }
-
-        if (typeof(Result).IsAssignableFrom(typeof(TResult)))
-        {
-            var innerHandler = handler;
-            handler = async (request, cancellationToken) =>
-            {
-                var result = await innerHandler(request, cancellationToken).ConfigureAwait(false);
-
-                // resultType is a 2026-07-28 result field; only stamp it when the request was negotiated
-                // under that revision or later. Earlier revisions (e.g. 2025-11-25) reject it as an
-                // unrecognized key (issue #1721).
-                if (result is Result protocolResult && protocolResult.ResultType is null &&
-                    IsJuly2026OrLaterProtocolRequest(request.JsonRpcRequest))
-                {
-                    protocolResult.ResultType = "complete";
-                }
-
-                return result;
-            };
-        }
-
         _requestHandlers.Set(method,
             (request, jsonRpcRequest, cancellationToken) =>
                 InvokeHandlerAsync(handler, request, jsonRpcRequest, cancellationToken),
@@ -1916,23 +1914,6 @@ internal sealed partial class McpServerImpl : McpServer
         JsonTypeInfo<TResult> responseTypeInfo)
         where TResult : Result
     {
-        var innerHandler = handler;
-        handler = async (request, cancellationToken) =>
-        {
-            var result = await innerHandler(request, cancellationToken).ConfigureAwait(false);
-
-            // resultType is a 2026-07-28 result field; only stamp it when the request was negotiated
-            // under that revision or later. Earlier revisions (e.g. 2025-11-25) reject it as an
-            // unrecognized key (issue #1721).
-            if (!result.IsAlternate && result.Result is { ResultType: null } immediateResult &&
-                IsJuly2026OrLaterProtocolRequest(request.JsonRpcRequest))
-            {
-                immediateResult.ResultType = "complete";
-            }
-
-            return result;
-        };
-
         _requestHandlers.SetWithAlternate(method,
             (request, jsonRpcRequest, cancellationToken) =>
                 InvokeHandlerAsync(handler, request, jsonRpcRequest, cancellationToken),
@@ -2082,8 +2063,8 @@ internal sealed partial class McpServerImpl : McpServer
     /// calls (elicitation, sampling, roots) and the handler is retried with the responses - allowing
     /// MRTR-native tools to work transparently with clients that don't support MRTR.
     /// </summary>
-    private async Task<JsonNode?> InvokeWithInputRequiredResultHandlingAsync(
-        Func<JsonRpcRequest, CancellationToken, Task<JsonNode?>> handler,
+    private async Task<RequestHandlerResult> InvokeWithInputRequiredResultHandlingAsync(
+        Func<JsonRpcRequest, CancellationToken, Task<RequestHandlerResult>> handler,
         JsonRpcRequest request,
         CancellationToken cancellationToken)
     {
@@ -2102,7 +2083,7 @@ internal sealed partial class McpServerImpl : McpServer
                 // or by RETURNING an InputRequiredResult through the alternate result path (ResultOrAlternate).
                 // Normalize both forms so a client that doesn't natively support MRTR gets the same server-side
                 // resolution either way.
-                if (GetReturnedInputRequiredResult(result) is not { } returnedInputRequired)
+                if (GetReturnedInputRequiredResult(result.Json) is not { } returnedInputRequired)
                 {
                     return result;
                 }
@@ -2261,8 +2242,10 @@ internal sealed partial class McpServerImpl : McpServer
         }
     }
 
-    private static JsonNode? SerializeInputRequiredResult(InputRequiredResult inputRequiredResult) =>
-        JsonSerializer.SerializeToNode(inputRequiredResult, McpJsonUtilities.JsonContext.Default.InputRequiredResult);
+    private static RequestHandlerResult SerializeInputRequiredResult(InputRequiredResult inputRequiredResult) =>
+        new(
+            JsonSerializer.SerializeToNode(inputRequiredResult, McpJsonUtilities.JsonContext.Default.InputRequiredResult),
+            IsProtocolResult: true);
 
     /// <summary>
     /// Detects an <see cref="InputRequiredResult"/> that a handler surfaced by RETURNING it through the alternate
@@ -2384,7 +2367,7 @@ internal sealed partial class McpServerImpl : McpServer
             // on the per-request DestinationBoundMcpServer. This is picked up synchronously
             // before any await, so the finally cleanup is safe.
             _mrtrContextsByRequestId[request.Id] = mrtrContext;
-            Task<JsonNode?> handlerTask;
+            Task<RequestHandlerResult> handlerTask;
             try
             {
                 handlerTask = originalHandler(request, handlerCts.Token);
@@ -2415,8 +2398,8 @@ internal sealed partial class McpServerImpl : McpServer
     /// If the handler throws <see cref="InputRequiredException"/>, the result is returned directly
     /// without storing a continuation (explicit MRTR path).
     /// </summary>
-    private async Task<JsonNode?> AwaitMrtrHandlerAsync(
-        Task<JsonNode?> handlerTask,
+    private async Task<RequestHandlerResult> AwaitMrtrHandlerAsync(
+        Task<RequestHandlerResult> handlerTask,
         MrtrContinuation continuation,
         Task<MrtrExchange> exchangeTask,
         CancellationToken cancellationToken)
@@ -2460,7 +2443,7 @@ internal sealed partial class McpServerImpl : McpServer
     /// double-reporting at Error) and decrements <see cref="_mrtrInFlightCount"/> when the
     /// handler completes, following the same in-flight tracking pattern as <see cref="McpSessionHandler"/>.
     /// </summary>
-    private async Task ObserveHandlerCompletionAsync(Task<JsonNode?> handlerTask)
+    private async Task ObserveHandlerCompletionAsync(Task<RequestHandlerResult> handlerTask)
     {
         try
         {
@@ -2491,7 +2474,7 @@ internal sealed partial class McpServerImpl : McpServer
     /// Awaits a handler task, catching <see cref="InputRequiredException"/> to convert it to an
     /// <see cref="InputRequiredResult"/> JSON response without storing a continuation.
     /// </summary>
-    private static async Task<JsonNode?> AwaitHandlerWithInputRequiredResultHandlingAsync(Task<JsonNode?> handlerTask)
+    private static async Task<RequestHandlerResult> AwaitHandlerWithInputRequiredResultHandlingAsync(Task<RequestHandlerResult> handlerTask)
     {
         try
         {
@@ -2529,4 +2512,7 @@ internal sealed partial class McpServerImpl : McpServer
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to deliver \"{NotificationMethod}\" to subscription \"{SubscriptionId}\".")]
     private partial void SubscriptionNotificationFailed(string notificationMethod, string subscriptionId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{EndpointName} application returned protocol-incompatible result field(s) '{Fields}' for '{Method}' on protocol version '{ProtocolVersion}'. The fields were omitted from the response.")]
+    private partial void ProtocolIncompatibleResultFieldsOmitted(string endpointName, string method, string fields, string? protocolVersion);
 }

--- a/src/ModelContextProtocol.Core/Server/MrtrContinuation.cs
+++ b/src/ModelContextProtocol.Core/Server/MrtrContinuation.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Nodes;
-
 namespace ModelContextProtocol.Server;
 
 /// <summary>
@@ -11,7 +9,7 @@ internal sealed class MrtrContinuation
 {
     private readonly CancellationTokenSource _handlerCts;
 
-    public MrtrContinuation(CancellationTokenSource handlerCts, Task<JsonNode?> handlerTask, MrtrContext mrtrContext)
+    public MrtrContinuation(CancellationTokenSource handlerCts, Task<RequestHandlerResult> handlerTask, MrtrContext mrtrContext)
     {
         _handlerCts = handlerCts;
         HandlerTask = handlerTask;
@@ -27,7 +25,7 @@ internal sealed class MrtrContinuation
     /// <summary>
     /// The handler task that is suspended awaiting input.
     /// </summary>
-    public Task<JsonNode?> HandlerTask { get; }
+    public Task<RequestHandlerResult> HandlerTask { get; }
 
     /// <summary>
     /// The MRTR context for the handler's async flow.

--- a/tests/ModelContextProtocol.AspNetCore.Tests/ProtocolVersionResultEmissionTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/ProtocolVersionResultEmissionTests.cs
@@ -77,9 +77,76 @@ public sealed class ProtocolVersionResultEmissionTests(ITestOutputHelper outputH
         Assert.Equal(CacheScope.Public, _sharedResult.CacheScope);
     }
 
-    private Task<HttpResponseMessage> SendModernListToolsAsync()
+    [Fact]
+    public async Task SharedResult_ConcurrentLegacyAndModernRequestsRemainIsolated()
     {
-        var request = CreateRequest(ListToolsModernRequest);
+        Builder.Services.AddMcpServer(options =>
+        {
+            options.ServerInfo = new() { Name = "result-emission-http-test", Version = "1" };
+            options.Handlers.ListToolsHandler = (_, _) => new(_sharedResult);
+        })
+            .WithHttpTransport(options => options.SessionMode = HttpServerSessionMode.StatefulForInitializeClients);
+
+        _app = Builder.Build();
+        _app.MapMcp();
+        await _app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var initializeResponse = await SendAsync(InitializeRequest);
+        Assert.Equal(HttpStatusCode.OK, initializeResponse.StatusCode);
+        var sessionId = Assert.Single(initializeResponse.Headers.GetValues("Mcp-Session-Id"));
+        using var initializedResponse = await SendAsync(InitializedNotification, sessionId);
+        Assert.Equal(HttpStatusCode.Accepted, initializedResponse.StatusCode);
+
+        var modernTasks = Enumerable.Range(0, 8).Select(async i =>
+        {
+            using var response = await SendModernListToolsAsync(id: 100 + i);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            return (await ReadJsonResponseAsync(response))["result"]!;
+        }).ToArray();
+        var legacyTasks = Enumerable.Range(0, 8).Select(async i =>
+        {
+            using var response = await SendAsync(
+                ListToolsRequest.Replace("\"id\":2", $"\"id\":{200 + i}", StringComparison.Ordinal),
+                sessionId);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            return (await ReadJsonResponseAsync(response))["result"]!;
+        }).ToArray();
+
+        var results = await Task.WhenAll(modernTasks.Concat(legacyTasks));
+        var expectedModern = JsonNode.Parse("""
+            {
+              "resultType": "shared",
+              "tools": [],
+              "ttlMs": 4321,
+              "cacheScope": "public",
+              "_meta": {
+                "io.modelcontextprotocol/serverInfo": {
+                  "name": "result-emission-http-test",
+                  "version": "1"
+                }
+              }
+            }
+            """);
+        var expectedLegacy = new JsonObject { ["tools"] = new JsonArray() };
+
+        Assert.All(results[..modernTasks.Length], result =>
+            Assert.True(JsonNode.DeepEquals(expectedModern, result), $"Unexpected modern result: {result}"));
+        Assert.All(results[modernTasks.Length..], result =>
+            Assert.True(JsonNode.DeepEquals(expectedLegacy, result), $"Unexpected legacy result: {result}"));
+        Assert.Single(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains("protocol-incompatible result field", StringComparison.Ordinal) &&
+            message.Message.Contains(RequestMethods.ToolsList, StringComparison.Ordinal));
+
+        Assert.Equal("shared", _sharedResult.ResultType);
+        Assert.Equal(TimeSpan.FromMilliseconds(4_321), _sharedResult.TimeToLive);
+        Assert.Equal(CacheScope.Public, _sharedResult.CacheScope);
+    }
+
+    private Task<HttpResponseMessage> SendModernListToolsAsync(int id = 3)
+    {
+        var request = CreateRequest(
+            ListToolsModernRequest.Replace("\"id\":3", $"\"id\":{id}", StringComparison.Ordinal));
         request.Headers.Add("MCP-Protocol-Version", McpProtocolVersions.July2026ProtocolVersion);
         request.Headers.Add("Mcp-Method", RequestMethods.ToolsList);
         return HttpClient.SendAsync(request, TestContext.Current.CancellationToken);

--- a/tests/ModelContextProtocol.AspNetCore.Tests/ProtocolVersionResultEmissionTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/ProtocolVersionResultEmissionTests.cs
@@ -1,0 +1,144 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.AspNetCore.Tests.Utils;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.ServerSentEvents;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace ModelContextProtocol.AspNetCore.Tests;
+
+public sealed class ProtocolVersionResultEmissionTests(ITestOutputHelper outputHelper) : KestrelInMemoryTest(outputHelper), IAsyncDisposable
+{
+    private readonly ListToolsResult _sharedResult = new()
+    {
+        ResultType = "shared",
+        TimeToLive = TimeSpan.FromMilliseconds(4_321),
+        CacheScope = CacheScope.Public,
+    };
+    private WebApplication? _app;
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_app is not null)
+        {
+            await _app.DisposeAsync();
+        }
+        base.Dispose();
+    }
+
+    [Fact]
+    public async Task SharedResult_UsesPerRequestAndSessionProtocolsWithoutMutation()
+    {
+        Builder.Services.AddMcpServer(options =>
+        {
+            options.ServerInfo = new() { Name = "result-emission-http-test", Version = "1" };
+            options.Handlers.ListToolsHandler = (_, _) => new(_sharedResult);
+        })
+            .WithHttpTransport(options => options.SessionMode = HttpServerSessionMode.StatefulForInitializeClients);
+
+        _app = Builder.Build();
+        _app.MapMcp();
+        await _app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var modernResponse = await SendModernListToolsAsync();
+        Assert.Equal(HttpStatusCode.OK, modernResponse.StatusCode);
+        var modernResult = (await ReadJsonResponseAsync(modernResponse))["result"]!;
+        Assert.True(JsonNode.DeepEquals(JsonNode.Parse("""
+            {
+              "resultType": "shared",
+              "tools": [],
+              "ttlMs": 4321,
+              "cacheScope": "public",
+              "_meta": {
+                "io.modelcontextprotocol/serverInfo": {
+                  "name": "result-emission-http-test",
+                  "version": "1"
+                }
+              }
+            }
+            """), modernResult), $"Unexpected modern result: {modernResult}");
+
+        using var initializeResponse = await SendAsync(InitializeRequest);
+        Assert.Equal(HttpStatusCode.OK, initializeResponse.StatusCode);
+        var sessionId = Assert.Single(initializeResponse.Headers.GetValues("Mcp-Session-Id"));
+        using var initializedResponse = await SendAsync(InitializedNotification, sessionId);
+        Assert.Equal(HttpStatusCode.Accepted, initializedResponse.StatusCode);
+        using var legacyResponse = await SendAsync(ListToolsRequest, sessionId);
+        Assert.Equal(HttpStatusCode.OK, legacyResponse.StatusCode);
+        var legacyResult = (await ReadJsonResponseAsync(legacyResponse))["result"]!.AsObject();
+        Assert.True(JsonNode.DeepEquals(new JsonObject { ["tools"] = new JsonArray() }, legacyResult));
+
+        Assert.Equal("shared", _sharedResult.ResultType);
+        Assert.Equal(TimeSpan.FromMilliseconds(4_321), _sharedResult.TimeToLive);
+        Assert.Equal(CacheScope.Public, _sharedResult.CacheScope);
+    }
+
+    private Task<HttpResponseMessage> SendModernListToolsAsync()
+    {
+        var request = CreateRequest(ListToolsModernRequest);
+        request.Headers.Add("MCP-Protocol-Version", McpProtocolVersions.July2026ProtocolVersion);
+        request.Headers.Add("Mcp-Method", RequestMethods.ToolsList);
+        return HttpClient.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+
+    private Task<HttpResponseMessage> SendAsync(string json, string? sessionId = null)
+    {
+        var request = CreateRequest(json);
+        if (sessionId is not null)
+        {
+            request.Headers.Add("Mcp-Session-Id", sessionId);
+            request.Headers.Add("MCP-Protocol-Version", McpProtocolVersions.November2025ProtocolVersion);
+        }
+        return HttpClient.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+
+    private static HttpRequestMessage CreateRequest(string json)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "")
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+        return request;
+    }
+
+    private static async Task<JsonNode> ReadJsonResponseAsync(HttpResponseMessage response)
+    {
+        if (response.Content.Headers.ContentType?.MediaType != "text/event-stream")
+        {
+            return JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!;
+        }
+
+        var responseStream = await response.Content.ReadAsStreamAsync(TestContext.Current.CancellationToken);
+        await foreach (var item in SseParser.Create(responseStream).EnumerateAsync(TestContext.Current.CancellationToken))
+        {
+            if (item.EventType == "message")
+            {
+                return JsonNode.Parse(item.Data)!;
+            }
+        }
+
+        throw new InvalidOperationException("SSE response did not contain a message event.");
+    }
+
+    private const string InitializeRequest = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"result-emission-test","version":"1"}}}
+        """;
+
+    private const string ListToolsRequest = """
+        {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+        """;
+
+    private const string InitializedNotification = """
+        {"jsonrpc":"2.0","method":"notifications/initialized"}
+        """;
+
+    private const string ListToolsModernRequest = """
+        {"jsonrpc":"2.0","id":3,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"result-emission-test","version":"1"},"io.modelcontextprotocol/clientCapabilities":{}}}}
+        """;
+}

--- a/tests/ModelContextProtocol.Tests/Server/MrtrInputRequiredExceptionTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/MrtrInputRequiredExceptionTests.cs
@@ -4,6 +4,7 @@ using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Tests.Utils;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
 
 namespace ModelContextProtocol.Tests.Server;
@@ -15,6 +16,7 @@ namespace ModelContextProtocol.Tests.Server;
 public class MrtrInputRequiredExceptionTests : ClientServerTestBase
 {
     private readonly ServerMessageTracker _messageTracker = new();
+    private JsonObject? _inputRequiredWireResult;
 
     public MrtrInputRequiredExceptionTests(ITestOutputHelper testOutputHelper)
         : base(testOutputHelper, startServer: false)
@@ -27,6 +29,17 @@ public class MrtrInputRequiredExceptionTests : ClientServerTestBase
         {
             options.ProtocolVersion = "2026-07-28";
             _messageTracker.AddFilters(options.Filters.Message);
+            options.Filters.Message.OutgoingFilters.Add(next => async (context, cancellationToken) =>
+            {
+                if (_inputRequiredWireResult is null &&
+                    context.JsonRpcMessage is JsonRpcResponse { Result: JsonObject result } &&
+                    result["resultType"]?.GetValue<string>() == "input_required")
+                {
+                    _inputRequiredWireResult = result.DeepClone().AsObject();
+                }
+
+                await next(context, cancellationToken);
+            });
         });
 
         mcpServerBuilder.WithTools([
@@ -59,6 +72,11 @@ public class MrtrInputRequiredExceptionTests : ClientServerTestBase
                 cancellationToken: TestContext.Current.CancellationToken).AsTask());
 
         Assert.Contains("more than", exception.Message);
+        Assert.NotNull(_inputRequiredWireResult);
+        Assert.Equal("input_required", _inputRequiredWireResult!["resultType"]?.GetValue<string>());
+        Assert.DoesNotContain(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains("protocol-incompatible result field", StringComparison.Ordinal));
     }
 }
 
@@ -74,6 +92,7 @@ public class MrtrReturnedInputRequiredResultNativeTests : ClientServerTestBase
         (JsonTypeInfo<InputRequiredResult>)McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(InputRequiredResult));
 
     private int _attempt;
+    private JsonObject? _inputRequiredWireResult;
 
     public MrtrReturnedInputRequiredResultNativeTests(ITestOutputHelper testOutputHelper)
         : base(testOutputHelper, startServer: false)
@@ -86,6 +105,17 @@ public class MrtrReturnedInputRequiredResultNativeTests : ClientServerTestBase
         services.Configure<McpServerOptions>(options =>
         {
             options.ProtocolVersion = "2026-07-28";
+            options.Filters.Message.OutgoingFilters.Add(next => async (context, cancellationToken) =>
+            {
+                if (_inputRequiredWireResult is null &&
+                    context.JsonRpcMessage is JsonRpcResponse { Result: JsonObject result } &&
+                    result["resultType"]?.GetValue<string>() == "input_required")
+                {
+                    _inputRequiredWireResult = result.DeepClone().AsObject();
+                }
+
+                await next(context, cancellationToken);
+            });
 
             options.Handlers.CallToolWithAlternateHandler = (context, cancellationToken) =>
             {
@@ -144,5 +174,12 @@ public class MrtrReturnedInputRequiredResultNativeTests : ClientServerTestBase
         Assert.Equal(2, _attempt);
         var content = Assert.Single(result.Content);
         Assert.Equal("resolved", Assert.IsType<TextContentBlock>(content).Text);
+        Assert.NotNull(_inputRequiredWireResult);
+        Assert.Equal("input_required", _inputRequiredWireResult!["resultType"]?.GetValue<string>());
+        Assert.Equal("round1", _inputRequiredWireResult["requestState"]?.GetValue<string>());
+        Assert.NotNull(_inputRequiredWireResult["inputRequests"]);
+        Assert.DoesNotContain(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains("protocol-incompatible result field", StringComparison.Ordinal));
     }
 }

--- a/tests/ModelContextProtocol.Tests/Server/MrtrServerBackcompatTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/MrtrServerBackcompatTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol;
@@ -127,6 +128,7 @@ public class MrtrReturnedInputRequiredResultBackcompatTests : ClientServerTestBa
         (JsonTypeInfo<InputRequiredResult>)McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(InputRequiredResult));
 
     private int _attempt;
+    private JsonObject? _finalWireResult;
 
     public MrtrReturnedInputRequiredResultBackcompatTests(ITestOutputHelper testOutputHelper)
         : base(testOutputHelper, startServer: false)
@@ -138,6 +140,17 @@ public class MrtrReturnedInputRequiredResultBackcompatTests : ClientServerTestBa
     {
         mcpServerBuilder.Services.Configure<McpServerOptions>(options =>
         {
+            options.Filters.Message.OutgoingFilters.Add(next => async (context, cancellationToken) =>
+            {
+                if (context.JsonRpcMessage is JsonRpcResponse { Result: JsonObject result } &&
+                    result.ContainsKey("content"))
+                {
+                    _finalWireResult = result.DeepClone().AsObject();
+                }
+
+                await next(context, cancellationToken);
+            });
+
             options.Handlers.CallToolWithAlternateHandler = (context, cancellationToken) =>
             {
                 Interlocked.Increment(ref _attempt);
@@ -147,6 +160,7 @@ public class MrtrReturnedInputRequiredResultBackcompatTests : ClientServerTestBa
                 {
                     return new ValueTask<ResultOrAlternate<CallToolResult>>(new CallToolResult
                     {
+                        ResultType = "resolved-by-application",
                         Content = [new TextContentBlock { Text = "resolved" }],
                     });
                 }
@@ -197,5 +211,13 @@ public class MrtrReturnedInputRequiredResultBackcompatTests : ClientServerTestBa
         Assert.Equal(2, _attempt);
         var content = Assert.Single(result.Content);
         Assert.Equal("resolved", Assert.IsType<TextContentBlock>(content).Text);
+        Assert.NotNull(_finalWireResult);
+        Assert.True(JsonNode.DeepEquals(
+            JsonNode.Parse("""{"content":[{"type":"text","text":"resolved"}]}"""),
+            _finalWireResult), $"Unexpected legacy result: {_finalWireResult}");
+        Assert.Contains(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains("protocol-incompatible result field", StringComparison.Ordinal) &&
+            message.Message.Contains("'resultType'", StringComparison.Ordinal));
     }
 }

--- a/tests/ModelContextProtocol.Tests/Server/MrtrServerBackcompatTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/MrtrServerBackcompatTests.cs
@@ -29,6 +29,20 @@ public class MrtrServerBackcompatTests : ClientServerTestBase
 
     protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
     {
+        services.Configure<McpServerOptions>(options =>
+        {
+            options.Filters.Message.OutgoingFilters.Add(next => async (context, cancellationToken) =>
+            {
+                if (context.JsonRpcMessage is JsonRpcResponse { Result: JsonObject result } &&
+                    result.ContainsKey("content"))
+                {
+                    result["resultType"] = "filter-thrown-final";
+                }
+
+                await next(context, cancellationToken);
+            });
+        });
+
         mcpServerBuilder.WithTools([
             McpServerTool.Create(
                 (RequestContext<CallToolRequestParams> context) =>
@@ -112,6 +126,11 @@ public class MrtrServerBackcompatTests : ClientServerTestBase
         var content = Assert.Single(result.Content);
         var text = Assert.IsType<TextContentBlock>(content).Text;
         Assert.Equal("final-state:<null>", text);
+        Assert.Null(result.ResultType);
+        Assert.Contains(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains("protocol-incompatible result field", StringComparison.Ordinal) &&
+            message.Message.Contains("'resultType'", StringComparison.Ordinal));
     }
 }
 
@@ -128,8 +147,6 @@ public class MrtrReturnedInputRequiredResultBackcompatTests : ClientServerTestBa
         (JsonTypeInfo<InputRequiredResult>)McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(InputRequiredResult));
 
     private int _attempt;
-    private JsonObject? _finalWireResult;
-
     public MrtrReturnedInputRequiredResultBackcompatTests(ITestOutputHelper testOutputHelper)
         : base(testOutputHelper, startServer: false)
     {
@@ -145,7 +162,7 @@ public class MrtrReturnedInputRequiredResultBackcompatTests : ClientServerTestBa
                 if (context.JsonRpcMessage is JsonRpcResponse { Result: JsonObject result } &&
                     result.ContainsKey("content"))
                 {
-                    _finalWireResult = result.DeepClone().AsObject();
+                    result["resultType"] = "filter-returned-final";
                 }
 
                 await next(context, cancellationToken);
@@ -211,10 +228,7 @@ public class MrtrReturnedInputRequiredResultBackcompatTests : ClientServerTestBa
         Assert.Equal(2, _attempt);
         var content = Assert.Single(result.Content);
         Assert.Equal("resolved", Assert.IsType<TextContentBlock>(content).Text);
-        Assert.NotNull(_finalWireResult);
-        Assert.True(JsonNode.DeepEquals(
-            JsonNode.Parse("""{"content":[{"type":"text","text":"resolved"}]}"""),
-            _finalWireResult), $"Unexpected legacy result: {_finalWireResult}");
+        Assert.Null(result.ResultType);
         Assert.Contains(MockLoggerProvider.LogMessages, message =>
             message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
             message.Message.Contains("protocol-incompatible result field", StringComparison.Ordinal) &&

--- a/tests/ModelContextProtocol.Tests/Server/ProtocolVersionResultDecorationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/ProtocolVersionResultDecorationTests.cs
@@ -20,6 +20,7 @@ namespace ModelContextProtocol.Tests.Server;
 /// </remarks>
 public class ProtocolVersionResultDecorationTests : ClientServerTestBase
 {
+    private const string ProtocolWarningMarker = "protocol-incompatible result field";
     private static readonly Implementation s_serverInfo = new() { Name = "result-gating-test", Version = "1" };
     private ListToolsResult _cacheableResult = null!;
     private ListResourcesResult _defaultedCacheableResult = null!;
@@ -81,9 +82,7 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             TestContext.Current.CancellationToken);
 
         AssertExact(new JsonObject { ["tools"] = new JsonArray() }, response.Result);
-        Assert.Contains(MockLoggerProvider.LogMessages, message =>
-            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
-            message.Message.Contains("'resultType, ttlMs, cacheScope'", StringComparison.Ordinal));
+        AssertProtocolWarning("resultType, ttlMs, cacheScope");
     }
 
     [Fact]
@@ -104,6 +103,7 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             TestContext.Current.CancellationToken);
 
         AssertExact(JsonNode.Parse("""{"content":[{"type":"text","text":"immediate"}]}"""), response.Result);
+        AssertProtocolWarning("resultType");
     }
 
     [Fact]
@@ -125,6 +125,7 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             ["ttlMs"] = 1_234,
             ["cacheScope"] = "public",
         }), response.Result);
+        AssertNoProtocolWarning();
     }
 
     [Fact]
@@ -145,6 +146,7 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             TestContext.Current.CancellationToken);
 
         AssertExact(ModernResult(JsonNode.Parse("""{"resultType":"handler-immediate","content":[{"type":"text","text":"immediate"}]}""")!.AsObject()), response.Result);
+        AssertNoProtocolWarning();
     }
 
     [Fact]
@@ -167,6 +169,21 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
         Assert.Null(_defaultedCacheableResult.ResultType);
         Assert.Null(_defaultedCacheableResult.TimeToLive);
         Assert.Null(_defaultedCacheableResult.CacheScope);
+        AssertNoProtocolWarning();
+    }
+
+    [Fact]
+    public async Task ResourcesList_On2025_11_25Session_WithNoApplicationFields_DoesNotWarn()
+    {
+        await using var client = await CreateMcpClientForServer(
+            new McpClientOptions { ProtocolVersion = McpProtocolVersions.November2025ProtocolVersion });
+
+        var response = await client.SendRequestAsync(
+            new JsonRpcRequest { Method = RequestMethods.ResourcesList },
+            TestContext.Current.CancellationToken);
+
+        AssertExact(new JsonObject { ["resources"] = new JsonArray() }, response.Result);
+        AssertNoProtocolWarning();
     }
 
     [Theory]
@@ -189,6 +206,14 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             ? """{"resultType":"handler-normal","description":"normal","messages":[]}"""
             : """{"description":"normal","messages":[]}""")!.AsObject();
         AssertExact(modern ? ModernResult(expected) : expected, response.Result);
+        if (modern)
+        {
+            AssertNoProtocolWarning();
+        }
+        else
+        {
+            AssertProtocolWarning("resultType");
+        }
     }
 
     private static JsonObject ModernResult(JsonObject result)
@@ -202,4 +227,15 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
 
     private static void AssertExact(JsonNode? expected, JsonNode? actual) =>
         Assert.True(JsonNode.DeepEquals(expected, actual), $"Expected: {expected}\nActual: {actual}");
+
+    private void AssertProtocolWarning(string fields) =>
+        Assert.Contains(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains(ProtocolWarningMarker, StringComparison.Ordinal) &&
+            message.Message.Contains($"'{fields}'", StringComparison.Ordinal));
+
+    private void AssertNoProtocolWarning() =>
+        Assert.DoesNotContain(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains(ProtocolWarningMarker, StringComparison.Ordinal));
 }

--- a/tests/ModelContextProtocol.Tests/Server/ProtocolVersionResultDecorationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/ProtocolVersionResultDecorationTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using ModelContextProtocol.Tests.Utils;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -27,6 +28,7 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
     private ListPromptsResult _partialCacheableResult = null!;
     private GetPromptResult _normalResult = null!;
     private CallToolResult _immediateAlternateResult = null!;
+    private Func<JsonRpcResponse, JsonRpcMessage>? _outgoingResponseTransform;
 
     public ProtocolVersionResultDecorationTests(ITestOutputHelper testOutputHelper)
         : base(testOutputHelper)
@@ -69,6 +71,16 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             options.Handlers.CallToolWithAlternateHandler = (_, _) =>
                 new(new ResultOrAlternate<CallToolResult>(_immediateAlternateResult));
 #pragma warning restore MCPEXP002
+            options.Filters.Message.OutgoingFilters.Add(next => async (context, cancellationToken) =>
+            {
+                if (context.JsonRpcMessage is JsonRpcResponse response &&
+                    _outgoingResponseTransform is { } transform)
+                {
+                    context.JsonRpcMessage = transform(response);
+                }
+
+                await next(context, cancellationToken);
+            });
         });
     }
 
@@ -111,6 +123,197 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
 
         AssertExact(JsonNode.Parse("""{"content":[{"type":"text","text":"immediate"}]}"""), response.Result);
         AssertProtocolWarning("resultType");
+    }
+
+    [Fact]
+    public async Task PromptsGet_OnLegacySession_OmitsResultTypeAddedByOutgoingFilter()
+    {
+        _outgoingResponseTransform = response =>
+        {
+            if (response.Result is JsonObject result && result.ContainsKey("messages"))
+            {
+                result["resultType"] = "filter-normal";
+            }
+
+            return response;
+        };
+
+        await using var client = await CreateMcpClientForServer(
+            new McpClientOptions { ProtocolVersion = McpProtocolVersions.November2025ProtocolVersion });
+
+        var response = await client.SendRequestAsync(
+            new JsonRpcRequest
+            {
+                Method = RequestMethods.PromptsGet,
+                Params = JsonSerializer.SerializeToNode(
+                    new GetPromptRequestParams { Name = "shared" }, McpJsonUtilities.DefaultOptions),
+            },
+            TestContext.Current.CancellationToken);
+
+        AssertExact(JsonNode.Parse("""{"description":"normal","messages":[]}"""), response.Result);
+        AssertProtocolWarning("resultType");
+    }
+
+    [Fact]
+    public async Task ToolsCall_OnLegacySession_OmitsResultTypeAddedByOutgoingFilter()
+    {
+        _outgoingResponseTransform = response =>
+        {
+            if (response.Result is JsonObject result && result.ContainsKey("content"))
+            {
+                result["resultType"] = "filter-immediate";
+            }
+
+            return response;
+        };
+
+        await using var client = await CreateMcpClientForServer(
+            new McpClientOptions { ProtocolVersion = McpProtocolVersions.November2025ProtocolVersion });
+
+        var response = await client.SendRequestAsync(
+            new JsonRpcRequest
+            {
+                Method = RequestMethods.ToolsCall,
+                Params = JsonSerializer.SerializeToNode(
+                    new CallToolRequestParams { Name = "echo" }, McpJsonUtilities.DefaultOptions),
+            },
+            TestContext.Current.CancellationToken);
+
+        AssertExact(JsonNode.Parse("""{"content":[{"type":"text","text":"immediate"}]}"""), response.Result);
+        AssertProtocolWarning("resultType");
+    }
+
+    [Fact]
+    public async Task ToolsList_OnLegacySession_NormalizesFilterReplacementWithoutMutation()
+    {
+        var sharedFilterResult = JsonNode.Parse("""
+            {
+              "resultType": "filter-cacheable",
+              "tools": [],
+              "ttlMs": 2468,
+              "cacheScope": "public"
+            }
+            """)!.AsObject();
+        _outgoingResponseTransform = response =>
+            response.Result is JsonObject result && result.ContainsKey("tools") ?
+                new JsonRpcResponse
+                {
+                    Id = response.Id,
+                    Result = sharedFilterResult,
+                    Context = response.Context,
+                } :
+                response;
+
+        await using var client = await CreateMcpClientForServer(
+            new McpClientOptions { ProtocolVersion = McpProtocolVersions.November2025ProtocolVersion });
+
+        var response = await client.SendRequestAsync(
+            new JsonRpcRequest { Method = RequestMethods.ToolsList },
+            TestContext.Current.CancellationToken);
+
+        AssertExact(new JsonObject { ["tools"] = new JsonArray() }, response.Result);
+        AssertExact(JsonNode.Parse("""
+            {
+              "resultType": "filter-cacheable",
+              "tools": [],
+              "ttlMs": 2468,
+              "cacheScope": "public"
+            }
+            """), sharedFilterResult);
+        AssertProtocolWarning("resultType, ttlMs, cacheScope");
+    }
+
+    [Fact]
+    public async Task ToolsList_OnLegacySession_NormalizesEveryOutgoingFilterEmission()
+    {
+        await using var transport = new TestServerTransport();
+        var options = new McpServerOptions
+        {
+            ProtocolVersion = McpProtocolVersions.November2025ProtocolVersion,
+            ServerInfo = s_serverInfo,
+        };
+        options.Handlers.ListToolsHandler = (_, _) => new(new ListToolsResult());
+        options.Filters.Message.OutgoingFilters.Add(next => async (context, cancellationToken) =>
+        {
+            if (context.JsonRpcMessage is JsonRpcResponse { Result: JsonObject result } &&
+                result.ContainsKey("tools"))
+            {
+                result["resultType"] = "first";
+                await next(context, cancellationToken);
+
+                result["resultType"] = "second";
+                await next(context, cancellationToken);
+                return;
+            }
+
+            await next(context, cancellationToken);
+        });
+
+        await using var server = McpServer.Create(transport, options, LoggerFactory);
+        Task runTask = server.RunAsync(TestContext.Current.CancellationToken);
+
+        var initializeId = new RequestId("initialize");
+        var listId = new RequestId("list");
+        var initialized = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responses = new List<JsonRpcResponse>();
+        transport.OnMessageSent = message =>
+        {
+            if (message is JsonRpcResponse response && response.Id == initializeId)
+            {
+                initialized.TrySetResult(true);
+            }
+            else if (message is JsonRpcResponse listResponse && listResponse.Id == listId)
+            {
+                responses.Add(listResponse);
+            }
+        };
+
+        await transport.SendClientMessageAsync(new JsonRpcRequest
+        {
+            Id = initializeId,
+            Method = RequestMethods.Initialize,
+            Params = JsonSerializer.SerializeToNode(new InitializeRequestParams
+            {
+                ProtocolVersion = McpProtocolVersions.November2025ProtocolVersion,
+                Capabilities = new ClientCapabilities(),
+                ClientInfo = new Implementation { Name = "result-gating-test", Version = "1" },
+            }, McpJsonUtilities.DefaultOptions),
+        }, TestContext.Current.CancellationToken);
+        await initialized.Task.WaitAsync(TestConstants.DefaultTimeout, TestContext.Current.CancellationToken);
+
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        transport.OnMessageSent = message =>
+        {
+            if (message is JsonRpcResponse response && response.Id == listId)
+            {
+                responses.Add(response);
+                if (responses.Count == 2)
+                {
+                    completed.TrySetResult(true);
+                }
+            }
+        };
+
+        await transport.SendClientMessageAsync(
+            new JsonRpcNotification { Method = NotificationMethods.InitializedNotification },
+            TestContext.Current.CancellationToken);
+        await transport.SendClientMessageAsync(new JsonRpcRequest
+        {
+            Id = listId,
+            Method = RequestMethods.ToolsList,
+        }, TestContext.Current.CancellationToken);
+        await completed.Task.WaitAsync(TestConstants.DefaultTimeout, TestContext.Current.CancellationToken);
+
+        Assert.All(responses, response =>
+            AssertExact(new JsonObject { ["tools"] = new JsonArray() }, response.Result));
+        Assert.NotSame(responses[0], responses[1]);
+        Assert.Single(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains(ProtocolWarningMarker, StringComparison.Ordinal) &&
+            message.Message.Contains(RequestMethods.ToolsList, StringComparison.Ordinal));
+
+        await transport.DisposeAsync();
+        await runTask;
     }
 
     [Fact]
@@ -176,6 +379,38 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
         Assert.Null(_defaultedCacheableResult.ResultType);
         Assert.Null(_defaultedCacheableResult.TimeToLive);
         Assert.Null(_defaultedCacheableResult.CacheScope);
+        AssertNoProtocolWarning();
+    }
+
+    [Fact]
+    public async Task ToolsList_OnModernSession_RestoresFieldsRemovedByOutgoingFilter()
+    {
+        _outgoingResponseTransform = response =>
+        {
+            if (response.Result is JsonObject result && result.ContainsKey("tools"))
+            {
+                result.Remove("resultType");
+                result.Remove("ttlMs");
+                result.Remove("cacheScope");
+            }
+
+            return response;
+        };
+
+        await using var client = await CreateMcpClientForServer(
+            new McpClientOptions { ProtocolVersion = McpProtocolVersions.July2026ProtocolVersion });
+
+        var response = await client.SendRequestAsync(
+            new JsonRpcRequest { Method = RequestMethods.ToolsList },
+            TestContext.Current.CancellationToken);
+
+        AssertExact(ModernResult(new JsonObject
+        {
+            ["resultType"] = "complete",
+            ["tools"] = new JsonArray(),
+            ["ttlMs"] = 0,
+            ["cacheScope"] = "private",
+        }), response.Result);
         AssertNoProtocolWarning();
     }
 

--- a/tests/ModelContextProtocol.Tests/Server/ProtocolVersionResultDecorationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/ProtocolVersionResultDecorationTests.cs
@@ -2,26 +2,30 @@ using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace ModelContextProtocol.Tests.Server;
 
 /// <summary>
-/// Regression tests for issue #1721: the SDK-provided <c>resultType</c>, <c>ttlMs</c>, and
-/// <c>cacheScope</c> result decorations are exclusive to the 2026-07-28 protocol revision and
-/// must be absent from result objects on a session negotiated to an earlier revision
-/// (e.g. <c>2025-11-25</c>). Emitting them breaks clients that strictly validate the 2025-11-25
-/// schema.
+/// Regression tests for issue #1754: application-provided <c>resultType</c>, <c>ttlMs</c>, and
+/// <c>cacheScope</c> properties must be omitted from legacy responses and preserved on 2026-07-28
+/// responses without mutating the application result.
 /// </summary>
 /// <remarks>
 /// These drive the in-process <see cref="ClientServerTestBase"/> client/server pair and inspect the
 /// raw JSON-RPC result wire shape (via <see cref="McpSession.SendRequestAsync(JsonRpcRequest, System.Threading.CancellationToken)"/>)
 /// so the assertions are about the actual serialized fields rather than deserialized objects.
-/// <c>tools/list</c> exercises the <c>SetHandler</c> decoration path (its result is both an
-/// <see cref="ICacheableResult"/> and a <see cref="Result"/>), while <c>tools/call</c> exercises the
-/// <c>SetWithAlternateHandler</c> path.
+/// The cases cover normal, cacheable, and immediate alternate typed results.
 /// </remarks>
 public class ProtocolVersionResultDecorationTests : ClientServerTestBase
 {
+    private static readonly Implementation s_serverInfo = new() { Name = "result-gating-test", Version = "1" };
+    private ListToolsResult _cacheableResult = null!;
+    private ListResourcesResult _defaultedCacheableResult = null!;
+    private GetPromptResult _normalResult = null!;
+    private CallToolResult _immediateAlternateResult = null!;
+
     public ProtocolVersionResultDecorationTests(ITestOutputHelper testOutputHelper)
         : base(testOutputHelper)
     {
@@ -29,7 +33,39 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
 
     protected override void ConfigureServices(ServiceCollection services, IMcpServerBuilder mcpServerBuilder)
     {
-        mcpServerBuilder.WithTools([McpServerTool.Create(() => "ok", new() { Name = "echo" })]);
+        _cacheableResult = new()
+        {
+            ResultType = "handler-cacheable",
+            TimeToLive = TimeSpan.FromSeconds(1),
+            CacheScope = CacheScope.Private,
+        };
+        _defaultedCacheableResult = new();
+        _normalResult = new() { ResultType = "handler-normal", Description = "normal" };
+        _immediateAlternateResult = new()
+        {
+            ResultType = "handler-immediate",
+            Content = [new TextContentBlock { Text = "immediate" }],
+        };
+
+        services.Configure<McpServerOptions>(options =>
+        {
+            options.ServerInfo = s_serverInfo;
+            options.Handlers.ListToolsHandler = (_, _) => new(_cacheableResult);
+            options.Filters.Request.ListToolsFilters.Add(next => async (request, cancellationToken) =>
+            {
+                var result = await next(request, cancellationToken);
+                result.ResultType = "filter-cacheable";
+                result.TimeToLive = TimeSpan.FromMilliseconds(1_234);
+                result.CacheScope = CacheScope.Public;
+                return result;
+            });
+            options.Handlers.ListResourcesHandler = (_, _) => new(_defaultedCacheableResult);
+            options.Handlers.GetPromptHandler = (_, _) => new(_normalResult);
+#pragma warning disable MCPEXP002
+            options.Handlers.CallToolWithAlternateHandler = (_, _) =>
+                new(new ResultOrAlternate<CallToolResult>(_immediateAlternateResult));
+#pragma warning restore MCPEXP002
+        });
     }
 
     [Fact]
@@ -44,10 +80,10 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             new JsonRpcRequest { Method = RequestMethods.ToolsList },
             TestContext.Current.CancellationToken);
 
-        var result = response.Result!.AsObject();
-        Assert.False(result.ContainsKey("resultType"), "resultType must be absent on a 2025-11-25 tools/list result.");
-        Assert.False(result.ContainsKey("ttlMs"), "ttlMs must be absent on a 2025-11-25 tools/list result.");
-        Assert.False(result.ContainsKey("cacheScope"), "cacheScope must be absent on a 2025-11-25 tools/list result.");
+        AssertExact(new JsonObject { ["tools"] = new JsonArray() }, response.Result);
+        Assert.Contains(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains("'resultType, ttlMs, cacheScope'", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -67,8 +103,7 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             },
             TestContext.Current.CancellationToken);
 
-        var result = response.Result!.AsObject();
-        Assert.False(result.ContainsKey("resultType"), "resultType must be absent on a 2025-11-25 tools/call result.");
+        AssertExact(JsonNode.Parse("""{"content":[{"type":"text","text":"immediate"}]}"""), response.Result);
     }
 
     [Fact]
@@ -83,10 +118,13 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             new JsonRpcRequest { Method = RequestMethods.ToolsList },
             TestContext.Current.CancellationToken);
 
-        var result = response.Result!.AsObject();
-        Assert.Equal("complete", result["resultType"]!.GetValue<string>());
-        Assert.True(result.ContainsKey("ttlMs"), "ttlMs must be present on a 2026-07-28 tools/list result.");
-        Assert.True(result.ContainsKey("cacheScope"), "cacheScope must be present on a 2026-07-28 tools/list result.");
+        AssertExact(ModernResult(new JsonObject
+        {
+            ["resultType"] = "filter-cacheable",
+            ["tools"] = new JsonArray(),
+            ["ttlMs"] = 1_234,
+            ["cacheScope"] = "public",
+        }), response.Result);
     }
 
     [Fact]
@@ -106,7 +144,62 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             },
             TestContext.Current.CancellationToken);
 
-        var result = response.Result!.AsObject();
-        Assert.Equal("complete", result["resultType"]!.GetValue<string>());
+        AssertExact(ModernResult(JsonNode.Parse("""{"resultType":"handler-immediate","content":[{"type":"text","text":"immediate"}]}""")!.AsObject()), response.Result);
     }
+
+    [Fact]
+    public async Task ResourcesList_On2026_07_28Session_AddsDefaultsWithoutMutatingResult()
+    {
+        await using var client = await CreateMcpClientForServer(
+            new McpClientOptions { ProtocolVersion = McpProtocolVersions.July2026ProtocolVersion });
+
+        var response = await client.SendRequestAsync(
+            new JsonRpcRequest { Method = RequestMethods.ResourcesList },
+            TestContext.Current.CancellationToken);
+
+        AssertExact(ModernResult(new JsonObject
+        {
+            ["resultType"] = "complete",
+            ["resources"] = new JsonArray(),
+            ["ttlMs"] = 0,
+            ["cacheScope"] = "private",
+        }), response.Result);
+        Assert.Null(_defaultedCacheableResult.ResultType);
+        Assert.Null(_defaultedCacheableResult.TimeToLive);
+        Assert.Null(_defaultedCacheableResult.CacheScope);
+    }
+
+    [Theory]
+    [InlineData(McpProtocolVersions.November2025ProtocolVersion, false)]
+    [InlineData(McpProtocolVersions.July2026ProtocolVersion, true)]
+    public async Task PromptsGet_EmitsExactNormalResultShape(string protocolVersion, bool modern)
+    {
+        await using var client = await CreateMcpClientForServer(new McpClientOptions { ProtocolVersion = protocolVersion });
+
+        var response = await client.SendRequestAsync(
+            new JsonRpcRequest
+            {
+                Method = RequestMethods.PromptsGet,
+                Params = JsonSerializer.SerializeToNode(
+                    new GetPromptRequestParams { Name = "shared" }, McpJsonUtilities.DefaultOptions),
+            },
+            TestContext.Current.CancellationToken);
+
+        var expected = JsonNode.Parse(modern
+            ? """{"resultType":"handler-normal","description":"normal","messages":[]}"""
+            : """{"description":"normal","messages":[]}""")!.AsObject();
+        AssertExact(modern ? ModernResult(expected) : expected, response.Result);
+    }
+
+    private static JsonObject ModernResult(JsonObject result)
+    {
+        result["_meta"] = new JsonObject
+        {
+            [MetaKeys.ServerInfo] = JsonSerializer.SerializeToNode(s_serverInfo, McpJsonUtilities.DefaultOptions),
+        };
+        return result;
+    }
+
+    private static void AssertExact(JsonNode? expected, JsonNode? actual) =>
+        Assert.True(JsonNode.DeepEquals(expected, actual), $"Expected: {expected}\nActual: {actual}");
 }

--- a/tests/ModelContextProtocol.Tests/Server/ProtocolVersionResultDecorationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/ProtocolVersionResultDecorationTests.cs
@@ -24,6 +24,7 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
     private static readonly Implementation s_serverInfo = new() { Name = "result-gating-test", Version = "1" };
     private ListToolsResult _cacheableResult = null!;
     private ListResourcesResult _defaultedCacheableResult = null!;
+    private ListPromptsResult _partialCacheableResult = null!;
     private GetPromptResult _normalResult = null!;
     private CallToolResult _immediateAlternateResult = null!;
 
@@ -41,6 +42,7 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
             CacheScope = CacheScope.Private,
         };
         _defaultedCacheableResult = new();
+        _partialCacheableResult = new() { TimeToLive = TimeSpan.FromMilliseconds(-5) };
         _normalResult = new() { ResultType = "handler-normal", Description = "normal" };
         _immediateAlternateResult = new()
         {
@@ -61,6 +63,7 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
                 return result;
             });
             options.Handlers.ListResourcesHandler = (_, _) => new(_defaultedCacheableResult);
+            options.Handlers.ListPromptsHandler = (_, _) => new(_partialCacheableResult);
             options.Handlers.GetPromptHandler = (_, _) => new(_normalResult);
 #pragma warning disable MCPEXP002
             options.Handlers.CallToolWithAlternateHandler = (_, _) =>
@@ -69,13 +72,17 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
         });
     }
 
-    [Fact]
-    public async Task ToolsList_On2025_11_25Session_OmitsResultTypeAndCacheHints()
+    [Theory]
+    [InlineData(McpProtocolVersions.November2024ProtocolVersion)]
+    [InlineData(McpProtocolVersions.March2025ProtocolVersion)]
+    [InlineData(McpProtocolVersions.June2025ProtocolVersion)]
+    [InlineData(McpProtocolVersions.November2025ProtocolVersion)]
+    public async Task ToolsList_OnLegacySession_OmitsResultTypeAndCacheHints(string protocolVersion)
     {
         await using var client = await CreateMcpClientForServer(
-            new McpClientOptions { ProtocolVersion = McpProtocolVersions.November2025ProtocolVersion });
+            new McpClientOptions { ProtocolVersion = protocolVersion });
 
-        Assert.Equal(McpProtocolVersions.November2025ProtocolVersion, client.NegotiatedProtocolVersion);
+        Assert.Equal(protocolVersion, client.NegotiatedProtocolVersion);
 
         var response = await client.SendRequestAsync(
             new JsonRpcRequest { Method = RequestMethods.ToolsList },
@@ -184,6 +191,79 @@ public class ProtocolVersionResultDecorationTests : ClientServerTestBase
 
         AssertExact(new JsonObject { ["resources"] = new JsonArray() }, response.Result);
         AssertNoProtocolWarning();
+    }
+
+    [Fact]
+    public async Task PromptsList_OnLegacySession_OmitsOnlyExplicitCacheHint()
+    {
+        await using var client = await CreateMcpClientForServer(
+            new McpClientOptions { ProtocolVersion = McpProtocolVersions.November2025ProtocolVersion });
+
+        var response = await client.SendRequestAsync(
+            new JsonRpcRequest { Method = RequestMethods.PromptsList },
+            TestContext.Current.CancellationToken);
+
+        AssertExact(new JsonObject { ["prompts"] = new JsonArray() }, response.Result);
+        AssertProtocolWarning("ttlMs");
+        Assert.Null(_partialCacheableResult.ResultType);
+        Assert.Equal(TimeSpan.FromMilliseconds(-5), _partialCacheableResult.TimeToLive);
+        Assert.Null(_partialCacheableResult.CacheScope);
+    }
+
+    [Fact]
+    public async Task PromptsList_OnModernSession_PreservesNegativeTtlAndDefaultsMissingFields()
+    {
+        await using var client = await CreateMcpClientForServer(
+            new McpClientOptions { ProtocolVersion = McpProtocolVersions.July2026ProtocolVersion });
+
+        var response = await client.SendRequestAsync(
+            new JsonRpcRequest { Method = RequestMethods.PromptsList },
+            TestContext.Current.CancellationToken);
+
+        AssertExact(ModernResult(new JsonObject
+        {
+            ["resultType"] = "complete",
+            ["prompts"] = new JsonArray(),
+            ["ttlMs"] = -5,
+            ["cacheScope"] = "private",
+        }), response.Result);
+        AssertNoProtocolWarning();
+        Assert.Null(_partialCacheableResult.ResultType);
+        Assert.Equal(TimeSpan.FromMilliseconds(-5), _partialCacheableResult.TimeToLive);
+        Assert.Null(_partialCacheableResult.CacheScope);
+    }
+
+    [Fact]
+    public async Task LegacyResults_WarnOncePerMethod()
+    {
+        await using var client = await CreateMcpClientForServer(
+            new McpClientOptions { ProtocolVersion = McpProtocolVersions.November2025ProtocolVersion });
+
+        for (int i = 0; i < 2; i++)
+        {
+            var response = await client.SendRequestAsync(
+                new JsonRpcRequest { Method = RequestMethods.ToolsList },
+                TestContext.Current.CancellationToken);
+
+            AssertExact(new JsonObject { ["tools"] = new JsonArray() }, response.Result);
+        }
+
+        var promptsResponse = await client.SendRequestAsync(
+            new JsonRpcRequest { Method = RequestMethods.PromptsList },
+            TestContext.Current.CancellationToken);
+        AssertExact(new JsonObject { ["prompts"] = new JsonArray() }, promptsResponse.Result);
+
+        Assert.Equal(2, MockLoggerProvider.LogMessages.Count(message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains(ProtocolWarningMarker, StringComparison.Ordinal)));
+        Assert.Single(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains(ProtocolWarningMarker, StringComparison.Ordinal) &&
+            message.Message.Contains(RequestMethods.ToolsList, StringComparison.Ordinal));
+        Assert.Single(MockLoggerProvider.LogMessages, message =>
+            message.LogLevel == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            message.Message.Contains(ProtocolWarningMarker, StringComparison.Ordinal) &&
+            message.Message.Contains(RequestMethods.PromptsList, StringComparison.Ordinal));
     }
 
     [Theory]


### PR DESCRIPTION
Fixes #1754.

## Summary

Normalize protocol-version-specific properties on typed results at a single terminal response-emission boundary, after outgoing message filters have run.

- Legacy requests remove `resultType` and, for cacheable results, `ttlMs` and `cacheScope`. The server emits at most one compatibility warning per method, including under concurrent or repeated emissions.
- Requests using protocol version `2026-07-28` or later preserve explicit values and restore required defaults (`resultType: "complete"`, `ttlMs: 0`, and `cacheScope: "private"`) if a filter removes them.
- Protocol selection uses the request-scoped version and falls back to the negotiated version for stateful sessions.
- The terminal boundary clones and normalizes the post-filter JSON response before transport emission. This covers filter mutation, response replacement, and repeated `next` calls without mutating shared result instances.
- Normal, cacheable, immediate alternate, and returned/thrown MRTR typed results all pass through the same boundary.
- Raw `McpServerOptions.RequestHandlers` remain outside this boundary because they operate on already-serialized JSON and intentionally bypass the typed handler infrastructure.

The selected policy is strip plus warning. This keeps legacy wire responses schema-valid while making application misuse visible, following the SDK's existing compatibility-warning convention without turning otherwise valid requests into errors.

## Tests

- Full `ModelContextProtocol.slnx` Release build: 0 warnings, 0 errors.
- Focused protocol-result gating tests: 21 passed.
- Core protocol, MRTR, and message-filter regression set: 45 passed.
- ASP.NET Core non-Manual suite (`Execution!=Manual`, `net10.0`): 617 passed, 30 skipped, 0 failed.
- MapMcp and filter-focused tests: 75 passed, 9 skipped, 0 failed.
- `git diff --check` and targeted `dotnet format --verify-no-changes` passed.
- Two Docker Everything Server sampling tests were attempted but are not counted as validation: the pinned image returned `Unknown tool: trigger-sampling-request` before exercising this change.
