### PR TITLE
Use none as the token-endpoint auth method for CIMD public clients

### DIFF
--- a/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
+++ b/src/ModelContextProtocol.Core/Authentication/ClientOAuthProvider.cs
@@ -494,6 +494,13 @@ internal sealed partial class ClientOAuthProvider : McpHttpClient
 
         _clientId = metadataUri.AbsoluteUri;
 
+        // A CIMD client is a public client (it has no client secret, and its identifier is a URL),
+        // so it authenticates at the token endpoint with "none" and proves possession via PKCE.
+        // Without this, GetAccessTokenAsync falls through to the first method the authorization
+        // server advertises (e.g. client_secret_basic on Auth0), which fails with 401 access_denied.
+        // See https://github.com/modelcontextprotocol/csharp-sdk/issues/1612.
+        _tokenEndpointAuthMethod = "none";
+
         // See: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00#section-3
         static bool IsValidClientMetadataDocumentUri(Uri uri)
             => uri.IsAbsoluteUri

--- a/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/OAuth/AuthTests.cs
@@ -361,6 +361,34 @@ public class AuthTests : OAuthTestBase
     }
 
     [Fact]
+    public async Task CanAuthenticate_WithClientMetadataDocument_WhenServerAdvertisesClientSecretBasicFirst()
+    {
+        // Auth0 advertises client_secret_basic ahead of none. A CIMD client is a public client and
+        // must use "none" (PKCE) regardless of the advertised order, otherwise the token exchange
+        // sends an empty-secret Basic header and is rejected with 401 access_denied (#1612).
+        TestOAuthServer.TokenEndpointAuthMethodsSupported = ["client_secret_basic", "client_secret_post", "private_key_jwt", "none"];
+        await using var app = await StartMcpServerAsync();
+
+        await using var transport = new HttpClientTransport(new()
+        {
+            Endpoint = new(McpServerUrl),
+            OAuth = new ClientOAuthOptions()
+            {
+                RedirectUri = new Uri("http://localhost:1179/callback"),
+                AuthorizationCallbackHandler = HandleAuthorizationUrlAsync,
+                ClientMetadataDocumentUri = new Uri(ClientMetadataDocumentUrl),
+                DynamicClientRegistration = new()
+                {
+                    ApplicationType = "web",
+                },
+            },
+        }, HttpClient, LoggerFactory);
+
+        await using var client = await McpClient.CreateAsync(
+            transport, loggerFactory: LoggerFactory, cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task CannotAuthenticate_WhenMetadataOmitsPkceMethods()
     {
         TestOAuthServer.CodeChallengeMethodsSupported = null;

--- a/tests/ModelContextProtocol.TestOAuthServer/Program.cs
+++ b/tests/ModelContextProtocol.TestOAuthServer/Program.cs
@@ -81,6 +81,17 @@ public sealed class Program
     public bool ClientIdMetadataDocumentSupported { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets the <c>token_endpoint_auth_methods_supported</c> values the authorization server
+    /// advertises in its discovery document. Tests set this to a list that does not lead with
+    /// <c>none</c> (e.g. <c>["client_secret_basic", "none"]</c>, mirroring Auth0) to verify that a
+    /// CIMD public client still authenticates with <c>none</c> rather than the first advertised method.
+    /// </summary>
+    /// <remarks>
+    /// The default value is <c>["client_secret_post"]</c>.
+    /// </remarks>
+    public List<string> TokenEndpointAuthMethodsSupported { get; set; } = ["client_secret_post"];
+
+    /// <summary>
     /// Gets or sets a value indicating whether the authorization server expects a resource parameter.
     /// When <c>true</c>, the resource parameter must be present and match a valid resource.
     /// When <c>false</c>, the resource parameter must be absent to simulate legacy servers that
@@ -276,7 +287,7 @@ public sealed class Program
                 ScopesSupported = IncludeOfflineAccessInMetadata
                     ? ["openid", "profile", "email", "mcp:tools", "offline_access"]
                     : ["openid", "profile", "email", "mcp:tools"],
-                TokenEndpointAuthMethodsSupported = ["client_secret_post"],
+                TokenEndpointAuthMethodsSupported = TokenEndpointAuthMethodsSupported,
                 ClaimsSupported = ["sub", "iss", "name", "email", "aud"],
                 CodeChallengeMethodsSupported = MetadataPathsWithoutPkceSupport.Contains(context.Request.Path)
                     ? null


### PR DESCRIPTION
## Summary

Use none as the token-endpoint auth method for CIMD public clients

## Verification

dotnet test tests/ModelContextProtocol.AspNetCore.Tests -f net10.0 --filter 'FullyQualifiedName~AuthTests' (67 passed); new CanAuthenticate_WithClientMetadataDocument_WhenServerAdvertisesClientSecretBasicFirst red-green verified (fails without the fix, passes with it)

Related to https://github.com/modelcontextprotocol/csharp-sdk/issues/1612

> AI assistance disclosure: AI was used to discover this opportunity and draft the change or text. The submission was checked against the prepared artifact and recorded verification evidence.