### PR TITLE
Launch Windows executables directly in stdio transport

### DIFF
--- a/src/ModelContextProtocol.Core/Client/StdioClientTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/StdioClientTransport.cs
@@ -63,11 +63,13 @@ public sealed partial class StdioClientTransport : IClientTransport
 
         string command = _options.Command;
         IList<string>? arguments = _options.Arguments;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-            !string.Equals(Path.GetFileName(command), "cmd.exe", StringComparison.OrdinalIgnoreCase))
+        bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        bool isCmd = string.Equals(Path.GetFileName(command), "cmd.exe", StringComparison.OrdinalIgnoreCase);
+        bool needsCmdEscaping = isWindows && isCmd;
+        if (isWindows && !isCmd && !ShouldLaunchDirectly(command))
         {
-            // On Windows, for stdio, we need to wrap non-shell commands with cmd.exe /c {command} (usually npx or uvicorn).
-            // The stdio transport will not work correctly if the command is not run in a shell.
+            // Use cmd.exe for commands that require shell handling or resolution through PATH/PATHEXT.
+            needsCmdEscaping = true;
             arguments = arguments is null or [] ? ["/c", command] : ["/c", command, ..arguments];
             command = "cmd.exe";
         }
@@ -98,13 +100,13 @@ public sealed partial class StdioClientTransport : IClientTransport
 #if NET
                 foreach (string arg in arguments)
                 {
-                    startInfo.ArgumentList.Add(EscapeArgumentString(arg));
+                    startInfo.ArgumentList.Add(needsCmdEscaping ? EscapeArgumentString(arg) : arg);
                 }
 #else
                 StringBuilder argsBuilder = new();
                 foreach (string arg in arguments)
                 {
-                    PasteArguments.AppendArgument(argsBuilder, EscapeArgumentString(arg));
+                    PasteArguments.AppendArgument(argsBuilder, needsCmdEscaping ? EscapeArgumentString(arg) : arg);
                 }
 
                 startInfo.Arguments = argsBuilder.ToString();
@@ -286,6 +288,23 @@ public sealed partial class StdioClientTransport : IClientTransport
         {
             return true;
         }
+    }
+
+    private static bool ShouldLaunchDirectly(string command)
+    {
+        // CreateProcess can only launch real executable images directly,
+        // which in practice means .exe/.com. Anything else (.bat/.cmd) relies on cmd.exe
+        // resolving it via file association / PATHEXT, so it must keep going through the cmd.exe wrapper.
+        string extension = Path.GetExtension(command);
+        if (!extension.Equals(".exe", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".com", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // Match Process resolution on Unix: rooted paths are used as supplied, while relative
+        // paths are probed against the parent process's current directory.
+        return Path.IsPathRooted(command) || File.Exists(command);
     }
 
     private static string EscapeArgumentString(string argument) =>

--- a/tests/ModelContextProtocol.TestServer/Program.cs
+++ b/tests/ModelContextProtocol.TestServer/Program.cs
@@ -41,6 +41,13 @@ internal static class Program
             return;
         }
 
+        if (args.Contains("--echo-cwd-and-exit"))
+        {
+            Console.Error.WriteLine($"CWD:{Environment.CurrentDirectory}");
+            Console.Error.Flush();
+            return;
+        }
+
         Log.Logger.Information("Starting server...");
 
         string? cliArg = ParseCliArgument(args);

--- a/tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj
+++ b/tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj
@@ -93,6 +93,10 @@
     <Content Include="$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)'))ModelContextProtocol.TestServer\$(Configuration)\$(TargetFramework)\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)'))ModelContextProtocol.TestServer\$(Configuration)\$(TargetFramework)\**\*">
+      <TargetPath>ExecutableWithSpacesHandledCorrectly\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)'))TestServerWithHosting\$(Configuration)\$(TargetFramework)\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -165,13 +165,13 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
             Command = (PlatformDetection.IsMonoRuntime, PlatformDetection.IsWindows) switch
             {
                 (true, _) => "mono",
-                (_, true) => testServerExecutable,
+                (_, true) => "cmd.exe",
                 _ => "dotnet",
             },
             Arguments = (PlatformDetection.IsMonoRuntime, PlatformDetection.IsWindows) switch
             {
                 (true, _) => [testServerExecutable, "--echo-cli-arg-and-exit", cliArgument],
-                (_, true) => ["--echo-cli-arg-and-exit", cliArgument],
+                (_, true) => ["/c", testServerExecutable, "--echo-cli-arg-and-exit", cliArgument],
                 _ => [testServerDll, "--echo-cli-arg-and-exit", cliArgument],
             },
             StandardErrorLines = line =>
@@ -192,12 +192,117 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
         JsonElement parsedArgument = JsonElement.Parse(serializedArgument);
         Assert.Equal(cliArgumentValue ?? "", parsedArgument.GetString());
 
-        var exception = await Assert.ThrowsAsync<ClientTransportClosedException>(
-            async () => await session.MessageReader.Completion.WaitAsync(
+        await AssertServerExitedCleanlyAsync(session);
+    }
+
+    [Theory]
+    [InlineData("My Test Server.exe", true)]
+    [InlineData("My Test Server.com", false)]
+    [InlineData("my directory/my test server.exe", false)]
+    public async Task ExecutableWithSpacesHandledCorrectly(string relativeExecutablePath, bool useRootedPath)
+    {
+        const string OutputPrefix = "CLI_ARG:";
+        const string CliArgumentValue = "42";
+
+        string rootDirectoryName = $"BypassCmd-{Guid.NewGuid():N}";
+        string rootDirectory = Path.Combine(Environment.CurrentDirectory, rootDirectoryName);
+        string executablePath = Path.Combine(rootDirectory, relativeExecutablePath);
+        string executableDirectory = Path.GetDirectoryName(executablePath)!;
+
+        Directory.CreateDirectory(executableDirectory);
+        try
+        {
+            foreach (string sourcePath in Directory.EnumerateFiles(AppContext.BaseDirectory))
+            {
+                File.Copy(sourcePath, Path.Combine(executableDirectory, Path.GetFileName(sourcePath)));
+            }
+
+            string sourceExecutablePath = Path.Combine(AppContext.BaseDirectory, PlatformDetection.IsWindows ? "TestServer.exe" : "TestServer");
+            File.Copy(sourceExecutablePath, executablePath, overwrite: true);
+
+            string command = useRootedPath ? executablePath : Path.Combine(rootDirectoryName, relativeExecutablePath);
+
+            var capturedArgument = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var transport = new StdioClientTransport(new()
+            {
+                Name = "TestServer",
+                Command = command,
+                Arguments = ["--echo-cli-arg-and-exit", $"--cli-arg={CliArgumentValue}"],
+                StandardErrorLines = line =>
+                {
+                    if (line.StartsWith(OutputPrefix, StringComparison.Ordinal))
+                    {
+                        capturedArgument.TrySetResult(line[OutputPrefix.Length..]);
+                    }
+                },
+            }, LoggerFactory);
+
+            await using var session = await transport.ConnectAsync(TestContext.Current.CancellationToken);
+
+            string serializedArgument = await capturedArgument.Task.WaitAsync(
                 TestConstants.DefaultTimeout,
-                TestContext.Current.CancellationToken));
-        var completionDetails = Assert.IsType<StdioClientCompletionDetails>(exception.Details);
-        Assert.Equal(0, completionDetails.ExitCode);
+                TestContext.Current.CancellationToken);
+            Assert.Equal(CliArgumentValue, JsonElement.Parse(serializedArgument).GetString());
+
+            await AssertServerExitedCleanlyAsync(session);
+        }
+        finally
+        {
+            Directory.Delete(rootDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WorkingDirectory_IsUsedAsChildProcessCurrentDirectory()
+    {
+        const string OutputPrefix = "CWD:";
+        string testServerExecutable = Path.Combine(
+            AppContext.BaseDirectory,
+            PlatformDetection.IsWindows ? "TestServer.exe" : "TestServer");
+
+        // A directory that does not contain the executable, so a successful launch also demonstrates the
+        // executable is located independently of WorkingDirectory.
+        string workingDirectory = Path.Combine(Path.GetTempPath(), $"McpStdioWorkingDir-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workingDirectory);
+        try
+        {
+            var capturedCwd = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            StdioClientTransportOptions options = new()
+            {
+                Name = "TestServer",
+                Command = testServerExecutable,
+                Arguments = ["--echo-cwd-and-exit"],
+                WorkingDirectory = workingDirectory,
+                StandardErrorLines = line =>
+                {
+                    if (line.StartsWith(OutputPrefix, StringComparison.Ordinal))
+                    {
+                        capturedCwd.TrySetResult(line[OutputPrefix.Length..]);
+                    }
+                },
+            };
+
+            var transport = new StdioClientTransport(options, LoggerFactory);
+            await using var session = await transport.ConnectAsync(TestContext.Current.CancellationToken);
+
+            string reportedCwd = (await capturedCwd.Task.WaitAsync(
+                TestConstants.DefaultTimeout,
+                TestContext.Current.CancellationToken)).Trim();
+
+            // The child reports the working directory we set. Compare with EndsWith because some platforms
+            // (e.g. macOS) report the temp path through its resolved location (/var -> /private/var).
+            char[] separators = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
+            Assert.EndsWith(
+                workingDirectory.TrimEnd(separators),
+                reportedCwd.TrimEnd(separators),
+                PlatformDetection.IsWindows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+
+            await AssertServerExitedCleanlyAsync(session);
+        }
+        finally
+        {
+            Directory.Delete(workingDirectory, recursive: true);
+        }
     }
 
     [Fact(Skip = "Platform not supported by this test.", SkipUnless = nameof(IsStdErrCallbackSupported))]
@@ -430,5 +535,15 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
         Assert.NotNull(readMessage);
         Assert.IsType<JsonRpcRequest>(readMessage);
         Assert.Equal("44", ((JsonRpcRequest)readMessage).Id.ToString());
+    }
+
+    private static async Task AssertServerExitedCleanlyAsync(ITransport session)
+    {
+        var exception = await Assert.ThrowsAsync<ClientTransportClosedException>(
+            async () => await session.MessageReader.Completion.WaitAsync(
+                TestConstants.DefaultTimeout,
+                TestContext.Current.CancellationToken));
+        var completionDetails = Assert.IsType<StdioClientCompletionDetails>(exception.Details);
+        Assert.Equal(0, completionDetails.ExitCode);
     }
 }

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -209,24 +209,31 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
         string executablePath = Path.Combine(rootDirectory, relativeExecutablePath);
         string executableDirectory = Path.GetDirectoryName(executablePath)!;
 
-        Directory.CreateDirectory(executableDirectory);
         try
         {
-            foreach (string sourcePath in Directory.EnumerateFiles(AppContext.BaseDirectory))
+            string sourceDirectory = Path.Combine(AppContext.BaseDirectory, nameof(ExecutableWithSpacesHandledCorrectly)) + Path.DirectorySeparatorChar;
+            foreach (string sourcePath in Directory.EnumerateFiles(sourceDirectory, "*", SearchOption.AllDirectories))
             {
-                File.Copy(sourcePath, Path.Combine(executableDirectory, Path.GetFileName(sourcePath)));
+                string destinationPath = Path.Combine(executableDirectory, sourcePath[sourceDirectory.Length..]);
+                Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+                File.Copy(sourcePath, destinationPath);
             }
 
-            string sourceExecutablePath = Path.Combine(AppContext.BaseDirectory, PlatformDetection.IsWindows ? "TestServer.exe" : "TestServer");
+            string sourceExecutablePath = Path.Combine(sourceDirectory, PlatformDetection.IsWindows ? "TestServer.exe" : "TestServer");
             File.Copy(sourceExecutablePath, executablePath, overwrite: true);
 
-            string command = useRootedPath ? executablePath : Path.Combine(rootDirectoryName, relativeExecutablePath);
+            // .NET Framework loads binding redirects from a configuration file matching the executable's name.
+            string sourceConfigurationPath = sourceExecutablePath + ".config";
+            if (File.Exists(sourceConfigurationPath))
+            {
+                File.Copy(sourceConfigurationPath, executablePath + ".config");
+            }
 
             var capturedArgument = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             var transport = new StdioClientTransport(new()
             {
                 Name = "TestServer",
-                Command = command,
+                Command = useRootedPath ? executablePath : Path.Combine(rootDirectoryName, relativeExecutablePath),
                 Arguments = ["--echo-cli-arg-and-exit", $"--cli-arg={CliArgumentValue}"],
                 StandardErrorLines = line =>
                 {

--- a/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/StdioClientTransportTests.cs
@@ -255,7 +255,11 @@ public class StdioClientTransportTests(ITestOutputHelper testOutputHelper) : Log
         }
         finally
         {
-            Directory.Delete(rootDirectory, recursive: true);
+            try
+            {
+                Directory.Delete(rootDirectory, recursive: true);
+            }
+            catch (UnauthorizedAccessException) { }
         }
     }
 


### PR DESCRIPTION
## Problem

On Windows, `StdioClientTransport` currently wraps every command other than an explicit `cmd.exe` invocation with:
`cmd.exe /c <command> <arguments>`
The wrapper allows commands such as `npx` to work because `cmd.exe` searches `PATH` and `PATHEXT` and resolves `npx` to `npx.cmd`. However, it also unnecessarily routes executables through `cmd.exe`.
This wrapper introduces an additional command-line parsing layer with behavior that differs from normal Windows argv parsing.

`ProcessStartInfo.ArgumentList` passes `cmd.exe /c` a correctly quoted executable path and argument, but cmd's legacy quote handling strips the outer quotes, reparses the command line, and mistakes the path prefix ending at the first space—such as `C:\Program`—for the executable. Although the `/s` approach explored in #1703 can avoid this, it requires constructing the entire command line manually and owning all cmd-specific quoting and escaping logic.

## Discarded alternative: Resolve the filename before starting the process

I implemented and iterated on this approach in https://github.com/jozkee/csharp-sdk/pull/4/changes#diff-3fc7a658a90921218be1ac3af08dcc12db8d1ba201b9cb9f186dfb0c6b7cab21.

The TypeScript SDK's stdio transport calls cross-spawn, which eventually calls the Node `which` implementation; the Python SDK's Windows command helper calls `shutil.which`; and .NET `Process.Start` on Unix performs its own `PATH` resolution before calling `execve`. All three therefore perform some form of filename resolution before executing the child. In contrast, .NET's Windows implementation performs no managed filename resolution when `UseShellExecute` is false: it builds a command line from the supplied `FileName` and arguments and passes it to `CreateProcess`, whose lookup can search `PATH` but does not expand `PATHEXT`.

The reference implementations differ in their treatment of empty or quoted `PATH` entries, current-directory participation, deduplication, default `PATHEXT` values, and commands that already have an extension. Those differences reinforced that reproducing a complete resolver in the SDK would add significant complexity and platform-specific behavior.

https://github.com/npm/node-which/blob/v2.0.2/which.js
https://github.com/python/cpython/blob/v3.14.0/Lib/shutil.py
https://github.com/dotnet/runtime/blob/fea92eb70a2b115e3c8c73aba01eea615a82eee2/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessUtils.Unix.cs#L268-L330

## This PR

This PR takes a deliberately surgical approach, suggested in https://github.com/modelcontextprotocol/csharp-sdk/pull/1703#issuecomment-5060489902.
Explicit `.exe` and `.com` commands are launched directly when they are rooted or exist relative to the parent process's current directory, consistent with the relevant part of .NET's Unix resolution behavior.
Directly launched executables receive their arguments through the normal argv path, without cmd-specific escaping.
Bare commands and script files, such as `.cmd` and `.bat` files, continue through the existing `cmd.exe /c` path.
Existing `PATH`, `PATHEXT`, batch-file, and `WorkingDirectory` behavior is therefore preserved for commands that require shell resolution.
This fixes paths containing spaces without introducing a parallel command resolver or changing how common commands such as `npx` are located.

Fixes #1601

cc @yayayouyou