### PR TITLE
test(oauth): extend metadata discovery probe timeout

### DIFF
--- a/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
@@ -46,7 +46,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -74,7 +74,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(callbackContext);
@@ -116,7 +116,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(receivedAuthorizationUri);
@@ -143,7 +143,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains("does not match the expected issuer", ex.Message);
@@ -188,7 +188,7 @@ public class AuthTests : OAuthTestBase
             return HandleAuthorizationUrlAsync(context, cancellationToken);
         });
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(requestedState);
@@ -203,7 +203,7 @@ public class AuthTests : OAuthTestBase
         await using var transport = CreateOAuthTransport(
             (_, _) => Task.FromResult<ModelContextProtocol.Authentication.AuthorizationResult?>(new() { Code = "unused-code" }));
 
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains("did not include the required state parameter", ex.Message);
@@ -218,7 +218,7 @@ public class AuthTests : OAuthTestBase
             (_, _) => Task.FromResult<ModelContextProtocol.Authentication.AuthorizationResult?>(
                 new() { Code = "unused-code", State = "unexpected-state" }));
 
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains("state did not match", ex.Message);
@@ -239,7 +239,7 @@ public class AuthTests : OAuthTestBase
                 return HandleAuthorizationUrlAsync(context, cancellationToken);
             });
 
-            await using var client = await McpClient.CreateAsync(
+            await using var client = await CreateMcpClientAsync(
                 transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
         }
 
@@ -257,7 +257,7 @@ public class AuthTests : OAuthTestBase
             Endpoint = new(McpServerUrl),
         }, HttpClient, LoggerFactory);
 
-        var httpEx = await Assert.ThrowsAsync<HttpRequestException>(async () => await McpClient.CreateAsync(
+        var httpEx = await Assert.ThrowsAsync<HttpRequestException>(async () => await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Equal(HttpStatusCode.Unauthorized, httpEx.StatusCode);
@@ -281,7 +281,7 @@ public class AuthTests : OAuthTestBase
         }, HttpClient, LoggerFactory);
 
         // The EqualException is thrown by HandleAuthorizationUrlAsync when the /authorize request gets a 400
-        var equalEx = await Assert.ThrowsAsync<EqualException>(async () => await McpClient.CreateAsync(
+        var equalEx = await Assert.ThrowsAsync<EqualException>(async () => await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
     }
 
@@ -305,7 +305,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("native", TestOAuthServer.LastApplicationType);
@@ -330,7 +330,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("web", TestOAuthServer.LastApplicationType);
@@ -356,7 +356,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -378,7 +378,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         // No discovery endpoint advertises PKCE, so metadata discovery is exhausted. The precise PKCE reason
@@ -406,7 +406,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains(
@@ -435,7 +435,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -466,7 +466,7 @@ public class AuthTests : OAuthTestBase
         }, HttpClient, LoggerFactory);
 
         // Should succeed via dynamic client registration.
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -493,7 +493,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -515,7 +515,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.StartsWith("Failed to handle unauthorized response", ex.Message);
@@ -579,7 +579,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
@@ -614,7 +614,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(lastAuthorizationUri?.Query);
@@ -644,7 +644,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await Assert.ThrowsAsync<ArgumentException>(() => McpClient.CreateAsync(
+        await Assert.ThrowsAsync<ArgumentException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
     }
 
@@ -665,7 +665,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -687,7 +687,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -720,7 +720,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         var requestedScopeSet = new HashSet<string>(requestedScope!.Split(' '));
@@ -773,7 +773,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(challengeScopes, requestedScope);
@@ -868,7 +868,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("mcp:tools", requestedScope);
@@ -973,7 +973,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         // Initial auth gets "mcp:tools" from protected resource metadata
@@ -1092,7 +1092,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         // Initial connect requests "mcp:tools" from protected resource metadata.
@@ -1187,7 +1187,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         // Initial auth gets "mcp:tools" from protected resource metadata.
@@ -1282,7 +1282,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         // Initial auth already requests "mcp:tools" from protected resource metadata.
@@ -1325,7 +1325,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
     }
 
@@ -1364,7 +1364,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains("Resource URI in metadata", ex.Message);
@@ -1392,7 +1392,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         var requests = TestOAuthServer.MetadataRequests.ToArray();
@@ -1425,7 +1425,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(
@@ -1446,7 +1446,7 @@ public class AuthTests : OAuthTestBase
         await using var app = await StartMcpServerAsync();
         await using var transport = CreateOAuthTransport();
 
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains("does not match the expected issuer", ex.Message);
@@ -1461,7 +1461,7 @@ public class AuthTests : OAuthTestBase
         await using var app = await StartMcpServerAsync();
         await using var transport = CreateOAuthTransport();
 
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains("did not provide the required issuer", ex.Message);
@@ -1476,7 +1476,7 @@ public class AuthTests : OAuthTestBase
 
         await using var app = await StartMcpServerAsync();
         await using var transport = CreateOAuthTransport();
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -1495,7 +1495,7 @@ public class AuthTests : OAuthTestBase
         await using var app = await StartMcpServerAsync();
         await using var transport = CreateOAuthTransport();
 
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains(expectedMessage, ex.Message);
@@ -1552,7 +1552,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(
@@ -1609,7 +1609,7 @@ public class AuthTests : OAuthTestBase
 
         var ex = await Assert.ThrowsAsync<McpException>(async () =>
         {
-            await McpClient.CreateAsync(
+            await CreateMcpClientAsync(
                 transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
         });
 
@@ -1654,7 +1654,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -1697,7 +1697,7 @@ public class AuthTests : OAuthTestBase
         }, HttpClient, LoggerFactory);
 
         // This should fail because the resource URI doesn't match
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains("does not match", ex.Message);
@@ -1744,7 +1744,7 @@ public class AuthTests : OAuthTestBase
 
         // This should fail because the resource URI is a different path on the same host,
         // which is neither an exact match nor the authority-only base URL.
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains("does not match", ex.Message);
@@ -1791,7 +1791,7 @@ public class AuthTests : OAuthTestBase
 
         // This should succeed - the client should not add a trailing slash
         // If the client incorrectly added a trailing slash, ValidResources would reject it
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -1943,7 +1943,7 @@ public class AuthTests : OAuthTestBase
 
         // This should succeed with the explicitly configured trailing slash
         // If the client incorrectly trimmed the slash, ValidResources would reject it
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -2058,7 +2058,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -2160,7 +2160,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
     }
 
@@ -2231,7 +2231,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         // The specific PKCE failure reason is surfaced rather than a generic discovery failure or a
@@ -2264,7 +2264,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(requestedScope);
@@ -2296,7 +2296,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(requestedScope);
@@ -2335,7 +2335,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(requestedScope);
@@ -2373,7 +2373,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("mcp:tools", requestedScope);
@@ -2404,7 +2404,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(requestedScope);
@@ -2441,7 +2441,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Null(capturedInput);
@@ -2471,7 +2471,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(scopePresent);
@@ -2501,7 +2501,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(scopePresent);
@@ -2544,7 +2544,7 @@ public class AuthTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("mcp:tools", TestOAuthServer.LastRegistrationScope);

--- a/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/DcrFailureTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/DcrFailureTests.cs
@@ -31,7 +31,7 @@ public class DcrFailureTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        var ex = await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        var ex = await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         // The consumer needs enough to produce a meaningful error: the HTTP status, the AS error
@@ -63,7 +63,7 @@ public class DcrFailureTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await Assert.ThrowsAsync<McpException>(() => McpClient.CreateAsync(
+        await Assert.ThrowsAsync<McpException>(() => CreateMcpClientAsync(
             firstTransport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken));
 
         // Second attempt: a new provider on the SAME HttpClient with an adjusted (loopback) redirect
@@ -84,7 +84,7 @@ public class DcrFailureTests : OAuthTestBase
             },
         }, HttpClient, LoggerFactory);
 
-        await using var client = await McpClient.CreateAsync(
+        await using var client = await CreateMcpClientAsync(
             secondTransport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("native", TestOAuthServer.LastApplicationType);

--- a/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/OAuthTestBase.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/OAuthTestBase.cs
@@ -3,10 +3,13 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using ModelContextProtocol.AspNetCore.Authentication;
 using ModelContextProtocol.AspNetCore.Tests.Utils;
 using ModelContextProtocol.Authentication;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Tests.Utils;
 using System.Net;
 
 namespace ModelContextProtocol.AspNetCore.Tests.OAuth;
@@ -79,6 +82,23 @@ public abstract class OAuthTestBase : KestrelInMemoryTest, IAsyncDisposable
         {
             TestCts.Dispose();
         }
+    }
+
+    protected Task<McpClient> CreateMcpClientAsync(
+        IClientTransport clientTransport,
+        ILoggerFactory? loggerFactory = null,
+        CancellationToken cancellationToken = default)
+    {
+        return McpClient.CreateAsync(
+            clientTransport,
+            new McpClientOptions
+            {
+                // Keep OAuth metadata discovery inside the client initialization budget on slow CI.
+                // The default five-second probe can cancel an in-flight metadata request.
+                DiscoverProbeTimeout = TestConstants.DefaultTimeout,
+            },
+            loggerFactory,
+            cancellationToken);
     }
 
     protected async Task<WebApplication> StartMcpServerAsync(string path = "", string? authScheme = null, Action<WebApplication>? configureMiddleware = null)

--- a/tests/ModelContextProtocol.ConformanceClient/Program.cs
+++ b/tests/ModelContextProtocol.ConformanceClient/Program.cs
@@ -22,6 +22,9 @@ var endpoint =  args[1];
 
 McpClientOptions options = new()
 {
+    // OAuth metadata discovery runs under the initial server/discover probe token.
+    // Keep slow CI handshakes from cancelling metadata requests after five seconds.
+    DiscoverProbeTimeout = TimeSpan.FromSeconds(60),
     ClientInfo = new()
     {
         Name = "ConformanceClient",


### PR DESCRIPTION
## Summary

Fixes #1806 by keeping OAuth metadata discovery from being cancelled by the five-second `server/discover` probe timeout in slow in-memory CI environments.

When the protected MCP endpoint returns `401`, metadata discovery runs under the same probe cancellation token. A slow TLS/duplex-pipe handshake can therefore cancel `GetAuthServerMetadataAsync` before it finishes, producing a misleading metadata-discovery assertion failure.

## Changes

- Add a test-only `OAuthTestBase.CreateMcpClientAsync` helper that uses the shared 60-second test budget for `DiscoverProbeTimeout`.
- Route the ASP.NET Core OAuth tests through that helper.
- Apply the same probe budget to the standalone conformance client used by OAuth scenarios.
- Production client defaults and OAuth behavior are unchanged.

## Verification

- `dotnet test tests/ModelContextProtocol.AspNetCore.Tests/ModelContextProtocol.AspNetCore.Tests.csproj --framework net10.0 --configuration Release --no-restore --filter 'FullyQualifiedName~CannotAuthenticate_WithInvalidClientMetadataDocument|FullyQualifiedName~DcrRejection_PropagatesToConsumer_WithStatusBodyAndSentParameters'` — 3 passed\n- `dotnet test tests/ModelContextProtocol.AspNetCore.Tests/ModelContextProtocol.AspNetCore.Tests.csproj --framework net10.0 --configuration Release --no-restore --filter 'FullyQualifiedName~ModelContextProtocol.AspNetCore.Tests.OAuth'` — 98 passed\n- `git diff --check` — passed\n\nThe net8.0/net9.0 variants were not runnable on this workstation because those runtimes are not installed; they remain covered by the repository CI matrix.