### PR TITLE
Fix RequestOptions writing an integer progress token as a JSON string

### DIFF
--- a/src/ModelContextProtocol.Core/RequestOptions.cs
+++ b/src/ModelContextProtocol.Core/RequestOptions.cs
@@ -79,7 +79,12 @@ public sealed class RequestOptions
         if (ProgressToken is not null)
         {
             meta = (JsonObject?)meta?.DeepClone() ?? [];
-            meta["progressToken"] = ProgressToken.ToString();
+
+            // Serialize through ProgressToken's own converter rather than ToString(), so that an integer
+            // token is written as a JSON number. Stringifying it changes the token the peer echoes back
+            // in progress notifications, and the caller then no longer recognizes its own token.
+            meta["progressToken"] = JsonSerializer.SerializeToNode(
+                ProgressToken.Value, McpJsonUtilities.JsonContext.Default.ProgressToken);
         }
 
         return meta;

--- a/tests/ModelContextProtocol.Tests/RequestOptionsTests.cs
+++ b/tests/ModelContextProtocol.Tests/RequestOptionsTests.cs
@@ -141,6 +141,21 @@ public static class RequestOptionsTests
     }
 
     [Fact]
+    public static void GetMetaForRequest_LongProgressToken_IsWrittenAsJsonNumber()
+    {
+        RequestOptions options = new() { ProgressToken = new ProgressToken(42L) };
+
+        var actual = options.GetMetaForRequest();
+
+        Assert.NotNull(actual);
+        Assert.Equal(JsonValueKind.Number, actual["progressToken"]!.GetValueKind());
+
+        // The token the peer reads back must be the token the caller asked for.
+        RequestParams request = new CallToolRequestParams { Name = "tool", Meta = actual };
+        Assert.Equal(new ProgressToken(42L), request.ProgressToken);
+    }
+
+    [Fact]
     public static void GetMetaForRequest_BothSet_ReturnsCloneWithProgressToken()
     {
         JsonObject meta = new() { ["custom"] = "data" };


### PR DESCRIPTION
`RequestOptions.GetMetaForRequest()` writes an integer progress token as a JSON string. `RequestOptions.cs:82` calls `ProgressToken.ToString()` rather than going through `ProgressToken`'s own converter, so `new ProgressToken(42)` leaves as `"42"`.

That is not cosmetic, because `ProgressToken` compares by boxed value. The peer reads the field back as `ProgressToken("42")` (`RequestParams.cs:62-72` tries `string` first), then stamps that token on every progress notification. The caller compares `"42"` against its own `42`, boxed `long` never equals `string`, and progress notifications match nothing. They are dropped silently, with no error.

It is reachable from every high-level request that takes a `RequestOptions`; fourteen call sites feed `options?.GetMetaForRequest()` into the request params.

The existing test for exactly this case, `GetMetaForRequest_OnlyProgressTokenSetAsLong_ReturnsNewObjectWithToken`, misses it because it asserts on `actual["progressToken"]?.ToString()`, and `JsonNode.ToString()` unquotes a string node.

**Fix:** serialize through the converter instead. `[JsonSerializable(typeof(ProgressToken))]` is already registered in the source-generated context (`McpJsonUtilities.cs:196`), so this stays trim and AOT safe and cannot drift from the converter again.

**One behaviour change worth flagging:** a `ProgressToken` with a null inner value now serializes as `""` rather than `null`. The SDK's own reader throws on `null` here, so this is an improvement, but it is a change on the same line.

**Verification:**

- New test fails on unpatched source with `Expected: Number, Actual: String`.
- `RequestOptionsTests`: 17 passed / 1 failed, to 18 passed.
- Full `ModelContextProtocol.Tests` on net10.0: 2298 passed, 0 failed, 2 skipped. Excludes `ClientIntegrationTests` and `DockerEverythingServerTests`, which need `npx` and Docker and fail identically before and after.
- net9.0 target (reflection disabled, source-gen only): 39 passed. This is the run that shows the generated path is used.
- `ModelContextProtocol.Core` builds clean on net10.0, net9.0, net8.0 and netstandard2.0 with 0 warnings under warnings-as-errors.
