### PR TITLE
Dispose the POST response in SseClientSessionTransport to stop leaking a connection per message

### DIFF
--- a/src/ModelContextProtocol.Core/Client/SseClientSessionTransport.cs
+++ b/src/ModelContextProtocol.Core/Client/SseClientSessionTransport.cs
@@ -90,7 +90,7 @@ internal sealed partial class SseClientSessionTransport : TransportBase
 
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, _messageEndpoint);
         StreamableHttpClientSessionTransport.CopyAdditionalHeaders(httpRequestMessage.Headers, _options.AdditionalHeaders, sessionId: null, protocolVersion: null);
-        var response = await _httpClient.SendAsync(httpRequestMessage, message, cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.SendAsync(httpRequestMessage, message, cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportTests.cs
@@ -148,6 +148,53 @@ public class HttpClientTransportTests : LoggedTest
     }
 
     [Fact]
+    public async Task SendMessageAsync_Disposes_Response_On_Success()
+    {
+        // Regression test for https://github.com/modelcontextprotocol/csharp-sdk/issues/1840
+        // Every POST is sent with HttpCompletionOption.ResponseHeadersRead, so the underlying
+        // connection only returns to the pool once the response is consumed or disposed. The
+        // success path (an accepted response whose body is unused) previously did neither,
+        // stranding one connection per sent message until the GC finalized the response.
+        using var mockHttpHandler = new MockHttpHandler();
+        using var httpClient = new HttpClient(mockHttpHandler);
+        await using var transport = new HttpClientTransport(_transportOptions, httpClient, LoggerFactory);
+
+        using var postContent = new DisposalTrackingContent("accepted");
+        var firstCall = true;
+        mockHttpHandler.RequestHandler = (request) =>
+        {
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsoluteUri == "http://localhost:8080/sseendpoint")
+            {
+                return Task.FromResult(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Accepted,
+                    Content = postContent
+                });
+            }
+            else
+            {
+                if (!firstCall)
+                    throw new IOException("Abort");
+                else
+                    firstCall = false;
+
+                return Task.FromResult(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("event: endpoint\r\ndata: /sseendpoint\r\n\r\n")
+                });
+            }
+        };
+
+        await using var session = await transport.ConnectAsync(TestContext.Current.CancellationToken);
+        await session.SendMessageAsync(new JsonRpcRequest { Method = RequestMethods.Initialize, Id = new RequestId(44) }, TestContext.Current.CancellationToken);
+
+        Assert.True(postContent.Disposed,
+            "The POST response was not disposed after SendMessageAsync completed; " +
+            "with HttpCompletionOption.ResponseHeadersRead this strands the connection until the GC finalizes the response.");
+    }
+
+    [Fact]
     public async Task StreamableHttp_NotificationWithEmptyAcceptedJsonResponse_DoesNotLogParseFailure()
     {
         var options = new HttpClientTransportOptions
@@ -585,5 +632,16 @@ public class HttpClientTransportTests : LoggedTest
             TestContext.Current.CancellationToken);
 
         Assert.Equal("test-session", session.SessionId);
+    }
+
+    private sealed class DisposalTrackingContent(string content) : StringContent(content)
+    {
+        public bool Disposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
     }
 }

--- a/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/HttpClientTransportTests.cs
@@ -154,7 +154,7 @@ public class HttpClientTransportTests : LoggedTest
         // Every POST is sent with HttpCompletionOption.ResponseHeadersRead, so the underlying
         // connection only returns to the pool once the response is consumed or disposed. The
         // success path (an accepted response whose body is unused) previously did neither,
-        // stranding one connection per sent message until the GC finalized the response.
+        // leaving cleanup nondeterministic and potentially stranding the connection.
         using var mockHttpHandler = new MockHttpHandler();
         using var httpClient = new HttpClient(mockHttpHandler);
         await using var transport = new HttpClientTransport(_transportOptions, httpClient, LoggerFactory);
@@ -191,7 +191,7 @@ public class HttpClientTransportTests : LoggedTest
 
         Assert.True(postContent.Disposed,
             "The POST response was not disposed after SendMessageAsync completed; " +
-            "with HttpCompletionOption.ResponseHeadersRead this strands the connection until the GC finalizes the response.");
+            "with HttpCompletionOption.ResponseHeadersRead this can strand the connection because cleanup is no longer deterministic.");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1840

### What

One-word change in `SseClientSessionTransport.SendMessageAsync`: the `HttpResponseMessage`
returned for each POSTed JSON-RPC message is now wrapped in `using`. A deterministic
regression test is included.

### Why

`McpHttpClient.SendAsync` sends every request with `HttpCompletionOption.ResponseHeadersRead`,
so the underlying connection stays checked out until the response is consumed or disposed.
The POST path never did either on the success path (a `202 Accepted` whose body is unused),
so every sent message stranded one ESTABLISHED connection — never returned to the pool,
never reused, reclaimed only by GC or an idle timeout. Measurements and the full analysis
are in #1840 (per client: 1 live SSE connection + one stranded connection per POST —
`initialize`, `notifications/initialized`, `tools/list`).

The surrounding code already does this correctly: the SSE GET response is wrapped in
`using var response` in the same file, and the failure path reads the body before throwing.
Only the success path was missing the dispose.

### Regression test

`HttpClientTransportTests.SendMessageAsync_Disposes_Response_On_Success` drives the SSE
transport through the public `HttpClientTransport.ConnectAsync` + `SendMessageAsync` path
against the existing `MockHttpHandler`. The mocked POST response carries content that
records its own disposal, and the test asserts the response has been disposed by the time
`SendMessageAsync` returns. No sockets, no GC, no timing dependence: neither
`HttpResponseMessage` nor `HttpContent` has a finalizer, so nothing but the transport's
explicit dispose can set the flag.

```
dotnet test tests/ModelContextProtocol.Tests/ --filter "FullyQualifiedName~SendMessageAsync_Disposes_Response_On_Success"
```

- **Without the fix** (parent commit's `SseClientSessionTransport.cs`): fails on every
  target framework — net10.0, net9.0, net8.0, and net472.
- **With the fix**: passes on all four TFMs, in both Debug and Release. The full
  `HttpClientTransportTests` class is 17/17 on each TFM.
- Full `ModelContextProtocol.Tests` suite: green locally on net10.0 (2357 passed,
  0 failed, 6 skipped — the tests requiring external credentials or Docker).
  `ModelContextProtocol.AspNetCore.Tests` (which exercises the SSE client transport
  against a real in-memory Kestrel server) is also green locally on net10.0, net9.0,
  and net8.0 (615 passed, 0 failed, 30 skipped each).

### Notes

- The failure path is unaffected: the body is read and the `HttpRequestException` is fully
  materialized from `StatusCode`/`ReasonPhrase`/body before the `using` scope unwinds; the
  exception holds no reference to the response.
- The full solution builds cleanly with `TreatWarningsAsErrors` enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
