### PR TITLE
Close stdio input before waiting for server exit

### DIFF
--- a/src/ModelContextProtocol.Core/Client/StdioClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/StdioClientSessionTransport.cs
@@ -61,6 +61,14 @@ internal sealed class StdioClientSessionTransport : StreamClientSessionTransport
         // so create an exception with details about that.
         error ??= await GetUnexpectedExitExceptionAsync().ConfigureAwait(false);
 
+        // Closing the server's stdin is the portable graceful-shutdown signal for stdio transports.
+        // Do this before waiting so a well-behaved server can finish its own cleanup and exit.
+        try
+        {
+            _process.StandardInput.Close();
+        }
+        catch { }
+
         // Ensure all pending ErrorDataReceived events are drained before detaching
         // the handler. GetUnexpectedExitExceptionAsync does this when HasExited is
         // true, but there is a narrow window on Linux where the process has closed

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -2,6 +2,7 @@
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Tests.Utils;
+using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -12,6 +13,46 @@ namespace ModelContextProtocol.Tests.Transport;
 public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : LoggedTest(testOutputHelper)
 {
     public static bool IsStdErrCallbackSupported => !PlatformDetection.IsMonoRuntime;
+
+    [Fact]
+    public async Task DisposeAsync_ClosesServerStandardInputBeforeWaitingForExit()
+    {
+        TimeSpan shutdownTimeout = TimeSpan.FromSeconds(4);
+        string testServerExecutable = Path.Combine(AppContext.BaseDirectory, "TestServer.exe");
+        string testServerDll = Path.Combine(AppContext.BaseDirectory, "TestServer.dll");
+
+        StdioClientTransport transport = new(new()
+        {
+            Name = "TestServer",
+            Command = (PlatformDetection.IsMonoRuntime, PlatformDetection.IsWindows) switch
+            {
+                (true, _) => "mono",
+                (_, true) => testServerExecutable,
+                _ => "dotnet",
+            },
+            Arguments = (PlatformDetection.IsMonoRuntime, PlatformDetection.IsWindows) switch
+            {
+                (true, _) => [testServerExecutable],
+                (_, true) => [],
+                _ => [testServerDll],
+            },
+            ShutdownTimeout = shutdownTimeout,
+        }, LoggerFactory);
+
+        await using ITransport session = await transport.ConnectAsync(TestContext.Current.CancellationToken);
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        await session.DisposeAsync();
+        stopwatch.Stop();
+
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromTicks(shutdownTimeout.Ticks / 2),
+            $"Disposal took {stopwatch.Elapsed}, indicating it waited for the {shutdownTimeout} shutdown timeout.");
+
+        var exception = await Assert.ThrowsAsync<ClientTransportClosedException>(
+            async () => await session.MessageReader.Completion);
+        var completionDetails = Assert.IsType<StdioClientCompletionDetails>(exception.Details);
+        Assert.Equal(0, completionDetails.ExitCode);
+    }
 
     [Fact]
     public async Task ConnectAsync_DoesNotLogEnvironmentVariablesAtTrace()

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -2,7 +2,6 @@
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Tests.Utils;
-using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -15,7 +14,7 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
     public static bool IsStdErrCallbackSupported => !PlatformDetection.IsMonoRuntime;
 
     [Fact]
-    public async Task DisposeAsync_ClosesServerStandardInputBeforeWaitingForExit()
+    public async Task DisposeAsync_ClosesServerStandardInputForGracefulExit()
     {
         TimeSpan shutdownTimeout = TimeSpan.FromSeconds(4);
         string testServerExecutable = Path.Combine(AppContext.BaseDirectory, "TestServer.exe");
@@ -41,16 +40,13 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
 
         await using ITransport session = await transport.ConnectAsync(TestContext.Current.CancellationToken);
 
-        Stopwatch stopwatch = Stopwatch.StartNew();
         await session.DisposeAsync();
-        stopwatch.Stop();
-
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromTicks(shutdownTimeout.Ticks / 2),
-            $"Disposal took {stopwatch.Elapsed}, indicating it waited for the {shutdownTimeout} shutdown timeout.");
 
         var exception = await Assert.ThrowsAsync<ClientTransportClosedException>(
             async () => await session.MessageReader.Completion);
         var completionDetails = Assert.IsType<StdioClientCompletionDetails>(exception.Details);
+        // A zero exit code proves the server observed stdin EOF and exited on its own
+        // instead of being terminated after ShutdownTimeout.
         Assert.Equal(0, completionDetails.ExitCode);
     }
 


### PR DESCRIPTION
## Summary

- close the child process's standard input before waiting for stdio server shutdown
- allow well-behaved servers that exit on EOF to complete graceful cleanup without consuming `ShutdownTimeout`
- add a regression test that verifies disposal observes a clean server exit after stdin EOF without relying on wall-clock timing

## Validation

- `dotnet test tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj --filter FullyQualifiedName~StdioClientTransportTests` — 54 passed on each of net472, net8.0, net9.0, and net10.0 (216 total)
- `dotnet build -c Release` — succeeded with 0 warnings and 0 errors
- the regression scenario was verified to fail against the previous implementation after `ShutdownTimeout` and pass with this change by observing a clean exit code of 0, without asserting wall-clock duration

The full test suite was also attempted locally. Unrelated environment dependencies involving the missing Node conformance helper and a localhost OAuth development certificate prevented a clean full-suite completion. One parallel task-cancellation test also failed during that run and passed when rerun in isolation.

Fixes #1836

> [!NOTE]
> This pull request description and implementation were prepared with AI assistance.
